### PR TITLE
When a dependency cannot be fetched, name the app that required it

### DIFF
--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -216,10 +216,23 @@ handle_single_vsn(Pkg, PkgVsn, Dep, Vsn, Constraint) ->
             {ok, Vsn}
     end.
 
-format_error({missing_package, {Name, Vsn}}) ->
-    io_lib:format("Package not found in registry: ~s-~s.", [ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)]);
+format_dep({Name, Vsn}) ->
+    io_lib:format("~s-~s", [ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)]);
+format_dep(Dep) when is_binary(Dep) ->
+    io_lib:format("~s", [Dep]);
+format_dep(Dep) ->
+    io_lib:format("~p", [Dep]).
+
 format_error({missing_package, Dep}) ->
-    io_lib:format("Package not found in registry: ~p.", [Dep]).
+    format_error({missing_package, Dep, []});
+format_error({missing_package, Dep, Parents}) ->
+    Msg = io_lib:format("Package not found in registry: ~s", [format_dep(Dep)]),
+    ParentsMsg = lists:map(fun
+                               (PDep) -> io_lib:format(" requred by ~s", [format_dep(PDep)])
+                           end,
+                           Parents),
+    [Msg, ParentsMsg].
+
 
 verify_table(State) ->
     ets:info(?PACKAGE_TABLE, named_table) =:= true orelse load_and_verify_version(State).

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -206,9 +206,13 @@ maybe_lock(Profile, AppInfo, Seen, State, Level) ->
 update_deps(Profile, Level, Deps, Apps, State, Upgrade, Seen, Locks) ->
     lists:foldl(
       fun(AppInfo, {DepsAcc, AppsAcc, StateAcc, SeenAcc}) ->
-              update_dep(AppInfo, Profile, Level,
-                         DepsAcc, AppsAcc, StateAcc,
-                         Upgrade, SeenAcc, Locks)
+              try update_dep(AppInfo, Profile, Level,
+                             DepsAcc, AppsAcc, StateAcc,
+                             Upgrade, SeenAcc, Locks)
+              catch
+                  throw:{error, {rebar_packages, {missing_package, Package}}} ->
+                      throw({error, {rebar_packages, {missing_package, Package, [rebar_app_info:name(AppInfo)]}}})
+              end
       end,
       {[], Apps, State, Seen},
       rebar_utils:sort_deps(Deps)).


### PR DESCRIPTION
I think that this helps with #1161, though it only captures one level of dependency. Still, that's an entire level of the dependency tree that doesn't have to be manually searched.