### PR TITLE
Make pkgs output *nix friendly

### DIFF
--- a/src/rebar_prv_packages.erl
+++ b/src/rebar_prv_packages.erl
@@ -49,8 +49,8 @@ print_packages() ->
                                                         ec_semver:lte(ec_semver:parse(A)
                                                                      ,ec_semver:parse(B))
                                                 end, Vsns),
-                        VsnStr = join(SortedVsns, <<", ">>),
-                        ?CONSOLE("~s:~n    Versions: ~s~n", [Name, VsnStr])
+                        VsnStr = join(SortedVsns, <<" ">>),
+                        ?CONSOLE("~s ~s~n", [Name, VsnStr])
                 end, SortedPkgs).
 
 -spec join([binary()], binary()) -> binary().


### PR DESCRIPTION
Constraining the output of a package to one line makes it easy to use
tools like grep to search or AWK to get the latest version of a specific
package.

Remove comma separator because space is default separator for most cli
tools that work with columnar data, like AWK.

Example:

    rebar3 pkgs | grep hackney | awk '{print $NF}'