### PR TITLE
Don't die when source deps with [raw] are used

### DIFF
--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -134,7 +134,12 @@ parse_dep(Parent, {Name, Source}, DepsDir, IsLock, State) when is_tuple(Source) 
     dep_to_app(Parent, DepsDir, Name, [], Source, IsLock, State);
 parse_dep(Parent, {Name, _Vsn, Source}, DepsDir, IsLock, State) when is_tuple(Source) ->
     dep_to_app(Parent, DepsDir, Name, [], Source, IsLock, State);
-parse_dep(Parent, {Name, _Vsn, Source, Opts}, DepsDir, IsLock, State) when is_tuple(Source) ->
+parse_dep(Parent, {Name, _Vsn, Source, Opts}, DepsDir, IsLock, State) when is_tuple(Source),
+                                                                           is_list(Opts) ->
+    ?WARN("Dependency option list ~p in ~p is not supported and will be ignored", [Opts, Name]),
+    dep_to_app(Parent, DepsDir, Name, [], Source, IsLock, State);
+parse_dep(Parent, {Name, Source, Opts}, DepsDir, IsLock, State) when is_tuple(Source),
+                                                                     is_list(Opts) ->
     ?WARN("Dependency option list ~p in ~p is not supported and will be ignored", [Opts, Name]),
     dep_to_app(Parent, DepsDir, Name, [], Source, IsLock, State);
 parse_dep(Parent, {Name, {pkg, PkgName, Vsn}, Level}, DepsDir, IsLock, State) when is_integer(Level) ->

--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -180,6 +180,24 @@ check_newly_added({Name, _, Source}, LockedDeps) ->
 check_newly_added(Dep, LockedDeps) ->
     check_newly_added_(Dep, LockedDeps).
 
+%% get [raw] deps out of the way
+check_newly_added_({Name, Source, Opts}, LockedDeps) when is_tuple(Source),
+                                                          is_list(Opts) ->
+    case check_newly_added_(Name, LockedDeps) of
+        {true, Name1} ->
+            {true, {Name1, Source}};
+        false ->
+            false
+    end;
+check_newly_added_({Name,_Vsn,Source,Opts}, LockedDeps) when is_tuple(Source),
+                                                             is_list(Opts) ->
+    case check_newly_added_(Name, LockedDeps) of
+        {true, Name1} ->
+            {true, {Name1, Source}};
+        false ->
+            false
+    end;
+%% and on to regular deps
 check_newly_added_({Name, Vsn, Source}, LockedDeps) ->
     case check_newly_added_(Name, LockedDeps) of
         {true, Name1} ->


### PR DESCRIPTION
This adds support for their format both on the first read and when
looking for modifications to dependencies.