### PR TITLE
Handle empty PLT or app when using dialyzer

### DIFF
--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -380,12 +380,15 @@ succ_typings(State, Plt, Output) ->
             {0, State};
         _ ->
             Apps = rebar_state:project_apps(State),
-            succ_typings(State, Plt, Output, Apps)
+            ?INFO("Doing success typing analysis...", []),
+            Files = apps_to_files(Apps),
+            succ_typings(State, Plt, Output, Files)
     end.
 
-succ_typings(State, Plt, Output, Apps) ->
-    ?INFO("Doing success typing analysis...", []),
-    Files = apps_to_files(Apps),
+succ_typings(State, Plt, _, []) ->
+    ?INFO("Analyzing no files with ~p...", [Plt]),
+    {0, State};
+succ_typings(State, Plt, Output, Files) ->
     ?INFO("Analyzing ~b files with ~p...", [length(Files), Plt]),
     Opts = [{analysis_type, succ_typings},
             {get_warnings, true},

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -353,8 +353,19 @@ update_base_plt(State, BasePlt, Output, BaseFiles) ->
             build_plt(State, BasePlt, Output, BaseFiles)
     end.
 
+build_plt(State, Plt, _, []) ->
+    ?INFO("Building with no files in ~p...", [Plt]),
+    Opts = [{get_warnings, false},
+            {output_plt, Plt},
+            {apps, [erts]}],
+    % Create a PLT with erts files and then remove erts files to be left with an
+    % empty PLT. Dialyzer will crash when trying to build a PLT with an empty
+    % file list.
+    _ = dialyzer:run([{analysis_type, plt_build} | Opts]),
+    _ = dialyzer:run([{analysis_type, plt_remove}, {init_plt, Plt} | Opts]),
+    {0, State};
 build_plt(State, Plt, Output, Files) ->
-    ?INFO("Adding ~b files to ~p...", [length(Files), Plt]),
+    ?INFO("Building with ~b files in ~p...", [length(Files), Plt]),
     GetWarnings = get_config(State, get_warnings, false),
     Opts = [{analysis_type, plt_build},
             {get_warnings, GetWarnings},

--- a/test/rebar_dialyzer_SUITE.erl
+++ b/test/rebar_dialyzer_SUITE.erl
@@ -10,6 +10,7 @@
          groups/0,
          empty_base_plt/1,
          empty_app_plt/1,
+         empty_app_succ_typings/1,
          update_base_plt/1,
          update_app_plt/1,
          build_release_plt/1,
@@ -55,7 +56,7 @@ all() ->
     [{group, empty}, {group, build_and_check}, {group, update}].
 
 groups() ->
-    [{empty, [empty_base_plt, empty_app_plt]},
+    [{empty, [empty_base_plt, empty_app_plt, empty_app_succ_typings]},
      {build_and_check, [build_release_plt, plt_apps_option]},
      {update, [update_base_plt, update_app_plt]}].
 
@@ -99,6 +100,19 @@ empty_app_plt(Config) ->
 
     {ok, PltFiles} = plt_files(Plt),
     ?assertEqual([], PltFiles),
+
+    ok.
+
+empty_app_succ_typings(Config) ->
+    AppDir = ?config(apps, Config),
+    RebarConfig = ?config(rebar_config, Config),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_empty_app(AppDir, Name, Vsn, []),
+
+    rebar_test_utils:run_and_check(Config, RebarConfig, ["dialyzer"],
+                                   {ok, [{app, Name}]}),
 
     ok.
 


### PR DESCRIPTION
Handle the situation where we build an empty PLT or try to analyse an empty app. Either of these might be a fix for #1261.

I also reworded the building message so it is possible to tell the difference between building and adding.