### PR TITLE
multiple repo support

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -40,7 +40,7 @@ main(_) ->
         false ->
             rebar3:run(["update"])
     end,
-    rebar3:run(["update"]),
+
     {ok, State} = rebar3:run(["compile"]),
     reset_env(),
     os:putenv("REBAR_PROFILE", ""),

--- a/bootstrap
+++ b/bootstrap
@@ -40,7 +40,7 @@ main(_) ->
         false ->
             rebar3:run(["update"])
     end,
-
+    rebar3:run(["update"]),
     {ok, State} = rebar3:run(["compile"]),
     reset_env(),
     os:putenv("REBAR_PROFILE", ""),
@@ -410,7 +410,7 @@ otp_release1(Rel) ->
 set_proxy_auth([]) ->
     ok;
 set_proxy_auth(UserInfo) ->
-    Idx = string:chr(UserInfo, $:), 
+    Idx = string:chr(UserInfo, $:),
     Username = string:sub_string(UserInfo, 1, Idx-1),
     Password = string:sub_string(UserInfo, Idx+1),
     %% password may contain url encoded characters, need to decode them first
@@ -421,4 +421,3 @@ get_proxy_auth() ->
         undefined -> [];
         ProxyAuth -> ProxyAuth
     end.
-

--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -24,13 +24,14 @@
 -define(DEFAULT_RELEASE_DIR, "rel").
 -define(CONFIG_VERSION, "1.1.0").
 -define(DEFAULT_CDN, "https://repo.hex.pm/").
+-define(DEFAULT_REGISTRY, "https://repo.hex.pm/").
+-define(REPOS_TABLE, repos_table).
 -define(REMOTE_PACKAGE_DIR, "tarballs").
 -define(REMOTE_REGISTRY_FILE, "registry.ets.gz").
 -define(LOCK_FILE, "rebar.lock").
 
 -define(PACKAGE_INDEX_VERSION, 3).
--define(PACKAGE_TABLE, package_index).
--define(INDEX_FILE, "packages.idx").
+-define(INDEX_FILE, "registry"). %"packages.idx").
 -define(REGISTRY_FILE, "registry").
 
 -ifdef(namespaced_types).

--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -30,6 +30,23 @@
 -define(REMOTE_REGISTRY_FILE, "registry.ets.gz").
 -define(LOCK_FILE, "rebar.lock").
 
+%% Hex related OS env vars
+-define(HEX_UNSAFE_REGISTRY, "HEX_UNSAFE_REGISTRY").
+
+%% Public key for the default hex registry at the time of this commit.
+%% Users can update manually and we update the build when a new one
+%% is created.
+-define(DEFAULT_REPO_PUBLIC_KEY,
+<<"-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApqREcFDt5vV21JVe2QNB
+Edvzk6w36aNFhVGWN5toNJRjRJ6m4hIuG4KaXtDWVLjnvct6MYMfqhC79HAGwyF+
+IqR6Q6a5bbFSsImgBJwz1oadoVKD6ZNetAuCIK84cjMrEFRkELtEIPNHblCzUkkM
+3rS9+DPlnfG8hBvGi6tvQIuZmXGCxF/73hU0/MyGhbmEjIKRtG6b0sJYKelRLTPW
+XgK7s5pESgiwf2YC/2MGDXjAJfpfCd0RpLdvd4eRiXtVlE9qO9bND94E7PgQ/xqZ
+J1i2xWFndWa6nfFnRxZmCStCOZWYYPlaxr+FZceFbpMwzTNs4g3d4tLNUcbKAIH4
+0wIDAQAB
+-----END PUBLIC KEY-----">>).
+
 -define(PACKAGE_INDEX_VERSION, 3).
 -define(INDEX_FILE, "registry"). %"packages.idx").
 -define(REGISTRY_FILE, "registry").

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -28,6 +28,8 @@
          applications/2,
          profiles/1,
          profiles/2,
+         registry/1,
+         registry/2,
          deps/1,
          deps/2,
          dep_level/1,
@@ -76,6 +78,7 @@
                      parent=root        :: binary() | root,
                      app_details=[]     :: list(),
                      applications=[]    :: list(),
+                     registry           :: string(),
                      deps=[]            :: list(),
                      profiles=[default] :: [atom()],
                      default=dict:new() :: rebar_dict(),
