### PR TITLE
Handle `escriptize` when the specified app is missing

### DIFF
--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -72,8 +72,12 @@ do(State) ->
             end;
         Name ->
             AllApps = rebar_state:all_deps(State)++rebar_state:project_apps(State),
-            {ok, AppInfo} = rebar_app_utils:find(ec_cnv:to_binary(Name), AllApps),
-            escriptize(State, AppInfo)
+            case rebar_app_utils:find(ec_cnv:to_binary(Name), AllApps) of
+                {ok, AppInfo} ->
+                    escriptize(State, AppInfo);
+                _ ->
+                    ?PRV_ERROR({bad_name, Name})
+            end
     end.
 
 escriptize(State0, App) ->

--- a/test/rebar_escriptize_SUITE.erl
+++ b/test/rebar_escriptize_SUITE.erl
@@ -5,6 +5,8 @@
          end_per_suite/1,
          init_per_testcase/2,
          all/0,
+         escriptize_with_name/1,
+         escriptize_with_bad_name/1,
          build_and_clean_app/1]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -24,7 +26,11 @@ init_per_testcase(_, Config) ->
     rebar_test_utils:init_rebar_state(Config).
 
 all() ->
-    [build_and_clean_app].
+    [
+     build_and_clean_app,
+     escriptize_with_name,
+     escriptize_with_bad_name
+    ].
 
 %% Test escriptize builds and runs the app's escript
 build_and_clean_app(Config) ->
@@ -35,3 +41,21 @@ build_and_clean_app(Config) ->
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
     rebar_test_utils:run_and_check(Config, [], ["escriptize"],
                                    {ok, [{app, Name, valid}]}).
+
+escriptize_with_name(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    rebar_test_utils:run_and_check(Config, [{escript_main_app, Name}], ["escriptize"],
+                                   {ok, [{app, Name, valid}]}).
+
+escriptize_with_bad_name(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    rebar_test_utils:run_and_check(Config, [{escript_main_app, boogers}], ["escriptize"],
+                                   {error,{rebar_prv_escriptize, {bad_name, boogers}}}).


### PR DESCRIPTION
When rebar.config contains a `escript_main_app` option, but the specified app doesn't exist in the build directory, print an error instead of crashing.

I reused the `bad_name` error, but I'm not sure if that's good or if it would be better to make a new error.

Also adds a pair of tests for the `escript_main_app` option.