### PR TITLE
debug message update so that it is human readable

### DIFF
--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -107,14 +107,14 @@ download(Dir, {git, Url, ""}, State) ->
     download(Dir, {git, Url, {branch, "master"}}, State);
 download(Dir, {git, Url, {branch, Branch}}, _State) ->
     ok = filelib:ensure_dir(Dir),
-    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s ",
+    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s --single-branch",
                        [rebar_utils:escape_chars(Url),
                         rebar_utils:escape_chars(filename:basename(Dir)),
                         rebar_utils:escape_chars(Branch)]),
                    [{cd, filename:dirname(Dir)}]);
 download(Dir, {git, Url, {tag, Tag}}, _State) ->
     ok = filelib:ensure_dir(Dir),
-    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s ",
+    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s --single-branch",
                        [rebar_utils:escape_chars(Url),
                         rebar_utils:escape_chars(filename:basename(Dir)),
                         rebar_utils:escape_chars(Tag)]),

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -107,14 +107,14 @@ download(Dir, {git, Url, ""}, State) ->
     download(Dir, {git, Url, {branch, "master"}}, State);
 download(Dir, {git, Url, {branch, Branch}}, _State) ->
     ok = filelib:ensure_dir(Dir),
-    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s --single-branch",
+    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s ",
                        [rebar_utils:escape_chars(Url),
                         rebar_utils:escape_chars(filename:basename(Dir)),
                         rebar_utils:escape_chars(Branch)]),
                    [{cd, filename:dirname(Dir)}]);
 download(Dir, {git, Url, {tag, Tag}}, _State) ->
     ok = filelib:ensure_dir(Dir),
-    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s --single-branch",
+    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s ",
                        [rebar_utils:escape_chars(Url),
                         rebar_utils:escape_chars(filename:basename(Dir)),
                         rebar_utils:escape_chars(Tag)]),

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -17,7 +17,7 @@
 lock(AppDir, {git, Url, _}) ->
     lock(AppDir, {git, Url});
 lock(AppDir, {git, Url}) ->
-    AbortMsg = io_lib:format("Locking of git dependency failed in ~s", [AppDir]),
+    AbortMsg = lists:flatten(io_lib:format("Locking of git dependency failed in ~s", [AppDir])),
     Dir = rebar_utils:escape_double_quotes(AppDir),
     {ok, VsnString} =
         case os:type() of


### PR DESCRIPTION
Debug log(s) was showing the following: 

```
===> 	opts: [{use_stdout,false},
                       {debug_abort_on_error,
                           [76,111,99,107,105,110,103,32,111,102,32,103,105,
                            116,32,100,101,112,101,110,100,101,110,99,121,32,
                            102,97,105,108,101,100,32,105,110,32,
                            "/home/...../_build/default/lib/recon"]}]
```

The PR is to make it human readible and result in the following. 

`"Locking of git dependency failed in /home/..../_build/default/lib/bear"
`