### PR TITLE
Add support for cover_excl_mods

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -57,6 +57,9 @@
 %% is `false'
 {cover_enabled, false}.
 
+%% Modules to exclude from cover
+{cover_excl_mods, []}.
+
 %% Options to pass to cover provider
 {cover_opts, [verbose]}.
 


### PR DESCRIPTION
Add config option to ignore certain modules from the cover.

```erlang
{cover_excl_mods, [
  statsderl_profile,
  statsderl_tests,
  statsderl_utils_tests
]}.
```

If I add tests, would this be accepted?
