### PR TITLE
compile + cover compile prior to analyzing coverdata

### DIFF
--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -15,7 +15,7 @@
 -include("rebar.hrl").
 
 -define(PROVIDER, cover).
--define(DEPS, [app_discovery]).
+-define(DEPS, [compile]).
 
 %% ===================================================================
 %% Public API
@@ -84,6 +84,11 @@ reset(State) ->
     {ok, State}.
 
 analyze(State) ->
+    %% modules have to be cover compiled in order for
+    %% cover data to be reloaded
+    %% this maybe breaks if modules have been deleted
+    %% since code coverage was collected?
+    ok = cover_compile(State, apps),
     ?INFO("Performing cover analysis...", []),
     %% figure out what coverdata we have
     CoverDir = cover_dir(State),

--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -15,7 +15,7 @@
 -include("rebar.hrl").
 
 -define(PROVIDER, cover).
--define(DEPS, [compile]).
+-define(DEPS, [lock]).
 
 %% ===================================================================
 %% Public API
@@ -84,11 +84,20 @@ reset(State) ->
     {ok, State}.
 
 analyze(State) ->
-    %% modules have to be cover compiled in order for
-    %% cover data to be reloaded
+    %% modules have to be compiled and then cover compiled
+    %% in order for cover data to be reloaded
     %% this maybe breaks if modules have been deleted
     %% since code coverage was collected?
-    ok = cover_compile(State, apps),
+    case rebar_prv_compile:do(State) of
+        %% successfully compiled apps
+        {ok, S} ->
+            ok = cover_compile(S, apps),
+            do_analyze(State);
+        %% this should look like a compiler error, not a cover error
+        Error   -> Error
+    end.
+
+do_analyze(State) ->
     ?INFO("Performing cover analysis...", []),
     %% figure out what coverdata we have
     CoverDir = cover_dir(State),


### PR DESCRIPTION
the `cover` tool relies on having cover compiled versions of the modules to be analyzed in order to generate accurate coverage

fixes #1327