### PR TITLE
Print error on too many help arguments

### DIFF
--- a/src/rebar_prv_help.erl
+++ b/src/rebar_prv_help.erl
@@ -41,7 +41,10 @@ do(State) ->
         [Name] -> % default namespace
             task_help(default, list_to_atom(Name), State);
         [Namespace, Name] ->
-            task_help(list_to_atom(Namespace), list_to_atom(Name), State)
+            task_help(list_to_atom(Namespace), list_to_atom(Name), State);
+        _ ->
+            {error, "Too many arguments given. " ++
+                 "Usage: rebar3 help [<namespace>] <task>"}
     end.
 
 -spec format_error(any()) -> iolist().


### PR DESCRIPTION
Previously the help task would crash when given more than two
arguments. After this change it instead print a message:

    Too many arguments given. Usage: rebar3 help [<namespace>] <task>