### PR TITLE
Equivalent trim_all in bin split for <17.x

### DIFF
--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -182,7 +182,7 @@ update_source(AppInfo, {pkg, PkgName, PkgVsn, Hash}, State) ->
                               undefined ->
                                   get_package(PkgName, "0", State);
                               <<"~>", Vsn/binary>> ->
-                                  [Vsn1] = binary:split(Vsn, [<<" ">>], [trim_all, global]),
+                                  [Vsn1] = [X || X <- binary:split(Vsn, [<<" ">>], [global]), X =/= <<>>],
                                   get_package(PkgName, Vsn1, State);
                               _ ->
                                   {PkgName, PkgVsn}


### PR DESCRIPTION
The trim_all option used in binary:split/3 is not supported in 17.x.
This patch makes an equivalent operation by eliminating empty split
fragments. From the docs:

    trim
    Removes trailing empty parts of the result (as does trim in
    re:split/3.

    trim_all
    Removes all empty parts of the result.

The new expression is therefore equivalent to the old one, but with the
added benefit of compatibility.

Fixes #1275