### PR TITLE
fix catching  `not_valid` error on dialyzer

### DIFF
--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -261,8 +261,7 @@ read_plt(_State, Plt) ->
         {error, no_such_file} ->
             error;
         {error, not_valid} ->
-            Error = io_lib:format("Could not read the PLT file ~p", [Plt]),
-            throw({dialyzer_error, Error});
+            error;
         {error, read_error} ->
             Error = io_lib:format("Could not read the PLT file ~p", [Plt]),
             throw({dialyzer_error, Error})

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -260,6 +260,9 @@ read_plt(_State, Plt) ->
             Result;
         {error, no_such_file} ->
             error;
+        {error, not_valid} ->
+            Error = io_lib:format("Could not read the PLT file ~p", [Plt]),
+            throw({dialyzer_error, Error});
         {error, read_error} ->
             Error = io_lib:format("Could not read the PLT file ~p", [Plt]),
             throw({dialyzer_error, Error})


### PR DESCRIPTION
**VERSION**
```
$> ./rebar3 version
rebar 3.2.0 on Erlang/OTP 18 Erts 7.3.1
```

**WHY**
when running `DEBUG=1  rebar3 dialyzer`, I got following error:
```
...
===> Uncaught error in rebar_core. Run with DEBUG=1 to see stacktrace or consult rebar3.crashdump
===> Uncaught error: {case_clause,{error,not_valid}}
===> Stack trace to the error location: [{rebar_prv_dialyzer,read_plt,
                                                 2,
                                                 [{file,
                                                   "/home/gbour/DEVEL/erlang-rebar3/_build/default/lib/rebar/src/rebar_prv_dialyzer.erl"},
                                                  {line,253}]},
                                                {rebar_prv_dialyzer,
                                                 update_base_plt,4,
                                                 [{file,
                                                   "/home/gbour/DEVEL/erlang-rebar3/_build/default/lib/rebar/src/rebar_prv_dialyzer.erl"},
                                                  {line,364}]},
...
```

the reason was $HOME/.cache/rebar3/rebar3_18.3.4.1_plt was empty.
`dialyzer:plt_info()` is returning  **{error, not_valid}** tuple, which is not catched by rebar_prv_dialyzer:read_plt() function

**HOW**
this patch is simply catching previous error in read_plt() case matchlist, raising same exception as *read_error*

**RESULT**
```
$ ./rebar3 dialyzer
===> Verifying dependencies...
===> Compiling rebar
===> Dialyzer starting, this may take a while...
===> Updating plt...
===> Resolving files...
===> Updating base plt...
===> Resolving files...
===> Error in dialyzing apps: Could not read the PLT file "/home/gbour/.cache/rebar3/rebar3_18.3.4.1_plt"
```