### PR TITLE
change travis config to only upload escripts for tags (stable releases)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 before_deploy: "rm -rf !(rebar3)"
 deploy:
   on:
-    branch: master
+    tags: true
     condition: $TRAVIS_OTP_RELEASE = R16B03-1
   provider: s3
   access_key_id: AKIAJAPYAQEFYCYSNL7Q


### PR DESCRIPTION
With this change we can update the website to have the stable version number of the download. I think we don't need 'nightly' and people who need that can build from source.

I think we are also due for a 3.1.0 release, right?