### PR TITLE
Allows overwrite default cache dir using REBAR_CACHE_DIR

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -129,13 +129,20 @@ run_aux(State, RawArgs) ->
     %% Initializing project_plugins which can override default providers
     State6 = rebar_plugins:project_plugins_install(State5),
     State7 = rebar_plugins:top_level_install(State6),
-    State8 = rebar_state:default(State7, rebar_state:opts(State7)),
+    State8 = case os:getenv("REBAR_CACHE_DIR") of
+                false ->
+                    State7;
+                ConfigFile ->
+                    rebar_state:set(State7, global_rebar_dir, ConfigFile)
+            end,
+
+    State9 = rebar_state:default(State8, rebar_state:opts(State8)),
 
     {Task, Args} = parse_args(RawArgs),
 
-    State9 = rebar_state:code_paths(State8, default, code:get_path()),
+    State10 = rebar_state:code_paths(State9, default, code:get_path()),
 
-    rebar_core:init_command(rebar_state:command_args(State9, Args), Task).
+    rebar_core:init_command(rebar_state:command_args(State10, Args), Task).
 
 init_config() ->
     %% Initialize logging system

--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -93,8 +93,14 @@ global_config() ->
     filename:join([Home, ".config", "rebar3", "rebar.config"]).
 
 global_cache_dir(Opts) ->
-    Home = home_dir(),
-    rebar_opts:get(Opts, global_rebar_dir, filename:join([Home, ".cache", "rebar3"])).
+    RebarCacheDir = case os:getenv("REBAR_CACHE_DIR") of
+        false ->
+            Home = home_dir(),
+            filename:join([Home, ".cache", "rebar3"]);
+        ConfigFile ->
+            ConfigFile
+    end,
+    rebar_opts:get(Opts, global_rebar_dir, RebarCacheDir).
 
 local_cache_dir(Dir) ->
     filename:join(Dir, ".rebar3").

--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -94,14 +94,8 @@ global_config() ->
 
 -spec global_cache_dir(rebar_dict()) -> file:filename_all().
 global_cache_dir(Opts) ->
-    RebarCacheDir = case os:getenv("REBAR_CACHE_DIR") of
-        false ->
-            Home = home_dir(),
-            filename:join([Home, ".cache", "rebar3"]);
-        ConfigFile ->
-            ConfigFile
-    end,
-    rebar_opts:get(Opts, global_rebar_dir, RebarCacheDir).
+    Home = home_dir(),
+    rebar_opts:get(Opts, global_rebar_dir, filename:join([Home, ".cache", "rebar3"])).
 
 local_cache_dir(Dir) ->
     filename:join(Dir, ".rebar3").

--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -92,6 +92,7 @@ global_config() ->
     Home = home_dir(),
     filename:join([Home, ".config", "rebar3", "rebar.config"]).
 
+-spec global_cache_dir(rebar_dict()) -> file:filename_all().
 global_cache_dir(Opts) ->
     RebarCacheDir = case os:getenv("REBAR_CACHE_DIR") of
         false ->

--- a/test/rebar_dir_SUITE.erl
+++ b/test/rebar_dir_SUITE.erl
@@ -25,6 +25,7 @@ init_per_testcase(default_global_cache_dir, Config) ->
                             ,{root_dir, AppsDir}]),
     [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, NewState} | Config];
 init_per_testcase(overwrite_default_global_cache_dir, Config) ->
+    os:putenv("REBAR_CACHE_DIR", ?config(priv_dir, Config)),
     [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, _State} | Config] = rebar_test_utils:init_rebar_state(Config),
     NewState = rebar_state:new([{base_dir, filename:join([AppsDir, "_build"])}
                             ,{root_dir, AppsDir}]),
@@ -189,7 +190,6 @@ default_global_cache_dir(Config) ->
     ?assertEqual(Expected, rebar_dir:global_cache_dir(rebar_state:opts(State))).
 
 overwrite_default_global_cache_dir(Config) ->
-    os:putenv("REBAR_CACHE_DIR", ?config(priv_dir, Config)),
     RebarConfig = [{erl_opts, []}],
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
     Expected = ?config(priv_dir, Config),

