### PR TITLE
Fix opts check when compiler called with dict opts

### DIFF
--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -155,7 +155,13 @@ format_warnings(Source, Warnings) ->
     format_warnings(Source, Warnings, []).
 
 format_warnings(Source, Warnings, Opts) ->
-    Prefix = case lists:member(warnings_as_errors, Opts) of
+    %% `Opts' can be passed in both as a list or a dictionary depending
+    %% on whether the first call to rebar_erlc_compiler was done with
+    %% the type `rebar_dict()' or `rebar_state:t()'.
+    LookupFn = if is_list(Opts) -> fun lists:member/2
+                ; true          -> fun dict:is_key/2
+               end,
+    Prefix = case LookupFn(warnings_as_errors, Opts) of
                  true -> "";
                  false -> "Warning: "
              end,


### PR DESCRIPTION
rebar_base_compiler allows to be called with two types of options: a
dictionary, or a rebar_state record. In the later case, the options are
taken out with a call from rebar_opts, which fetches options that have
been inserted in the application via rebar_app_info as part of the
app_discovery phase, and are a list.

This yields a possibility that options used when formatting warnings can
either be a list of a dict, and we only used lists when making checks.
This ended up breaking 3rd party compiler users (i.e. LFE compile
plugin) since they were calling us with a dict rather than our own
internal records.

This patch supports both types of lookups to avoid issues.