### PR TITLE
supported dist_node in ct and eunit

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -644,7 +644,10 @@ ct_opts(_State) ->
      {create_priv_dir, undefined, "create_priv_dir", string, help(create_priv_dir)},
      {include, undefined, "include", string, help(include)},
      {readable, undefined, "readable", boolean, help(readable)},
-     {verbose, $v, "verbose", boolean, help(verbose)}
+     {verbose, $v, "verbose", boolean, help(verbose)},
+     {name, undefined, "name", atom, help(name)},
+     {sname, undefined, "sname", atom, help(sname)},
+     {setcookie, undefined, "setcookie", atom, help(setcookie)}
     ].
 
 help(dir) ->
@@ -699,5 +702,11 @@ help(readable) ->
     "Shows test case names and only displays logs to shell on failures";
 help(verbose) ->
     "Verbose output";
+help(name) ->
+    "Gives a long name to the node";
+help(sname) ->
+    "Gives a short name to the node";
+help(setcookie) ->
+    "Sets the cookie if the node is distributed";
 help(_) ->
     "".

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -37,6 +37,7 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
+    setup_name(State),
     Tests = prepare_tests(State),
     case compile(State, Tests) of
         %% successfully compiled apps
@@ -104,6 +105,10 @@ format_error({multiple_errors, Errors}) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
+
+setup_name(State) ->
+    {Long, Short, Opts} = rebar_dist_utils:find_options(State),
+    rebar_dist_utils:either(Long, Short, Opts).
 
 prepare_tests(State) ->
     %% command line test options

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -51,6 +51,7 @@ do(State) ->
 do(State, Tests) ->
     ?INFO("Performing EUnit tests...", []),
 
+    setup_name(State),
     rebar_utils:update_code(rebar_state:code_paths(State, all_deps), [soft_purge]),
 
     %% Run eunit provider prehooks
@@ -105,6 +106,10 @@ format_error({error, Error}) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
+
+setup_name(State) ->
+    {Long, Short, Opts} = rebar_dist_utils:find_options(State),
+    rebar_dist_utils:either(Long, Short, Opts).
 
 prepare_tests(State) ->
     %% parse and translate command line tests

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -484,11 +484,17 @@ eunit_opts(_State) ->
      {file, $f, "file", string, help(file)},
      {module, $m, "module", string, help(module)},
      {suite, $s, "suite", string, help(module)},
-     {verbose, $v, "verbose", boolean, help(verbose)}].
+     {verbose, $v, "verbose", boolean, help(verbose)},
+     {name, undefined, "name", atom, help(name)},
+     {sname, undefined, "sname", atom, help(sname)},
+     {setcookie, undefined, "setcookie", atom, help(setcookie)}].
 
-help(app)     -> "Comma separated list of application test suites to run. Equivalent to `[{application, App}]`.";
-help(cover)   -> "Generate cover data. Defaults to false.";
-help(dir)     -> "Comma separated list of dirs to load tests from. Equivalent to `[{dir, Dir}]`.";
-help(file)    -> "Comma separated list of files to load tests from. Equivalent to `[{file, File}]`.";
-help(module)  -> "Comma separated list of modules to load tests from. Equivalent to `[{module, Module}]`.";
-help(verbose) -> "Verbose output. Defaults to false.".
+help(app)       -> "Comma separated list of application test suites to run. Equivalent to `[{application, App}]`.";
+help(cover)     -> "Generate cover data. Defaults to false.";
+help(dir)       -> "Comma separated list of dirs to load tests from. Equivalent to `[{dir, Dir}]`.";
+help(file)      -> "Comma separated list of files to load tests from. Equivalent to `[{file, File}]`.";
+help(module)    -> "Comma separated list of modules to load tests from. Equivalent to `[{module, Module}]`.";
+help(verbose)   -> "Verbose output. Defaults to false.";
+help(name)      -> "Gives a long name to the node";
+help(sname)     -> "Gives a short name to the node";
+help(setcookie) -> "Sets the cookie if the node is distributed".


### PR DESCRIPTION
If we try to use the ct_slave in `rebar3 ct`, net_kernel:start is required each time.
In rebar2 it was not that necessary.
I want that the setting of dist_node is applied to ct and eunit.