### PR TITLE
ignore return value of `rebar_utils:reread_config` in shell provider

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -332,7 +332,8 @@ reread_config(State) ->
         no_config ->
             ok;
         ConfigList ->
-            rebar_utils:reread_config(ConfigList)
+            _ = rebar_utils:reread_config(ConfigList),
+            ok
     end.
 
 boot_apps(Apps) ->


### PR DESCRIPTION
i think this is correct, but i didn't think too hard about it. it fixes this tho:

```erlang
Eshell V7.3  (abort with ^G)
1> ===> No script_file specified.
===> Found shell apps from relx.
===> Found config from relx.
===> Loading configuration from "/Users/talentdeficit/dev/erlang/myapp/config/sys.config"
===> Uncaught error in rebar_core. Run with DEBUG=1 to see stacktrace or consult rebar3.crashdump
===> Uncaught error: {badmatch,[]}
===> Stack trace to the error location: [{rebar_prv_shell,
                                                 maybe_boot_apps,1,
                                                 [{file,
                                                   "/Users/talentdeficit/dev/erlang/rebar3/_build/default/lib/rebar/src/rebar_prv_shell.erl"},
                                                  {line,268}]},
                                                {rebar_prv_shell,shell,1,
                                                 [{file,
                                                   "/Users/talentdeficit/dev/erlang/rebar3/_build/default/lib/rebar/src/rebar_prv_shell.erl"},
                                                  {line,107}]},
                                                {rebar_prv_shell,do,1,
                                                 [{file,
                                                   "/Users/talentdeficit/dev/erlang/rebar3/_build/default/lib/rebar/src/rebar_prv_shell.erl"},
                                                  {line,85}]},
                                                {rebar_core,do,2,
                                                 [{file,
                                                   "/Users/talentdeficit/dev/erlang/rebar3/_build/default/lib/rebar/src/rebar_core.erl"},
                                                  {line,125}]},
                                                {rebar3,main,1,
                                                 [{file,
                                                   "/Users/talentdeficit/dev/erlang/rebar3/_build/default/lib/rebar/src/rebar3.erl"},
                                                  {line,56}]},
                                                {escript,run,2,
                                                 [{file,"escript.erl"},
                                                  {line,757}]},
                                                {escript,start,1,
                                                 [{file,"escript.erl"},
                                                  {line,277}]},
                                                {init,start_it,1,[]}]
===> When submitting a bug report, please include the output of `rebar3 report "your command"`
```