### PR TITLE
fix templates not found for R15B

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,8 +16,8 @@
 {escript_emu_args, "%%! +sbtu +A0\n"}.
 %% escript_incl_extra is for internal rebar-private use only.
 %% Do not use outside rebar. Config interface is not stable.
-{escript_incl_extra, [{"relx/priv/templates/*", "_build/default/lib/"},
-                      {"rebar/priv/templates/*", "_build/default/lib/"}]}.
+{escript_incl_extra, [{"relx/priv/templates/","*","_build/default/lib/relx/priv/templates/"},
+                      {"rebar/priv/templates/","*", "_build/default/lib/rebar/priv/templates/"}]}.
 
 {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
             no_debug_info,

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -170,16 +170,15 @@ get_app_beams(App, Path) ->
 
 get_extra(State) ->
     Extra = rebar_state:get(State, escript_incl_extra, []),
-    lists:foldl(fun({Wildcard, Dir}, Files) ->
-                        load_files(Wildcard, Dir) ++ Files
-                end, [], Extra).
-
-load_files(Wildcard, Dir) ->
-    load_files("", Wildcard, Dir).
+    lists:foldl(
+        fun
+            ({Prefix, Wildcard, Dir}, Files) ->
+                load_files(Prefix, Wildcard, Dir) ++ Files
+        end, [], Extra).
 
 load_files(Prefix, Wildcard, Dir) ->
     [read_file(Prefix, Filename, Dir)
-     || Filename <- filelib:wildcard(Wildcard, Dir)].
+     || Filename <- filelib:wildcard(Wildcard, Dir) ].
 
 read_file(Prefix, Filename, Dir) ->
     Filename1 = case Prefix of


### PR DESCRIPTION
Turns out this is a pretty small fix if you are willing to change the format used in the rebar.config for the 'escript_incl_extra' variable.  The only places filelib:wildcard/2 is called is is rebar_prv_escriptize.erl (and rebar_prv_dialyzer.erl, but I don't know if that is an issue).  By changing the escript_inc_extra variable to a 3-tuple and removing the case where the prefix is empty (which was only called from the modified function) it fixes the issue outlined in https://github.com/rebar/rebar3/issues/1002.