### PR TITLE
Drop search for templates in cwd

### DIFF
--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -273,8 +273,7 @@ find_disk_templates(State) ->
     Home = rebar_utils:home_dir(),
     HomeFiles = rebar_utils:find_files(filename:join([Home, ?CONFIG_DIR, "templates"]),
                                        ?TEMPLATE_RE),
-    LocalFiles = rebar_utils:find_files(".", ?TEMPLATE_RE, true),
-    [{file, F} || F <- OtherTemplates ++ HomeFiles ++ LocalFiles].
+    [{file, F} || F <- OtherTemplates ++ HomeFiles].
 
 %% Fetch template indexes that sit on disk in custom areas
 find_other_templates(State) ->


### PR DESCRIPTION
Templates should only be in ~/.rebar3/templates and the built-in ones,
bar some specific overrides someone may want.

Looking recursively for templates in the CWD (.) may end up searching
nearly forever if the project is being created at the top of a very deep
directory tree, with extremely unlikely chances to find relevant
templates.

It causes more problems than benefits.

Should fix https://github.com/rebar/rebar3/issues/4
