### PR TITLE
log error if a module failed to load_file, the user should be aware

### DIFF
--- a/src/rebar_agent.erl
+++ b/src/rebar_agent.erl
@@ -142,7 +142,9 @@ reload_modules(Modules, true) ->
                         on_load_not_allowed ->
                             reload_modules([ModError], false),
                             [ModError|Acc];
-                        _ -> [ModError|Acc]
+                        _ -> 
+                            ?ERROR("Module ~p failed to atomic load because ~p", [ModError, Error]),
+                            [ModError|Acc]
                     end
                 end,
                 [], ModRsns
@@ -152,4 +154,13 @@ reload_modules(Modules, true) ->
 
 %% Older versions, use a more ad-hoc mechanism.
 reload_modules(Modules, false) ->
-    [begin code:delete(M), code:purge(M), code:load_file(M) end || M <- Modules].
+    lists:foreach(fun(M) ->
+            code:delete(M), 
+            code:purge(M), 
+            case code:load_file(M) of
+                {module, M} -> ok;
+                {error, Error} ->
+                    ?ERROR("Module ~p failed to load because ~p", [M, Error])
+            end
+        end, Modules
+    ).

--- a/src/rebar_agent.erl
+++ b/src/rebar_agent.erl
@@ -143,7 +143,7 @@ reload_modules(Modules, true) ->
                             reload_modules([ModError], false),
                             [ModError|Acc];
                         _ -> 
-                            ?ERROR("Module ~p failed to atomic load because ~p", [ModError, Error]),
+                            ?DEBUG("Module ~p failed to atomic load because ~p", [ModError, Error]),
                             [ModError|Acc]
                     end
                 end,
@@ -160,7 +160,7 @@ reload_modules(Modules, false) ->
             case code:load_file(M) of
                 {module, M} -> ok;
                 {error, Error} ->
-                    ?ERROR("Module ~p failed to load because ~p", [M, Error])
+                    ?DEBUG("Module ~p failed to load because ~p", [M, Error])
             end
         end, Modules
     ).


### PR DESCRIPTION
This should log if a module failed to load for whatever reason. 

Pretty important for the user to be aware if this ever happens on compile so they don't pull their hair out trying to figure out whats wrong.

Can someone review this if using ?ERROR macro is correct here?