@@ -376,6 +379,14 @@ profiles(AppInfo=#app_info_t{}, Profiles) ->
     AppInfo#app_info_t{profiles=Profiles}.
 
 %% @doc returns the list of dependencies
+-spec registry(t()) -> string().
+registry(#app_info_t{registry=Registry}) ->
+    Registry.
+
+-spec registry(t(), string()) -> t().
+registry(AppInfo=#app_info_t{}, Registry) ->
+    AppInfo#app_info_t{registry=Registry}.
+
 -spec deps(t()) -> list().
 deps(#app_info_t{deps=Deps}) ->
     Deps.

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -378,7 +378,6 @@ profiles(#app_info_t{profiles=Profiles}) ->
 profiles(AppInfo=#app_info_t{}, Profiles) ->
     AppInfo#app_info_t{profiles=Profiles}.
 
-%% @doc returns the list of dependencies
 -spec registry(t()) -> string().
 registry(#app_info_t{registry=Registry}) ->
     Registry.
@@ -387,6 +386,7 @@ registry(#app_info_t{registry=Registry}) ->
 registry(AppInfo=#app_info_t{}, Registry) ->
     AppInfo#app_info_t{registry=Registry}.
 
+%% @doc returns the list of dependencies
 -spec deps(t()) -> list().
 deps(#app_info_t{deps=Deps}) ->
     Deps.

--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -168,6 +168,9 @@ parse_dep(Dep, Parent, DepsDir, State, Locks, Level) ->
       Dir :: file:filename(),
       IsLock :: boolean(),
       State :: rebar_state:t().
+parse_dep(Parent, [PkgName, Vsn, _Required, Name], DepsDir, IsLock, State) ->
+    {PkgName1, PkgVsn} = {ec_cnv:to_binary(PkgName), ec_cnv:to_binary(Vsn)},
+    dep_to_app(Parent, DepsDir, Name, PkgVsn, {pkg, PkgName1, PkgVsn, undefined}, IsLock, State);
 parse_dep(Parent, {Name, Vsn, {pkg, PkgName}}, DepsDir, IsLock, State) ->
     {PkgName1, PkgVsn} = {ec_cnv:to_binary(PkgName), ec_cnv:to_binary(Vsn)},
     dep_to_app(Parent, DepsDir, Name, PkgVsn, {pkg, PkgName1, PkgVsn, undefined}, IsLock, State);
@@ -262,10 +265,10 @@ update_source(AppInfo, {pkg, PkgName, PkgVsn, Hash}, State) ->
     end,
     AppInfo1 = rebar_app_info:source(AppInfo, {pkg, PkgName1, PkgVsn1, Hash1}),
     AppInfo2 = rebar_app_info:registry(AppInfo1, Registry),
-    {ok, Deps} = rebar_packages:deps_(PkgName1
-                                     ,PkgVsn1
-                                     ,Registry
-                                     ,State),
+    {ok, Deps} = rebar_packages:deps(PkgName1
+                                    ,PkgVsn1
+                                    ,Registry
+                                    ,State),
     AppInfo3 = rebar_app_info:resource_type(rebar_app_info:deps(AppInfo2, Deps), pkg),
     rebar_app_info:original_vsn(AppInfo3, PkgVsn1);
 update_source(AppInfo, Source, _State) ->

--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -280,7 +280,7 @@ fetch_checksum(PkgName, PkgVsn, Hash, Registry, State) ->
     catch
         _:_ ->
             ?INFO("Package ~s-~s not found. Fetching registry updates and trying again...", [PkgName, PkgVsn]),
-            {ok, _} = rebar_prv_update:do(State),
+            ok = rebar_prv_update:do(State),
             rebar_packages:registry_checksum({{pkg, PkgName, PkgVsn, Hash}, Registry}, State)
     end.
 

--- a/src/rebar_fetch.erl
+++ b/src/rebar_fetch.erl
@@ -25,6 +25,8 @@ lock_source(AppDir, Source, State) ->
 
 -spec download_source(file:filename_all(), rebar_resource:resource(), rebar_state:t()) ->
                              true | {error, any()}.
+download_source(AppDir, {Source, undefined}, State) when is_tuple(Source) ->
+    download_source(AppDir, Source, State);
 download_source(AppDir, Source, State) ->
     try download_source_(AppDir, Source, State) of
         true ->
@@ -86,6 +88,8 @@ format_error({bad_checksum, File}) ->
 format_error({bad_registry_checksum, File}) ->
     io_lib:format("Checksum mismatch against registry in ~s", [File]).
 
+get_resource_type({{pkg, _, _, _}, _}, _) ->
+    rebar_pkg_resource;
 get_resource_type({Type, Location}, Resources) ->
     find_resource_module(Type, Location, Resources);
 get_resource_type({Type, Location, _}, Resources) ->

--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -1,16 +1,18 @@
 -module(rebar_packages).
 
--export([packages/1
-        ,close_packages/0
-        ,load_and_verify_version/1
+-export([packages/2
+        ,close_packages/1
+        ,load_and_verify_version/2
         ,deps/3
-        ,registry_dir/1
-        ,package_dir/1
+        ,deps_/4
+        ,registry_dir/2
+        ,package_dir/2
         ,registry_checksum/2
-        ,find_highest_matching/6
-        ,find_highest_matching/4
+        ,find_package_registry/3
+        ,find_highest_matching/5
+        ,find_highest_matching/3
         ,find_all/3
-        ,verify_table/1
+        ,verify_table/2
         ,format_error/1]).
 
 -export_type([package/0]).
@@ -22,57 +24,93 @@
 -type vsn() :: binary().
 -type package() :: pkg_name() | {pkg_name(), vsn()}.
 
--spec packages(rebar_state:t()) -> ets:tid().
-packages(State) ->
-    catch ets:delete(?PACKAGE_TABLE),
-    case load_and_verify_version(State) of
-        true ->
-            ok;
-        false ->
-            ?DEBUG("Error loading package index.", []),
-            handle_bad_index(State)
-    end.
-
-handle_bad_index(State) ->
-    ?ERROR("Bad packages index. Trying to fix by updating the registry.", []),
-    {ok, State1} = rebar_prv_update:do(State),
-    case load_and_verify_version(State1) of
-        true ->
-            ok;
-        false ->
-            %% Still unable to load after an update, create an empty registry
-            ets:new(?PACKAGE_TABLE, [named_table, public])
-    end.
-
-close_packages() ->
-    catch ets:delete(?PACKAGE_TABLE).
-
-load_and_verify_version(State) ->
-    {ok, RegistryDir} = registry_dir(State),
-    case ets:file2tab(filename:join(RegistryDir, ?INDEX_FILE)) of
-        {ok, _} ->
-            case ets:lookup_element(?PACKAGE_TABLE, package_index_version, 2) of
-                ?PACKAGE_INDEX_VERSION ->
-                    true;
-                _ ->
-                    (catch ets:delete(?PACKAGE_TABLE)),
-                    rebar_prv_update:hex_to_index(State)
-            end;
+-spec packages(binary(), rebar_state:t()) -> ets:tid().
+packages(Registry, State) ->
+    case load_and_verify_version(Registry, State) of
+        {ok, T1} ->
+            {ok, T1};
         _ ->
-            rebar_prv_update:hex_to_index(State)
+            ?DEBUG("Error loading package index.", []),
+            handle_bad_index(Registry, State)
+    end.
+
+handle_bad_index(Registry, State) ->
+    ?ERROR("Bad packages index. Trying to fix by updating the registry from ~s", [Registry]),
+    case rebar_prv_update:do(Registry, State) of
+        {ok, State1} ->
+            case load_and_verify_version(Registry, State1) of
+                {ok, T} ->
+                    {ok, T};
+                false ->
+                    %% Still unable to load after an update, create an empty registry
+                    ets:new(repo, [public])
+            end;
+        E ->
+            throw(E)
+    end.
+
+close_packages(T) ->
+    catch ets:delete(T).
+
+load_and_verify_version(Registry, State) ->
+    case ?MODULE:registry_dir(Registry, State) of
+        {ok, RegistryDir} ->
+            case ets:file2tab(filename:join(RegistryDir, ?INDEX_FILE)) of
+                {ok, T} ->
+                    {ok, T};
+                E ->
+                    E
+            end;
+        E ->
+            E
     end.
 
 deps(Name, Vsn, State) ->
     try
-        deps_(Name, Vsn, State)
+        find(rebar_state:repos(State),
+            fun(Registry) -> deps_(Name, Vsn, Registry, State) end)
     catch
         _:_ ->
             handle_missing_package({Name, Vsn}, State, fun(State1) -> deps_(Name, Vsn, State1) end)
     end.
 
 deps_(Name, Vsn, State) ->
-    ?MODULE:verify_table(State),
-    ets:lookup_element(?PACKAGE_TABLE, {ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)}, 2).
+    find(rebar_state:repos(State),
+         fun(Registry) -> deps_(Name, Vsn, Registry, State) end).
+
+deps_(Name, Vsn, Registry, State) ->
+    {ok, T} = ?MODULE:verify_table(Registry, State),
+    case ets:lookup_element(T, {ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)}, 2) of
+        [Deps | _] ->
+            {ok, Deps};
+        E ->
+            E
+    end.
+
+find_package_registry(Name, Vsn, State) ->
+    find(rebar_state:repos(State),
+         fun(Registry) -> find_package_registry_(Name, Vsn, Registry, State) end).
+
+find_package_registry_(Name, Vsn, Registry, State) ->
+    {ok, T} = ?MODULE:verify_table(Registry, State),
+    case ets:member(T, {ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)}) of
+        true ->
+            {ok, Registry};
+        false ->
+            not_found
+    end.
+
+find([], _) ->
+    error;
+find([X | R], Fun) ->
+    case catch(Fun(X)) of
+        {ok, Y, Z} ->
+            {ok, Y, Z};
+        {ok, Y} ->
+            {ok, Y};
+        _ ->
+            find(R, Fun)
+    end.
 
 handle_missing_package(Dep, State, Fun) ->
     case Dep of
@@ -91,9 +129,9 @@ handle_missing_package(Dep, State, Fun) ->
             throw(?PRV_ERROR({missing_package, Dep}))
     end.
 
-registry_dir(State) ->
+registry_dir(Registry, State) ->
     CacheDir = rebar_dir:global_cache_dir(rebar_state:opts(State)),
-    case rebar_state:get(State, rebar_packages_cdn, ?DEFAULT_CDN) of
+    case Registry of
         ?DEFAULT_CDN ->
             RegistryDir = filename:join([CacheDir, "hex", "default"]),
             ok = filelib:ensure_dir(filename:join(RegistryDir, "placeholder")),
@@ -112,8 +150,8 @@ registry_dir(State) ->
             end
     end.
 
-package_dir(State) ->
-    case registry_dir(State) of
+package_dir(Registry, State) ->
+    case registry_dir(Registry, State) of
         {ok, RegistryDir} ->
             PackageDir = filename:join([RegistryDir, "packages"]),
             ok = filelib:ensure_dir(filename:join(PackageDir, "placeholder")),
@@ -122,10 +160,11 @@ package_dir(State) ->
             Error
     end.
 
-registry_checksum({pkg, Name, Vsn, _Hash}, State) ->
+registry_checksum({{pkg, Name, Vsn, _Hash}, Registry}, State) ->
     try
-        ?MODULE:verify_table(State),
-        ets:lookup_element(?PACKAGE_TABLE, {Name, Vsn}, 3)
+        {ok, T} = ?MODULE:verify_table(Registry, State),
+        [_, Checksum | _] = ets:lookup_element(T, {Name, Vsn}, 2),
+        Checksum
     catch
         _:_ ->
             throw(?PRV_ERROR({missing_package, ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)}))
@@ -146,15 +185,20 @@ registry_checksum({pkg, Name, Vsn, _Hash}, State) ->
 %% `~> 2.1.3-dev` | `>= 2.1.3-dev and < 2.2.0`
 %% `~> 2.0` | `>= 2.0.0 and < 3.0.0`
 %% `~> 2.1` | `>= 2.1.0 and < 3.0.0`
-find_highest_matching(Dep, Constraint, Table, State) ->
-    find_highest_matching(undefined, undefined, Dep, Constraint, Table, State).
+find_highest_matching(Dep, Constraint, State) ->
+    find_highest_matching(undefined, undefined, Dep, Constraint, State).
 
-find_highest_matching(Pkg, PkgVsn, Dep, Constraint, Table, State) ->
-    try find_highest_matching_(Pkg, PkgVsn, Dep, Constraint, Table, State) of
+find_highest_matching(Pkg, PkgVsn, Dep, Constraint, State) ->
+    try
+        find(rebar_state:repos(State),
+            fun(Registry) ->
+                find_highest_matching_(Pkg, PkgVsn, Dep, Constraint, Registry, State)
+            end)
+    of
         none ->
             handle_missing_package(Dep, State,
                                    fun(State1) ->
-                                       find_highest_matching_(Pkg, PkgVsn, Dep, Constraint, Table, State1)
+                                       find_highest_matching_(Pkg, PkgVsn, Dep, Constraint, State1)
                                    end);
         Result ->
             Result
@@ -162,31 +206,49 @@ find_highest_matching(Pkg, PkgVsn, Dep, Constraint, Table, State) ->
         _:_ ->
             handle_missing_package(Dep, State,
                                    fun(State1) ->
-                                       find_highest_matching_(Pkg, PkgVsn, Dep, Constraint, Table, State1)
+                                       find_highest_matching_(Pkg, PkgVsn, Dep, Constraint, State1)
                                    end)
     end.
 
-find_highest_matching_(Pkg, PkgVsn, Dep, Constraint, Table, State) ->
-    try find_all(Dep, Table, State) of
+find_highest_matching_(Pkg, PkgVsn, Dep, Constraint, State) ->
+    try
+        find(rebar_state:repos(State),
+            fun(Registry) ->
+                find_highest_matching_(Pkg, PkgVsn, Dep, Constraint, Registry, State)
+            end)
+    catch
+        _:_ ->
+            none
+    end.
+
+find_highest_matching_(Pkg, PkgVsn, Dep, Constraint, Registry, State) ->
+    try find_all(Dep, Registry, State) of
         {ok, [Vsn]} ->
-            handle_single_vsn(Pkg, PkgVsn, Dep, Vsn, Constraint);
+            {ok, Vsn} = handle_single_vsn(Pkg, PkgVsn, Dep, Vsn, Constraint),
+            {ok, Vsn, Registry};
         {ok, [HeadVsn | VsnTail]} ->
-                            {ok, handle_vsns(Constraint, HeadVsn, VsnTail)}
+            {ok, handle_vsns(Constraint, HeadVsn, VsnTail), Registry};
+        _ ->
+            none
     catch
         error:badarg ->
             none
     end.
 
-find_all(Dep, Table, State) ->
-    ?MODULE:verify_table(State),
-    try ets:lookup_element(Table, Dep, 2) of
-        [Vsns] when is_list(Vsns)->
-            {ok, Vsns};
-        Vsns ->
-            {ok, Vsns}
-    catch
-        error:badarg ->
-            none
+find_all(Dep, Registry, State) ->
+    case ?MODULE:verify_table(Registry, State) of
+        {ok, T} ->
+            try ets:lookup_element(T, Dep, 2) of
+                [Vsns | _] when is_list(Vsns)->
+                    {ok, Vsns};
+                Vsns ->
+                    {ok, Vsns}
+            catch
+                error:badarg ->
+                    none
+            end;
+        E ->
+            E
     end.
 
 handle_vsns(Constraint, HeadVsn, VsnTail) ->
@@ -207,19 +269,34 @@ handle_single_vsn(Pkg, PkgVsn, Dep, Vsn, Constraint) ->
         false ->
             case {Pkg, PkgVsn} of
                 {undefined, undefined} ->
-                    ?WARN("Only existing version of ~s is ~s which does not match constraint ~~> ~s. "
+                    ?DEBUG("Only existing version of ~s is ~s which does not match constraint ~~> ~s. "
                           "Using anyway, but it is not guaranteed to work.", [Dep, Vsn, Constraint]);
                 _ ->
-                    ?WARN("[~s:~s] Only existing version of ~s is ~s which does not match constraint ~~> ~s. "
+                    ?DEBUG("[~s:~s] Only existing version of ~s is ~s which does not match constraint ~~> ~s. "
                           "Using anyway, but it is not guaranteed to work.", [Pkg, PkgVsn, Dep, Vsn, Constraint])
             end,
             {ok, Vsn}
     end.
 
+format_error({package_parse_cdn, Uri}) ->
+    io_lib:format("Failed to parse registry url: ~p", [Uri]);
 format_error({missing_package, Name, Vsn}) ->
     io_lib:format("Package not found in registry: ~s-~s.", [ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)]);
 format_error({missing_package, Dep}) ->
     io_lib:format("Package not found in registry: ~p.", [Dep]).
 
-verify_table(State) ->
-    ets:info(?PACKAGE_TABLE, named_table) =:= true orelse load_and_verify_version(State).
+verify_table(Registry, State) ->
+    case ets:lookup(?REPOS_TABLE, Registry) of
+        [{Registry, T}] ->
+            {ok, T};
+        _ ->
+            case load_and_verify_version(Registry, State) of
+                {ok, T} ->
+                    ets:insert(?REPOS_TABLE, {Registry, T}),
+                    {ok, T};
+                {uri_parse_error, Uri} ->
+                    throw(?PRV_ERROR({package_parse_cdn, Uri}));
+                _ ->
+                    handle_bad_index(Registry, State)
+            end
+    end.

--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -165,7 +165,9 @@ public_key(Registry, State) ->
 maybe_verify_registry(Registry, Data, State) ->
     maybe_verify_registry(os:getenv(?HEX_UNSAFE_REGISTRY), Registry, Data, State).
 
-maybe_verify_registry(false, Registry, Data, State) ->
+maybe_verify_registry(Unsafe, Registry, Data, State) when Unsafe =:= "false"
+                                                        ; Unsafe =:= "0"
+                                                        ; Unsafe =:= false ->
     case signature(Registry) of
         {ok, Signature} ->
             case public_key(Registry, State) of

--- a/src/rebar_prv_app_discovery.erl
+++ b/src/rebar_prv_app_discovery.erl
@@ -39,6 +39,8 @@ do(State) ->
         State2 = rebar_plugins:project_apps_install(State1),
         {ok, State2}
     catch
+        throw:{error, {rebar_prv_update, Error}} ->
+            {error, {rebar_prv_update, Error}};
         throw:{error, {rebar_packages, Error}} ->
             {error, {rebar_packages, Error}};
         throw:{error, {rebar_app_utils, Error}} ->

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -362,7 +362,8 @@ fetch_app(AppInfo, AppDir, State) ->
     ?INFO("Fetching ~s (~p)", [rebar_app_info:name(AppInfo),
                                format_source(rebar_app_info:source(AppInfo))]),
     Source = rebar_app_info:source(AppInfo),
-    true = rebar_fetch:download_source(AppDir, Source, State).
+    Registry = rebar_app_info:registry(AppInfo),
+    true = rebar_fetch:download_source(AppDir, {Source, Registry}, State).
 
 format_source({pkg, Name, Vsn, _Hash}) -> {pkg, Name, Vsn};
 format_source(Source) -> Source.
@@ -380,12 +381,13 @@ update_app_info(AppDir, AppInfo) ->
 
 maybe_upgrade(AppInfo, AppDir, Upgrade, State) ->
     Source = rebar_app_info:source(AppInfo),
+    Registry = rebar_app_info:registry(AppInfo),
     case Upgrade orelse rebar_app_info:is_lock(AppInfo) of
         true ->
             case rebar_fetch:needs_update(AppDir, Source, State) of
                 true ->
                     ?INFO("Upgrading ~s (~p)", [rebar_app_info:name(AppInfo), rebar_app_info:source(AppInfo)]),
-                    true = rebar_fetch:download_source(AppDir, Source, State);
+                    true = rebar_fetch:download_source(AppDir, {Source, Registry}, State);
                 false ->
                     case Upgrade of
                         true ->

--- a/src/rebar_prv_packages.erl
+++ b/src/rebar_prv_packages.erl
@@ -27,18 +27,23 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    rebar_packages:packages(State),
-    case rebar_state:command_args(State) of
-        [Name] ->
-            print_packages(get_packages(iolist_to_binary(Name)));
-        _ ->
-            print_packages(sort_packages())
-    end,
+    [catch(do(Registry, State)) || Registry <- rebar_state:repos(State)],
     {ok, State}.
 
 -spec format_error(any()) -> iolist().
 format_error(load_registry_fail) ->
     "Failed to load package regsitry. Try running 'rebar3 update' to fix".
+
+do(Registry, State) ->
+    {ok, T} = rebar_packages:verify_table(Registry, State),
+    {ok, _} = rebar_packages:packages(Registry, State),
+    ?CONSOLE("Packages from ~s:~n", [Registry]),
+    case rebar_state:command_args(State) of
+        [Name] ->
+            print_packages(get_packages(iolist_to_binary(Name), T));
+        _ ->
+            print_packages(sort_packages(T))
+    end.
 
 print_packages(Pkgs) ->
     orddict:map(fun(Name, Vsns) ->
@@ -50,17 +55,17 @@ print_packages(Pkgs) ->
                         ?CONSOLE("~s:~n    Versions: ~s~n", [Name, VsnStr])
                 end, Pkgs).
 
-sort_packages() ->
+sort_packages(T) ->
     ets:foldl(fun({package_index_version, _}, Acc) ->
                       Acc;
-                 ({Pkg, Vsns}, Acc) ->
+                 ({Pkg, [Vsns | _]}, Acc) when is_binary(Pkg) ->
                       orddict:store(Pkg, Vsns, Acc);
                  (_, Acc) ->
                       Acc
-              end, orddict:new(), ?PACKAGE_TABLE).
+              end, orddict:new(), T).
 
-get_packages(Name) ->
-    ets:lookup(?PACKAGE_TABLE, Name).
+get_packages(Name, T) ->
+    ets:lookup(T, Name).
 
 
 -spec join([binary()], binary()) -> binary().

--- a/src/rebar_prv_update.erl
+++ b/src/rebar_prv_update.erl
@@ -7,13 +7,14 @@
 
 -export([init/1,
          do/1,
+         do/2,
          format_error/1]).
 
--export([hex_to_index/1]).
+%-export([hex_to_index/1]).
 
--ifdef(TEST).
+%-ifdef(TEST).
 -export([cmp_/6, cmpl_/6, valid_vsn/1]).
--endif.
+%-endif.
 
 -include("rebar.hrl").
 -include_lib("providers/include/providers.hrl").
@@ -39,17 +40,19 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
+    [do(Registry, State) || Registry <- rebar_state:repos(State)],
+    {ok, State}.
+
+do(Registry, State) ->
     try
-        case rebar_packages:registry_dir(State) of
+        case rebar_packages:registry_dir(Registry, State) of
             {ok, RegistryDir} ->
                 filelib:ensure_dir(filename:join(RegistryDir, "dummy")),
                 HexFile = filename:join(RegistryDir, "registry"),
                 ?INFO("Updating package registry...", []),
                 TmpDir = ec_file:insecure_mkdtemp(),
                 TmpFile = filename:join(TmpDir, "packages.gz"),
-
-                CDN = rebar_state:get(State, rebar_packages_cdn, ?DEFAULT_CDN),
-                case rebar_utils:url_append_path(CDN, ?REMOTE_REGISTRY_FILE) of
+                case rebar_utils:url_append_path(Registry, ?REMOTE_REGISTRY_FILE) of
                     {ok, Url} ->
                         ?DEBUG("Fetching registry from ~p", [Url]),
                         case httpc:request(get, {Url, [{"User-Agent", rebar_utils:user_agent()}]},
@@ -60,21 +63,20 @@ do(State) ->
                                 Unzipped = zlib:gunzip(Data),
                                 ok = file:write_file(HexFile, Unzipped),
                                 ?INFO("Writing registry to ~s", [HexFile]),
-                                hex_to_index(State),
                                 {ok, State};
                             _ ->
-                                ?PRV_ERROR(package_index_download)
+                                ?PRV_ERROR({package_index_download, Registry})
                         end;
                     _ ->
-                        ?PRV_ERROR({package_parse_cdn, CDN})
+                        ?PRV_ERROR({package_parse_cdn, Registry})
                 end;
-            {uri_parse_error, CDN} ->
-                ?PRV_ERROR({package_parse_cdn, CDN})
+            {uri_parse_error, Registry} ->
+                ?PRV_ERROR({package_parse_cdn, Registry})
         end
     catch
         _E:C ->
             ?DEBUG("Error creating package index: ~p ~p", [C, erlang:get_stacktrace()]),
-            throw(?PRV_ERROR(package_index_write))
+            ?ERROR("Failed to write package index for registry ~s", [Registry])
     end.
 
 -spec format_error(any()) -> iolist().
@@ -85,139 +87,12 @@ format_error(package_index_download) ->
 format_error(package_index_write) ->
     "Failed to write package index.".
 
-is_supported(<<"make">>) -> true;
-is_supported(<<"rebar">>) -> true;
-is_supported(<<"rebar3">>) -> true;
-is_supported(_) -> false.
-
-hex_to_index(State) ->
-    {ok, RegistryDir} = rebar_packages:registry_dir(State),
-    HexFile = filename:join(RegistryDir, "registry"),
-    try ets:file2tab(HexFile) of
-        {ok, Registry} ->
-            try
-                PackageIndex = filename:join(RegistryDir, "packages.idx"),
-                ?INFO("Generating package index...", []),
-                (catch ets:delete(?PACKAGE_TABLE)),
-                ets:new(?PACKAGE_TABLE, [named_table, public]),
-                ets:foldl(fun({{Pkg, PkgVsn}, [Deps, Checksum, BuildTools | _]}, _) when is_list(BuildTools) ->
-                                  case lists:any(fun is_supported/1, BuildTools) of
-                                      true ->
-                                          DepsList = update_deps_list(Pkg, PkgVsn, Deps, Registry, State),
-                                          HashedDeps = update_deps_hashes(DepsList),
-                                          ets:insert(?PACKAGE_TABLE, {{Pkg, PkgVsn}, HashedDeps, Checksum});
-                                      false ->
-                                          true
-                                  end;
-                             (_, _) ->
-                                  true
-                          end, true, Registry),
-
-                ets:foldl(fun({Pkg, [[]]}, _) when is_binary(Pkg) ->
-                                  true;
-                             ({Pkg, [Vsns=[_Vsn | _Rest]]}, _) when is_binary(Pkg) ->
-                                  %% Verify the package is of the right build tool by checking if the first
-                                  %% version exists in the table from the foldl above
-                                  case [V || V <- Vsns, ets:member(?PACKAGE_TABLE, {Pkg, V})] of
-                                      [] ->
-                                          true;
-                                      Vsns1 ->
-                                          ets:insert(?PACKAGE_TABLE, {Pkg, Vsns1})
-                                  end;
-                             (_, _) ->
-                                  true
-                          end, true, Registry),
-                ets:insert(?PACKAGE_TABLE, {package_index_version, ?PACKAGE_INDEX_VERSION}),
-                ?INFO("Writing index to ~s", [PackageIndex]),
-                ets:tab2file(?PACKAGE_TABLE, PackageIndex),
-                true
-            after
-                catch ets:delete(Registry)
-            end;
-        {error, Reason} ->
-            ?DEBUG("Error loading package registry: ~p", [Reason]),
-            false
-    catch
-        _:_ ->
-            fail
-    end.
-
-update_deps_list(Pkg, PkgVsn, Deps, HexRegistry, State) ->
-    lists:foldl(fun([Dep, DepVsn, false, AppName | _], DepsListAcc) ->
-                        Dep1 = {Pkg, PkgVsn, Dep, AppName},
-                        case {valid_vsn(DepVsn), DepVsn} of
-                            %% Those are all not perfectly implemented!
-                            %% and doubled since spaces seem not to be
-                            %% enforced
-                            {false, Vsn} ->
-                                ?WARN("[~s:~s], Bad dependency version for ~s: ~s.",
-                                      [Pkg, PkgVsn, Dep, Vsn]),
-                                DepsListAcc;
-                            {_, <<"~>", Vsn/binary>>} ->
-                                highest_matching(Dep1, rm_ws(Vsn), HexRegistry,
-                                                 State, DepsListAcc);
-                            {_, <<">=", Vsn/binary>>} ->
-                                cmp(Dep1, rm_ws(Vsn), HexRegistry, State,
-                                    DepsListAcc, fun ec_semver:gte/2);
-                            {_, <<">", Vsn/binary>>} ->
-                                cmp(Dep1, rm_ws(Vsn), HexRegistry, State,
-                                    DepsListAcc, fun ec_semver:gt/2);
-                            {_, <<"<=", Vsn/binary>>} ->
-                                cmpl(Dep1, rm_ws(Vsn), HexRegistry, State,
-                                     DepsListAcc, fun ec_semver:lte/2);
-                            {_, <<"<", Vsn/binary>>} ->
-                                cmpl(Dep1, rm_ws(Vsn), HexRegistry, State,
-                                     DepsListAcc, fun ec_semver:lt/2);
-                            {_, <<"==", Vsn/binary>>} ->
-                                [{AppName, {pkg, Dep, Vsn, undefined}} | DepsListAcc];
-                            {_, Vsn} ->
-                                [{AppName, {pkg, Dep, Vsn, undefined}} | DepsListAcc]
-                        end;
-                   ([_Dep, _DepVsn, true, _AppName | _], DepsListAcc) ->
-                        DepsListAcc
-                end, [], Deps).
-
-update_deps_hashes(List) ->
-    [{Name, {pkg, PkgName, Vsn, lookup_hash(PkgName, Vsn, Hash)}}
-     || {Name, {pkg, PkgName, Vsn, Hash}} <- List].
-
-lookup_hash(Name, Vsn, undefined) ->
-    try
-        ets:lookup_element(?PACKAGE_TABLE, {Name, Vsn}, 3)
-    catch
-        _:_ ->
-            undefined
-    end;
-lookup_hash(_, _, Hash) ->
-    Hash.
-
-
-rm_ws(<<" ", R/binary>>) ->
-    rm_ws(R);
-rm_ws(R) ->
-    R.
-
 valid_vsn(Vsn) ->
     %% Regepx from https://github.com/sindresorhus/semver-regex/blob/master/index.js
     SemVerRegExp = "v?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))?"
         "(-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9a-z-]+(\\.[0-9a-z-]+)*)?",
     SupportedVersions = "^(>=?|<=?|~>|==)?\\s*" ++ SemVerRegExp ++ "$",
     re:run(Vsn, SupportedVersions) =/= nomatch.
-
-highest_matching({Pkg, PkgVsn, Dep, App}, Vsn, HexRegistry, State, DepsListAcc) ->
-    case rebar_packages:find_highest_matching(Pkg, PkgVsn, Dep, Vsn, HexRegistry, State) of
-        {ok, HighestDepVsn} ->
-            [{App, {pkg, Dep, HighestDepVsn, undefined}} | DepsListAcc];
-        none ->
-            ?WARN("[~s:~s] Missing registry entry for package ~s. Try to fix with `rebar3 update`",
-                  [Pkg, PkgVsn, Dep]),
-            DepsListAcc
-    end.
-
-cmp({_Pkg, _PkgVsn, Dep, _App} = Dep1, Vsn, HexRegistry, State, DepsListAcc, CmpFun) ->
-    {ok, Vsns}  = rebar_packages:find_all(Dep, HexRegistry, State),
-    cmp_(undefined, Vsn, Vsns, DepsListAcc, Dep1, CmpFun).
-
 
 cmp_(undefined, _MinVsn, [], DepsListAcc, {Pkg, PkgVsn, Dep, _App}, _CmpFun) ->
     ?WARN("[~s:~s] Missing registry entry for package ~s. Try to fix with `rebar3 update`",
@@ -233,12 +108,6 @@ cmp_(BestMatch, MinVsn, [Vsn | R], DepsListAcc, Dep, CmpFun) ->
         false  ->
             cmp_(BestMatch, MinVsn, R, DepsListAcc, Dep, CmpFun)
     end.
-
-%% We need to treat this differently since we want a version that is LOWER but
-%% the higest possible one.
-cmpl({_Pkg, _PkgVsn, Dep, _App} = Dep1, Vsn, HexRegistry, State, DepsListAcc, CmpFun) ->
-    {ok, Vsns}  = rebar_packages:find_all(Dep, HexRegistry, State),
-    cmpl_(undefined, Vsn, Vsns, DepsListAcc, Dep1, CmpFun).
 
 cmpl_(undefined, _MaxVsn, [], DepsListAcc, {Pkg, PkgVsn, Dep, _App}, _CmpFun) ->
     ?WARN("[~s:~s] Missing registry entry for package ~s. Try to fix with `rebar3 update`",

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -38,6 +38,8 @@
 
          to_list/1,
 
+         repos/1, repos/2,
+
          resources/1, resources/2, add_resource/2,
          providers/1, providers/2, add_provider/2,
          allow_provider_overrides/1, allow_provider_overrides/2
@@ -64,6 +66,8 @@
                   deps_to_build       = []          :: [rebar_app_info:t()],
                   all_plugin_deps     = []          :: [rebar_app_info:t()],
                   all_deps            = []          :: [rebar_app_info:t()],
+
+                  repos                             :: [string()],
 
                   resources           = [],
                   providers           = [],
@@ -301,7 +305,9 @@ dir(State=#state_t{}, Dir) ->
     State#state_t{dir=filename:absname(Dir)}.
 
 deps_names(Deps) when is_list(Deps) ->
-    lists:map(fun(Dep) when is_tuple(Dep) ->
+    lists:map(fun([Dep, _Vsn, _Required, _App]) ->
+                  Dep;
+                 (Dep) when is_tuple(Dep) ->
                       ec_cnv:to_binary(element(1, Dep));
                  (Dep) when is_atom(Dep) ->
                       ec_cnv:to_binary(Dep)
@@ -355,6 +361,12 @@ namespace(#state_t{namespace=Namespace}) ->
 
 namespace(State=#state_t{}, Namespace) ->
     State#state_t{namespace=Namespace}.
+
+repos(#state_t{repos=Repos}) ->
+    Repos.
+
+repos(State, Repos) ->
+    State#state_t{repos=Repos}.
 
 -spec resources(t()) -> [{rebar_resource:type(), module()}].
 resources(#state_t{resources=Resources}) ->

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -67,7 +67,7 @@
                   all_plugin_deps     = []          :: [rebar_app_info:t()],
                   all_deps            = []          :: [rebar_app_info:t()],
 
-                  repos                             :: [string()],
+                  repos               = [?DEFAULT_REGISTRY] :: [string()],
 
                   resources           = [],
                   providers           = [],

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -845,11 +845,14 @@ set_httpc_options(Scheme, Proxy) ->
     set_proxy_auth(UserInfo).
 
 url_append_path(Url, ExtraPath) ->
-     case http_uri:parse(Url) of
+     try http_uri:parse(Url) of
          {ok, {Scheme, UserInfo, Host, Port, Path, Query}} ->
              {ok, lists:append([atom_to_list(Scheme), "://", UserInfo, Host, ":", integer_to_list(Port),
                                 filename:join(Path, ExtraPath), "?", Query])};
          _ ->
+             error
+     catch
+         _:_ ->
              error
      end.
 

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -852,7 +852,8 @@ url_append_path(Url, ExtraPath) ->
          _ ->
              error
      catch
-         _:_ ->
+         C:T ->
+             ?DEBUG("Failed url_append_path ~p ~p: ~p ~p", [Url, ExtraPath, C, T]),
              error
      end.
 
@@ -888,7 +889,7 @@ list_dir(Dir) ->
 set_proxy_auth([]) ->
     ok;
 set_proxy_auth(UserInfo) ->
-    Idx = string:chr(UserInfo, $:), 
+    Idx = string:chr(UserInfo, $:),
     Username = string:sub_string(UserInfo, 1, Idx-1),
     Password = string:sub_string(UserInfo, Idx+1),
     %% password may contain url encoded characters, need to decode them first

--- a/test/mock_pkg_resource.erl
+++ b/test/mock_pkg_resource.erl
@@ -118,6 +118,8 @@ mock_pkg_index(Opts) ->
     meck:new(rebar_packages, [passthrough, no_link]),
     meck:expect(rebar_packages, packages,
                 fun(_, _State) -> to_index(Deps, Dict) end),
+    meck:expect(rebar_packages, maybe_verify_registry,
+                fun(_, _, _) -> true end),
     meck:expect(rebar_packages, verify_table,
                 fun(_, _State) -> to_index(Deps, Dict) end).
 

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -37,7 +37,8 @@ init_rebar_state(Config, Name) ->
     State = rebar_state:new([{base_dir, filename:join([AppsDir, "_build"])}
                             ,{global_rebar_dir, GlobalDir}
                             ,{root_dir, AppsDir}]),
-    [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, State} | Config].
+    State1 = rebar_state:repos(State, ["http://test.com/"]),
+    [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, State1} | Config].
 
 %% @doc Takes common test config, a rebar config ([] if empty), a command to
 %% run ("install_deps", "compile", etc.), and a list of expected applications


### PR DESCRIPTION
Packages are searched for in repositories in the order the are
defined. The first match is used. Repositories are not part of
the lock file, only the package name, version and checksum.