### PR TITLE
Debug log update

### DIFF
--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -17,7 +17,7 @@
 lock(AppDir, {git, Url, _}) ->
     lock(AppDir, {git, Url});
 lock(AppDir, {git, Url}) ->
-    AbortMsg = io_lib:format("Locking of git dependency failed in ~s", [AppDir]),
+    AbortMsg = lists:flatten(io_lib:format("Locking of git dependency failed in ~s", [AppDir])),
     Dir = rebar_utils:escape_double_quotes(AppDir),
     {ok, VsnString} =
         case os:type() of


### PR DESCRIPTION
sry for opening the same PR twice couldn't figure out how to rebase; I think I went too far to fix/didn't understand how to do it. (Still learning git)

Debug log(s) was showing the following: 

```
===> 	opts: [{use_stdout,false},
                       {debug_abort_on_error,
                           [76,111,99,107,105,110,103,32,111,102,32,103,105,
                            116,32,100,101,112,101,110,100,101,110,99,121,32,
                            102,97,105,108,101,100,32,105,110,32,
                            "/home/...../_build/default/lib/recon"]}]
```

The PR is to make it human readible and result in the following. 

`"Locking of git dependency failed in /home/..../_build/default/lib/bear"
`