### PR TITLE
Fixes for windows environment: 1) copy empty directories when cloning…

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -177,11 +177,11 @@ mv(Source, Dest) ->
         {win32, _} ->
             Cmd = case filelib:is_dir(Source) of
                       true ->
-                          ?FMT("robocopy /move /s \"~s\" \"~s\" 1> nul",
+                          ?FMT("robocopy /move /e \"~s\" \"~s\" 1> nul",
                                [rebar_utils:escape_double_quotes(filename:nativename(Source)),
                                 rebar_utils:escape_double_quotes(filename:nativename(Dest))]);
                       false ->
-                          ?FMT("robocopy /move /s \"~s\" \"~s\" \"~s\" 1> nul",
+                          ?FMT("robocopy /move /e \"~s\" \"~s\" \"~s\" 1> nul",
                                [rebar_utils:escape_double_quotes(filename:nativename(filename:dirname(Source))),
                                 rebar_utils:escape_double_quotes(filename:nativename(Dest)),
                                 rebar_utils:escape_double_quotes(filename:basename(Source))])

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -22,7 +22,7 @@ lock(AppDir, {git, Url}) ->
     {ok, VsnString} =
         case os:type() of
             {win32, _} ->
-                rebar_utils:sh("git rev-parse --git-dir=\"" ++ Dir ++ "/.git\" --work-tree=\"" ++ Dir ++ "\" --verify HEAD",
+                rebar_utils:sh("git --git-dir=\"" ++ Dir ++ "/.git\" --work-tree=\"" ++ Dir ++ "\" rev-parse --verify HEAD",
                     [{use_stdout, false}, {debug_abort_on_error, AbortMsg}]);
             _ ->
                 rebar_utils:sh("git --git-dir=\"" ++ Dir ++ "/.git\" rev-parse --verify HEAD",


### PR DESCRIPTION
… (since git occasionally has a refs directory with no files in it - if the directory is not present, then git does not believe it is a git repo) and 2) change order of git rev-parse arguments to match git docs