--- a/test/rebar_dir_SUITE.erl
+++ b/test/rebar_dir_SUITE.erl
@@ -189,8 +189,8 @@ default_global_cache_dir(Config) ->
     ?assertEqual(Expected, rebar_dir:global_cache_dir(rebar_state:opts(State))).
 
 overwrite_default_global_cache_dir(Config) ->
-    os:putenv("REBAR_CACHE_DIR", "/tmp/"),
+    os:putenv("REBAR_CACHE_DIR", ?config(priv_dir, Config)),
     RebarConfig = [{erl_opts, []}],
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
-    Expected = "/tmp/",
+    Expected = ?config(priv_dir, Config),
     ?assertEqual(Expected, rebar_dir:global_cache_dir(rebar_state:opts(State))).

--- a/test/rebar_dir_SUITE.erl
+++ b/test/rebar_dir_SUITE.erl
@@ -6,6 +6,7 @@
 -export([src_dirs/1, extra_src_dirs/1, all_src_dirs/1]).
 -export([profile_src_dirs/1, profile_extra_src_dirs/1, profile_all_src_dirs/1]).
 -export([retarget_path/1, alt_base_dir_abs/1, alt_base_dir_rel/1]).
+-export([global_cache_dir/1, default_global_cache_dir/1, overwrite_default_global_cache_dir/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -15,8 +16,19 @@
 all() -> [default_src_dirs, default_extra_src_dirs, default_all_src_dirs,
           src_dirs, extra_src_dirs, all_src_dirs,
           profile_src_dirs, profile_extra_src_dirs, profile_all_src_dirs,
-          retarget_path, alt_base_dir_abs, alt_base_dir_rel].
+          retarget_path, alt_base_dir_abs, alt_base_dir_rel, global_cache_dir,
+          default_global_cache_dir, overwrite_default_global_cache_dir].
 
+init_per_testcase(default_global_cache_dir, Config) ->
+    [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, _State} | Config] = rebar_test_utils:init_rebar_state(Config),
+    NewState = rebar_state:new([{base_dir, filename:join([AppsDir, "_build"])}
+                            ,{root_dir, AppsDir}]),
+    [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, NewState} | Config];
+init_per_testcase(overwrite_default_global_cache_dir, Config) ->
+    [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, _State} | Config] = rebar_test_utils:init_rebar_state(Config),
+    NewState = rebar_state:new([{base_dir, filename:join([AppsDir, "_build"])}
+                            ,{root_dir, AppsDir}]),
+    [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, NewState} | Config];
 init_per_testcase(_, Config) ->
     C = rebar_test_utils:init_rebar_state(Config),
     AppDir = ?config(apps, C),
@@ -162,3 +174,23 @@ alt_base_dir_rel(Config) ->
     ?assert(filelib:is_dir(filename:join([BaseDir, "lib", Name2, "ebin"]))),
     ?assert(filelib:is_file(filename:join([BaseDir, "lib", Name2, "ebin", Name2++".app"]))),
     ?assert(filelib:is_file(filename:join([BaseDir, "lib", Name2, "ebin", Name2++".beam"]))).
+
+global_cache_dir(Config) ->
+    RebarConfig = [{erl_opts, []}],
+    {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
+    DataDir = ?config(priv_dir, Config),
+    Expected = filename:join([DataDir, "cache"]),
+    ?assertEqual(Expected, rebar_dir:global_cache_dir(rebar_state:opts(State))).
+
+default_global_cache_dir(Config) ->
+    RebarConfig = [{erl_opts, []}],
+    {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
+    Expected = filename:join([rebar_dir:home_dir(), ".cache", "rebar3"]),
+    ?assertEqual(Expected, rebar_dir:global_cache_dir(rebar_state:opts(State))).
+
+overwrite_default_global_cache_dir(Config) ->
+    os:putenv("REBAR_CACHE_DIR", "/tmp/"),
+    RebarConfig = [{erl_opts, []}],
+    {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
+    Expected = "/tmp/",
+    ?assertEqual(Expected, rebar_dir:global_cache_dir(rebar_state:opts(State))).


### PR DESCRIPTION
Allows overwrite the default cache directory using the environment variable REBAR_CACHE_DIR.

There's some discussion about this in https://github.com/erlang/rebar3/issues/1116

