### PR TITLE
normalize include dirs to absolute paths during compilation

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -200,7 +200,7 @@ compile_dirs(RebarOpts, BaseDir, SrcDirs, OutDir, Opts) ->
     ok = filelib:ensure_dir(filename:join(OutDir, "dummy.beam")),
     true = code:add_patha(filename:absname(OutDir)),
 
-    G = init_erlcinfo(proplists:get_all_values(i, ErlOpts), AllErlFiles, BaseDir, OutDir),
+    G = init_erlcinfo(include_abs_dirs(ErlOpts, BaseDir), AllErlFiles, BaseDir, OutDir),
 
     NeededErlFiles = needed_files(G, ErlOpts, BaseDir, OutDir, AllErlFiles),
     {ErlFirstFiles, ErlOptsFirst} = erl_first_files(RebarOpts, ErlOpts, BaseDir, NeededErlFiles),
@@ -387,7 +387,7 @@ maybe_rm_beams_and_edges(G, Dir, Files) ->
 
 source_and_include_dirs(InclDirs, Erls) ->
     SourceDirs = lists:map(fun filename:dirname/1, Erls),
-    lists:usort(["include" | InclDirs ++ SourceDirs]).
+    lists:usort(InclDirs ++ SourceDirs).
 
 update_erlcinfo(G, Dirs, Source) ->
     case digraph:vertex(G, Source) of
@@ -502,7 +502,6 @@ expand_file_names(Files, Dirs) ->
                         end, Dirs)
               end
       end, Files).
-
 
 -spec internal_erl_compile(rebar_dict(), file:filename(), file:filename(),
     file:filename(), list()) -> ok | {ok, any()} | {error, any(), any()}.
@@ -737,6 +736,10 @@ check_file(File) ->
 outdir(RebarOpts) ->
     ErlOpts = rebar_opts:erl_opts(RebarOpts),
     proplists:get_value(outdir, ErlOpts, ?DEFAULT_OUTDIR).
+
+include_abs_dirs(ErlOpts, BaseDir) ->
+    InclDirs = ["include"|proplists:get_all_values(i, ErlOpts)],
+    lists:map(fun(Incl) -> filename:join([BaseDir, Incl]) end, InclDirs).
 
 parse_opts(Opts) -> parse_opts(Opts, #compile_opts{}).
 

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -23,6 +23,7 @@
          paths_extra_dirs_in_project_root/1,
          clean_extra_dirs_in_project_root/1,
          recompile_when_hrl_changes/1,
+         recompile_when_included_hrl_changes/1,
          recompile_when_opts_change/1,
          dont_recompile_when_opts_dont_change/1,
          dont_recompile_yrl_or_xrl/1,
@@ -56,7 +57,8 @@ all() ->
      {group, basic_srcdirs}, {group, release_srcdirs}, {group, unbalanced_srcdirs},
      {group, basic_extras}, {group, release_extras}, {group, unbalanced_extras},
      {group, root_extras},
-     recompile_when_hrl_changes, recompile_when_opts_change,
+     recompile_when_hrl_changes, recompile_when_included_hrl_changes,
+     recompile_when_opts_change,
      dont_recompile_when_opts_dont_change, dont_recompile_yrl_or_xrl,
      delete_beam_if_source_deleted,
      deps_in_path, checkout_priority, highest_version_of_pkg_dep,
@@ -647,7 +649,6 @@ recompile_when_hrl_changes(Config) ->
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
-
     ExtraSrc = <<"-module(test_header_include).\n"
                   "-export([main/0]).\n"
                   "-include(\"test_header_include.hrl\").\n"
@@ -665,10 +666,48 @@ recompile_when_hrl_changes(Config) ->
     ModTime = [filelib:last_modified(filename:join([EbinDir, F]))
                || F <- Files, filename:extension(F) == ".beam"],
 
+    timer:sleep(1000),
+
+    NewExtraHeader = <<"-define(SOME_DEFINE, false).\n">>,
+    ok = file:write_file(HeaderFile, NewExtraHeader),
+
+    rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name}]}),
+
+    {ok, NewFiles} = rebar_utils:list_dir(EbinDir),
+    NewModTime = [filelib:last_modified(filename:join([EbinDir, F]))
+                  || F <- NewFiles, filename:extension(F) == ".beam"],
+
+    ?assert(ModTime =/= NewModTime).
+
+recompile_when_included_hrl_changes(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    ExtraSrc = <<"-module(test_header_include).\n"
+                  "-export([main/0]).\n"
+                  "-include(\"test_header_include.hrl\").\n"
+                  "main() -> ?SOME_DEFINE.\n">>,
+
+    ExtraHeader = <<"-define(SOME_DEFINE, true).\n">>,
+    ok = filelib:ensure_dir(filename:join([AppDir, "include", "dummy"])),
+    HeaderFile = filename:join([AppDir, "include", "test_header_include.hrl"]),
+    ok = file:write_file(filename:join([AppDir, "src", "test_header_include.erl"]), ExtraSrc),
+    ok = file:write_file(HeaderFile, ExtraHeader),
+
+    rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name}]}),
+
+    EbinDir = filename:join([AppDir, "_build", "default", "lib", Name, "ebin"]),
+    {ok, Files} = rebar_utils:list_dir(EbinDir),
+    ModTime = [filelib:last_modified(filename:join([EbinDir, F]))
+               || F <- Files, filename:extension(F) == ".beam"],
 
     timer:sleep(1000),
 
-    rebar_file_utils:touch(HeaderFile),
+    NewExtraHeader = <<"-define(SOME_DEFINE, false).\n">>,
+    ok = file:write_file(HeaderFile, NewExtraHeader),
 
     rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name}]}),
 


### PR DESCRIPTION
changed include files were not properly picked up by `erlc_compiler`
in cases where they were in directories relative to the application
source and not the current working dir of rebar3

fixes #1199