### PR TITLE
WIP: Attempt to use atomic code reload for OTP >= 19

### DIFF
--- a/src/rebar_agent.erl
+++ b/src/rebar_agent.erl
@@ -138,6 +138,6 @@ reload_modules(Modules) ->
         false ->
             %% Older versions, use a more ad-hoc mechanism. Specifically has
             %% a harder time dealing with NIFs.
-            [begin code:purge(M), code:delete(M), code:load_file(M) end
+            [begin code:purge(M), code:load_file(M) end
              || M <- Modules]
     end.


### PR DESCRIPTION
This should resolve issues with NIFs and allow less risky reloading
operations with a running program.

This could fix #1304 and #1258 in OTP 19 and later.

@brigadier and @vans163 if you could try this branch with OTP 19 and let me know if it helps your issue, it would be much appreciated.

I don't know if an equally fast solution could be written for older versions.