### PR TITLE
don't generated coverage for `extra_src_dirs`

### DIFF
--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -296,8 +296,7 @@ strip_coverdir(File) ->
 cover_compile(State, apps) ->
     Apps = filter_checkouts(rebar_state:project_apps(State)),
     AppDirs = app_dirs(Apps),
-    ExtraDirs = extra_src_dirs(State, Apps),
-    cover_compile(State, lists:filter(fun(D) -> ec_file:is_dir(D) end, AppDirs ++ ExtraDirs));
+    cover_compile(State, lists:filter(fun(D) -> ec_file:is_dir(D) end, AppDirs));
 cover_compile(State, Dirs) ->
     %% start the cover server if necessary
     {ok, CoverPid} = start_cover(),
@@ -322,21 +321,7 @@ app_dirs(Apps) ->
     lists:foldl(fun app_ebin_dirs/2, [], Apps).
 
 app_ebin_dirs(App, Acc) ->
-    AppDir = rebar_app_info:ebin_dir(App),
-    ExtraDirs = rebar_dir:extra_src_dirs(rebar_app_info:opts(App), []),
-    OutDir = rebar_app_info:out_dir(App),
-    [AppDir] ++ [filename:join([OutDir, D]) || D <- ExtraDirs] ++ Acc.
-
-extra_src_dirs(State, Apps) ->
-    BaseDir = rebar_state:dir(State),
-    F = fun(App) -> rebar_app_info:dir(App) == BaseDir end,
-    %% check that this app hasn't already been dealt with
-    Extras = case lists:any(F, Apps) of
-        false -> rebar_dir:extra_src_dirs(rebar_state:opts(State), []);
-        true  -> []
-    end,
-    OutDir = rebar_dir:base_dir(State),
-    [filename:join([OutDir, "extras", D]) || D <- Extras].
+    [rebar_app_info:ebin_dir(App)|Acc].
 
 filter_checkouts(Apps) -> filter_checkouts(Apps, []).
 

--- a/test/rebar_cover_SUITE.erl
+++ b/test/rebar_cover_SUITE.erl
@@ -90,7 +90,7 @@ basic_extra_src_dirs(Config) ->
     {file, _} = cover:is_compiled(Mod),
 
     ExtraMod = list_to_atom(lists:flatten(io_lib:format("~ts_extra", [Name]))),
-    {file, _} = cover:is_compiled(ExtraMod).
+    false = cover:is_compiled(ExtraMod).
 
 release_extra_src_dirs(Config) ->
     AppDir = ?config(apps, Config),
@@ -129,9 +129,9 @@ release_extra_src_dirs(Config) ->
     {file, _} = cover:is_compiled(Mod2),
 
     ExtraMod1 = list_to_atom(lists:flatten(io_lib:format("~ts_extra", [Name1]))),
-    {file, _} = cover:is_compiled(ExtraMod1),
+    false = cover:is_compiled(ExtraMod1),
     ExtraMod2 = list_to_atom(lists:flatten(io_lib:format("~ts_extra", [Name2]))),
-    {file, _} = cover:is_compiled(ExtraMod2).
+    false = cover:is_compiled(ExtraMod2).
 
 root_extra_src_dirs(Config) ->
     AppDir = ?config(apps, Config),
@@ -160,7 +160,7 @@ root_extra_src_dirs(Config) ->
     Mod2 = list_to_atom(Name2),
     {file, _} = cover:is_compiled(Mod2),
 
-    {file, _} = cover:is_compiled(extra).
+    false = cover:is_compiled(extra).
 
 index_written(Config) ->
     AppDir = ?config(apps, Config),


### PR DESCRIPTION
closes #1057 and #1179 

this is technically a breaking change but i think most people would say including test suites in coverage is a bug. it could be gated behind an option if anyone disagrees tho