### PR TITLE
Transform rebar3 ct input

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -113,11 +113,11 @@ transform_opts([{multiply_timetraps, MultiplyTimetraps}|Rest], Acc) ->
                            ec_cnv:to_integer(MultiplyTimetraps)}|Acc]);
 transform_opts([{event_handler, EventHandler}|Rest], Acc) ->
     transform_opts(Rest, [{event_handler, parse_term(EventHandler)}|Acc]);
+transform_opts([{silent_connections, "all"}|Rest], Acc) ->
+    transform_opts(Rest, [{silent_connections, all}|Acc]);
 transform_opts([{silent_connections, SilentConnections}|Rest], Acc) ->
     transform_opts(Rest, [{silent_connections,
                            to_atoms(split_string(SilentConnections))}|Acc]);
-transform_opts([{verbosity, "all"}|Rest], Acc) ->
-    transform_opts(Rest, [{verbosity, all}|Acc]);
 transform_opts([{verbosity, Verbosity}|Rest], Acc) ->
     transform_opts(Rest, [{verbosity, parse_term(Verbosity)}|Acc]);
 transform_opts([{logopts, LogOpts}|Rest], Acc) ->


### PR DESCRIPTION
(Pull request now pointed at the correct repo).
Validate and transform input to rebar ct, this involves splitting up strings, converting things to atoms etc.

It does not validate that the input is correct, that means enums are not checked etc. That should be added later so we can return more readable error messages.

This will need some review (please!) but should be enough for rebar/rebar3#25.
