### PR TITLE
Fix shell node startup

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -108,6 +108,10 @@ shell(State) ->
     simulate_proc_lib(),
     true = register(rebar_agent, self()),
     {ok, GenState} = rebar_agent:init(State),
+    %% Hack to fool the init process into thinking we have stopped and the normal
+    %% node start process can go on. Without it, init:get_status() always return
+    %% '{starting, started}' instead of '{started, started}'
+    init ! {'EXIT', self(), normal},    
     gen_server:enter_loop(rebar_agent, [], GenState, {local, rebar_agent}, hibernate).
 
 info() ->


### PR DESCRIPTION
When using rebar3 shell, the `rebar_agent` process started from `init` never ends (in order to process shell commands with `r3:do/1`), but the init process keeps waiting forever in `'starting'` state. Applications like riak_core refuse to start in this situation.

A possible workaround is using `sys:terminate(rebar_agent, normal)` right after start, but of course you are not able to use the agent any more.

This is a quick and dirty fix to fool the init process into thinking we have stopped and the normal node starting process can go on. Of course a 'final' solution should be more elegant... maybe starting rebar_agent as an independent process?