### PR TITLE
Let DEBUG="" and QUIET="" mean disable the option

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -221,10 +221,10 @@ set_options(State, {Options, NonOptArgs}) ->
 %%
 log_level() ->
     case os:getenv("QUIET") of
-        false ->
+        Q when Q == false; Q == "" ->
             DefaultLevel = rebar_log:default_level(),
             case os:getenv("DEBUG") of
-                false ->
+                D when D == false; D == "" ->
                     DefaultLevel;
                 _ ->
                     DefaultLevel + 3


### PR DESCRIPTION
Setting DEBUG/QUIET environment variable to the empty string now acts
the same as unsetting it. Unsetting is not always easy/possible.

Slight backwards incompatibility here, but the previous behavior wasn't
"principle of least surprise".