### PR TITLE
Print stacktrace in a more conventional way

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -292,7 +292,7 @@ handle_error(Error) ->
     case erlang:get_stacktrace() of
         [] -> ok;
         Trace ->
-            ?DEBUG("Stack trace to the error location: ~p", [Trace])
+            ?DEBUG("Stack trace to the error location:~n~p", [Trace])
     end,
     ?INFO("When submitting a bug report, please include the output of `rebar3 report \"your command\"`", []),
     erlang:halt(1).


### PR DESCRIPTION
Insert a newline before printing the stacktrace so that the term is
easier to read and copy. This is a more conventional way to print
traces, and is, for instance, the way it's done by make and python.