### PR TITLE
Fixed git version bug

### DIFF
--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -201,7 +201,7 @@ parse_tags(Dir) ->
         {error, _} ->
             {undefined, "0.0.0"};
         {ok, Line} ->
-            case re:run(Line, "(\\(|\\s)(HEAD,\\s)tag:\\s(v?([^,\\)]+))", [{capture, [3, 4], list}]) of
+            case re:run(Line, "(\\(|\\s)(HEAD[^,]*,\\s)tag:\\s(v?([^,\\)]+))", [{capture, [3, 4], list}]) of
                 {match,[Tag, Vsn]} ->
                     {Tag, Vsn};
                 nomatch ->


### PR DESCRIPTION
I've tried to compile project with git in .app.src vsn
Project was tagged as 1.0.0, but resulting .app vsn becomes 1.0.0+build.6.reff0aec24

```
$ git lg
* f0aec24 - (80 minutes ago) Fixed ct — Kozlov Yakov (HEAD -> master, tag: 1.0.0, origin/master)
... 5 commits before
```

```
$ git log --oneline --no-walk --tags --decorate
f0aec24 (HEAD -> master, tag: 1.0.0, origin/master) Fixed ct
```

I've found that `HEAD -> master` doest match pattern in [rebar_git_resource](https://github.com/erlang/rebar3/blob/master/src/rebar_git_resource.erl#L204)