### PR TITLE
Option to format compiler sources

### DIFF
--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -153,12 +153,12 @@ format_errors(_MainSource, Extra, Errors) ->
      end
      || {Source, Descs} <- Errors].
 
-format_error(AbsSource, Extra, {{Line, Column}, Mod, Desc}) ->
+format_error(Source, Extra, {{Line, Column}, Mod, Desc}) ->
     ErrorDesc = Mod:format_error(Desc),
-    ?FMT("~s:~w:~w: ~s~s~n", [AbsSource, Line, Column, Extra, ErrorDesc]);
-format_error(AbsSource, Extra, {Line, Mod, Desc}) ->
+    ?FMT("~s:~w:~w: ~s~s~n", [Source, Line, Column, Extra, ErrorDesc]);
+format_error(Source, Extra, {Line, Mod, Desc}) ->
     ErrorDesc = Mod:format_error(Desc),
-    ?FMT("~s:~w: ~s~s~n", [AbsSource, Line, Extra, ErrorDesc]);
-format_error(AbsSource, Extra, {Mod, Desc}) ->
+    ?FMT("~s:~w: ~s~s~n", [Source, Line, Extra, ErrorDesc]);
+format_error(Source, Extra, {Mod, Desc}) ->
     ErrorDesc = Mod:format_error(Desc),
-    ?FMT("~s: ~s~s~n", [AbsSource, Extra, ErrorDesc]).
+    ?FMT("~s: ~s~s~n", [Source, Extra, ErrorDesc]).

--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -39,7 +39,9 @@
          reset_dir/1,
          touch/1,
          path_from_ancestor/2,
-         canonical_path/1]).
+         canonical_path/1,
+         resolve_link/1,
+         split_dirname/1]).
 
 -include("rebar.hrl").
 
@@ -272,6 +274,22 @@ canonical_path(Acc, ["."|Rest])       -> canonical_path(Acc, Rest);
 canonical_path([_|Acc], [".."|Rest])  -> canonical_path(Acc, Rest);
 canonical_path([], [".."|Rest])       -> canonical_path([], Rest);
 canonical_path(Acc, [Component|Rest]) -> canonical_path([Component|Acc], Rest).
+
+%% returns canonical target of path if path is a link, otherwise returns path
+-spec resolve_link(string()) -> string().
+
+resolve_link(Path) ->
+    case file:read_link(Path) of
+        {ok, Target} ->
+            canonical_path(filename:absname(Target, filename:dirname(Path)));
+        {error, _} -> Path
+    end.
+
+%% splits a path into dirname and basename
+-spec split_dirname(string()) -> {string(), string()}.
+
+split_dirname(Path) ->
+    {filename:dirname(Path), filename:basename(Path)}.
 
 %% ===================================================================
 %% Internal functions

--- a/test/rebar_file_utils_SUITE.erl
+++ b/test/rebar_file_utils_SUITE.erl
@@ -24,6 +24,7 @@
 all() ->
     [{group, tmpdir},
      {group, reset_dir},
+     path_from_ancestor,
      canonical_path,
      resolve_link,
      split_dirname].


### PR DESCRIPTION
By default rebar3 displays compiler sources as absolute paths in their
original location, which is under the build dir.

This change introduces an option 'compiler_source_format' to format
sources in two alternative ways:

    relative
    absolute

When either 'relative' or 'absolute' are specified, the file is
resolved to its original location when it is a link. When 'relative'
is specified, the path is displayed relative to the current working
directory. When 'absolute' is specified, the path is absolute.

The default value is 'unchaged' which leaves the compiler source
unchanged.

This is arguably too flexible as I suspect most people would opt for
'relative' all the time - it's the most compact representation of the
file and is sufficient to find the source given cwd. The change
however is meant to introduce the change gradually, preserving
existing behavior and giving users a choice for formats.

In time perhaps the default can be changed to 'relative' - but still
allowing users to revert to the other two options ('absolutel' and
'unchanged') as needed.