### PR TITLE
Fixes logging from remote shells in rebar3 shell

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -192,7 +192,9 @@ rewrite_leaders(OldUser, NewUser) ->
         %% disable the simple error_logger (which may have been added multiple
         %% times). removes at most the error_logger added by init and the
         %% error_logger added by the tty handler
-        remove_error_handler(3)
+        remove_error_handler(3),
+        %% reset the tty handler once more for remote shells
+        error_logger:swap_handler(tty)
     catch
         E:R -> % may fail with custom loggers
             ?DEBUG("Logger changes failed for ~p:~p (~p)", [E,R,erlang:get_stacktrace()]),


### PR DESCRIPTION
Somehow swapping the tty handler once more fixes everything. I guess we
were missing a step somehow.

Probably fixes #768