### PR TITLE
Fix compile error case when cover compilation

### DIFF
--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -299,6 +299,7 @@ cover_compile(State, apps) ->
     ExtraDirs = extra_src_dirs(State, Apps),
     cover_compile(State, lists:filter(fun(D) -> ec_file:is_dir(D) end, AppDirs ++ ExtraDirs));
 cover_compile(State, Dirs) ->
+    rebar_utils:update_code(rebar_state:code_paths(State, all_deps), [soft_purge]),
     %% start the cover server if necessary
     {ok, CoverPid} = start_cover(),
     %% redirect cover output
@@ -316,7 +317,9 @@ cover_compile(State, Dirs) ->
                 %% print any warnings about modules that failed to cover compile
                 lists:foreach(fun print_cover_warnings/1, lists:flatten(Results))
         end
-    end, Dirs).
+    end, Dirs),
+    rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
+    ok.
 
 app_dirs(Apps) ->
     lists:foldl(fun app_ebin_dirs/2, [], Apps).


### PR DESCRIPTION
Dependent libs is required for some module when cover compiling.
So all dependencies should be available on code path.

This fixes #1148 issue.

This P/R also fixes #1149 test fails on travis (maybe, in my case, tests is all  ok.)