### PR TITLE
Fix unicode rendering of deps tree (issue #1140)

### DIFF
--- a/src/rebar_prv_deps_tree.erl
+++ b/src/rebar_prv_deps_tree.erl
@@ -70,7 +70,7 @@ print_children(Prefix, [{Name, Vsn, Source} | Rest], Dict, Verbose) ->
                       [Prefix, "   "];
                   _ ->
                       io:format("~ts~ts", [Prefix, <<226,148,156,226,148,128,32>>]), %Binary for ├─ utf8%
-                      [Prefix, "│  "]
+                      [Prefix, <<226,148,130,32,32>>] %Binary for │  utf8%
               end,
     io:format("~ts~ts~ts (~ts)~n", [Name, <<226,148,128>>, Vsn, type(Source, Verbose)]), %Binary for ─ utf8%
     case dict:find(Name, Dict) of


### PR DESCRIPTION
As I mentioned back here https://github.com/erlang/rebar3/pull/867#issuecomment-147767501 ,
"the unicode vertical box-drawing character on line 73 needs the same treatment".
This fixes the issue (#1140).