### PR TITLE
add missing function from rebar_utils for compiling eunit tests

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -538,6 +538,22 @@ filter_defines([{platform_define, ArchRegex, Key, Value} | Rest], Acc) ->
 filter_defines([Opt | Rest], Acc) ->
     filter_defines(Rest, [Opt | Acc]).
 
+%% @doc Reset the path to what it looked like before loaded test modules
+cleanup_code_path(OrigPath) ->
+    CurrentPath = code:get_path(),
+    AddedPaths = CurrentPath -- OrigPath,
+    %% If someone has removed paths, it's hard to get them back into
+    %% the right order, but since this is currently rare, we can just
+    %% fall back to code:set_path/1.
+    case CurrentPath -- AddedPaths of
+        OrigPath ->
+            _ = [code:del_path(Path) || Path <- AddedPaths],
+            true;
+        _ ->
+            code:set_path(OrigPath)
+    end.
+
+
 %% @doc ident to the level specified
 -spec indent(non_neg_integer()) -> iolist().
 indent(Amount) when erlang:is_integer(Amount) ->


### PR DESCRIPTION
I simply copied the missing function from rebar2.

Fixes #2.
