### PR TITLE
Handle control sequences in formatted errors

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -276,11 +276,11 @@ handle_error({error, {Module, Reason}}) ->
             ?DEBUG("Uncaught error: ~p ~p", [Module, Reason]),
             ?INFO("When submitting a bug report, please include the output of `rebar3 report \"your command\"`", []);
         _ ->
-            ?ERROR(Module:format_error(Reason), [])
+            ?ERROR("~s", [Module:format_error(Reason)])
     end,
     erlang:halt(1);
 handle_error({error, Error}) when is_list(Error) ->
-    ?ERROR(Error, []),
+    ?ERROR("~s", [Error]),
     erlang:halt(1);
 handle_error(Error) ->
     %% Nothing should percolate up from rebar_core;


### PR DESCRIPTION
Formatted errors can accidentally contain substrings which are control
sequences for io:format/2. This is a naive attempt to handle such cases.

One example is running xref on the following module
(assuming module m does not exist)

```
-module(handle_error).

-export([f/0]).

f() -> m:'bobby~stables'().
```

```
$ rebar3 xref
===> Verifying dependencies...
===> Compiling myapp
===> Running cross reference analysis...
escript: exception error: bad argument
  in function  io:format/3
     called as io:format(<0.23.0>,
                         "\e[0;31m===> \e[1mWarning: handle_error:f/0 is unused export (Xref)\nWarning: handle_error:f/0 calls undefined function m:bobby~stables/0 (Xref)\n\n\e[0m\e[0m",
                         [])
  in call from rebar3:handle_error/1 (/Users/gomoripeti/git/rebar3/_build/default/lib/rebar/src/rebar3.erl, line 279)
```