### PR TITLE
Prevent crashing when `mv` warns and report warnings to the user instead.

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -171,9 +171,14 @@ mv(Source, Dest) ->
         {unix, _} ->
             EscSource = rebar_utils:escape_chars(Source),
             EscDest = rebar_utils:escape_chars(Dest),
-            {ok, []} = rebar_utils:sh(?FMT("mv ~s ~s", [EscSource, EscDest]),
-                                      [{use_stdout, false}, abort_on_error]),
-            ok;
+            case rebar_utils:sh(?FMT("mv ~s ~s", [EscSource, EscDest]),
+                                      [{use_stdout, false}, abort_on_error]) of
+                {ok, []} ->
+                    ok;
+                {ok, Warning} ->
+                    ?WARN("mv: ~p", [Warning]),
+                    ok
+            end;
         {win32, _} ->
             Cmd = case filelib:is_dir(Source) of
                       true ->

--- a/test/rebar_file_utils_SUITE.erl
+++ b/test/rebar_file_utils_SUITE.erl
@@ -14,7 +14,8 @@
          path_from_ancestor/1,
          canonical_path/1,
          resolve_link/1,
-         split_dirname/1]).
+         split_dirname/1,
+         mv_warning_is_ignored/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -27,7 +28,8 @@ all() ->
      path_from_ancestor,
      canonical_path,
      resolve_link,
-     split_dirname].
+     split_dirname,
+     mv_warning_is_ignored].
 
 groups() ->
     [{tmpdir, [], [raw_tmpdir, empty_tmpdir, simple_tmpdir, multi_tmpdir]},
@@ -135,3 +137,9 @@ split_dirname(_Config) ->
     ?assertEqual({".", "foo"}, rebar_file_utils:split_dirname("foo")),
     ?assertEqual({"/foo", "bar"}, rebar_file_utils:split_dirname("/foo/bar")),
     ?assertEqual({"foo", "bar"}, rebar_file_utils:split_dirname("foo/bar")).
+
+mv_warning_is_ignored(_Config) ->
+    meck:new(rebar_utils, [passthrough]),
+    meck:expect(rebar_utils, sh, fun("mv ding dong", _) -> {ok, "Warning"}  end),
+    ok = rebar_file_utils:mv("ding", "dong"),
+    meck:unload(rebar_utils).


### PR DESCRIPTION
Fix #1324.

In some cases, mv will throw a warning, while still moving the files correctly and returning a 0 return code:

"mv: can't preserve ownership of ... Permission denied".