### PR TITLE
Fix filtering of system libraries in escriptize

### DIFF
--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -232,7 +232,9 @@ find_deps_of_deps([Name|Names], Apps, Acc) ->
     DepNames = proplists:get_value(applications, rebar_app_info:app_details(App), []),
     BinDepNames = [ec_cnv:to_binary(Dep) || Dep <- DepNames,
                    %% ignore system libs; shouldn't include them.
-                   not lists:prefix(code:root_dir(), code:lib_dir(Dep))]
+                   DepDir <- [code:lib_dir(Dep)],
+                   DepDir =:= {error, bad_name} orelse % those are all local
+                   not lists:prefix(code:root_dir(), DepDir)]
                 -- ([Name|Names]++Acc), % avoid already seen deps
     ?DEBUG("new deps of ~p found to be ~p", [Name, BinDepNames]),
     find_deps_of_deps(BinDepNames ++ Names, Apps, BinDepNames ++ Acc).


### PR DESCRIPTION
https://github.com/erlang/rebar3/pull/1249 introduced a mechanism by
which escript dependencies of applications only would be included; this
required adding a filter to skip system libraries in the OTP root
because that tends to break escripts in very nasty ways.

However, the problem came that some libraries are just not in the
escript path but may still be included; for these libraries the path
prefix check failed as they return `{error, bad_name}` from
`code:lib_dir(Dep)` rather than just the path they're in --
specifically, this happens with top level apps.

The issue was reported in https://github.com/erlang/rebar3/issues/1294
and the current patch fixes it by accepting a `bad_name` dep as valid,
since it is obviously not in the root path.