### PR TITLE
Change the vertical bar to | for compatibility

### DIFF
--- a/src/rebar_prv_deps_tree.erl
+++ b/src/rebar_prv_deps_tree.erl
@@ -70,7 +70,7 @@ print_children(Prefix, [{Name, Vsn, Source} | Rest], Dict, Verbose) ->
                       [Prefix, "   "];
                   _ ->
                       io:format("~ts~ts", [Prefix, <<226,148,156,226,148,128,32>>]), %Binary for ├─ utf8%
-                      [Prefix, "│  "]
+                      [Prefix, "|  "]
               end,
     io:format("~ts~ts~ts (~ts)~n", [Name, <<226,148,128>>, Vsn, type(Source, Verbose)]), %Binary for ─ utf8%
     case dict:find(Name, Dict) of


### PR DESCRIPTION
It's not as pretty since | doesn't cover the inter-line space as well as│( | vs.│, or `|` vs `│`), but this should work everywhere and show up the same in most monospace fonts?

Attempt at fixing #1140 