### PR TITLE
Compiler source paths in output are now relative

### DIFF
--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -153,12 +153,12 @@ format_errors(_MainSource, Extra, Errors) ->
      end
      || {Source, Descs} <- Errors].
 
-format_error(AbsSource, Extra, {{Line, Column}, Mod, Desc}) ->
+format_error(Source, Extra, {{Line, Column}, Mod, Desc}) ->
     ErrorDesc = Mod:format_error(Desc),
-    ?FMT("~s:~w:~w: ~s~s~n", [AbsSource, Line, Column, Extra, ErrorDesc]);
-format_error(AbsSource, Extra, {Line, Mod, Desc}) ->
+    ?FMT("~s:~w:~w: ~s~s~n", [Source, Line, Column, Extra, ErrorDesc]);
+format_error(Source, Extra, {Line, Mod, Desc}) ->
     ErrorDesc = Mod:format_error(Desc),
-    ?FMT("~s:~w: ~s~s~n", [AbsSource, Line, Extra, ErrorDesc]);
-format_error(AbsSource, Extra, {Mod, Desc}) ->
+    ?FMT("~s:~w: ~s~s~n", [Source, Line, Extra, ErrorDesc]);
+format_error(Source, Extra, {Mod, Desc}) ->
     ErrorDesc = Mod:format_error(Desc),
-    ?FMT("~s: ~s~s~n", [AbsSource, Extra, ErrorDesc]).
+    ?FMT("~s: ~s~s~n", [Source, Extra, ErrorDesc]).

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -54,8 +54,8 @@
 -define(DEFAULT_OUTDIR, "ebin").
 -define(RE_PREFIX, "^[^._]").
 
--type compiler_source_format() :: absolute | relative | unchanged.
--define(DEFAULT_COMPILER_SOURCE_FORMAT, unchanged).
+-type compiler_source_format() :: absolute | relative | build.
+-define(DEFAULT_COMPILER_SOURCE_FORMAT, build).
 
 %% ===================================================================
 %% Public API
@@ -522,7 +522,7 @@ source_format(Opts) ->
                         ?DEFAULT_COMPILER_SOURCE_FORMAT) of
         V when V == absolute;
                V == relative;
-               V == unchanged -> V;
+               V == build -> V;
         Other ->
             ?WARN("Invalid argument ~p for compiler_source_format - "
                   "assuming ~s~n", [Other, ?DEFAULT_COMPILER_SOURCE_FORMAT]),
@@ -542,7 +542,7 @@ format_error_source(Src, absolute, _Cwd) ->
     resolve_linked_source(Src);
 format_error_source(Src, relative, Cwd) ->
     rebar_dir:make_relative_path(resolve_linked_source(Src), Cwd);
-format_error_source(Src, unchanged, _Cwd) ->
+format_error_source(Src, build, _Cwd) ->
     Src.
 
 resolve_linked_source(Src) ->

--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -39,7 +39,9 @@
          reset_dir/1,
          touch/1,
          path_from_ancestor/2,
-         canonical_path/1]).
+         canonical_path/1,
+         resolve_link/1,
+         split_dirname/1]).
 
 -include("rebar.hrl").
 
@@ -272,6 +274,22 @@ canonical_path(Acc, ["."|Rest])       -> canonical_path(Acc, Rest);
 canonical_path([_|Acc], [".."|Rest])  -> canonical_path(Acc, Rest);
 canonical_path([], [".."|Rest])       -> canonical_path([], Rest);
 canonical_path(Acc, [Component|Rest]) -> canonical_path([Component|Acc], Rest).
+
+%% returns canonical target of path if path is a link, otherwise returns path
+-spec resolve_link(string()) -> string().
+
+resolve_link(Path) ->
+    case file:read_link(Path) of
+        {ok, Target} ->
+            canonical_path(filename:absname(Target, filename:dirname(Path)));
+        {error, _} -> Path
+    end.
+
+%% splits a path into dirname and basename
+-spec split_dirname(string()) -> {string(), string()}.
+
+split_dirname(Path) ->
+    {filename:dirname(Path), filename:basename(Path)}.
 
 %% ===================================================================
 %% Internal functions

--- a/test/rebar_file_utils_SUITE.erl
+++ b/test/rebar_file_utils_SUITE.erl
@@ -24,6 +24,7 @@
 all() ->
     [{group, tmpdir},
      {group, reset_dir},
+     path_from_ancestor,
      canonical_path,
      resolve_link,
      split_dirname].


### PR DESCRIPTION
Supercedes https://github.com/erlang/rebar3/pull/1174 with the fixes on config name.