### PR TITLE
When running tests, don't soft purge cover compiled modules

### DIFF
--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -349,6 +349,8 @@ is_ignored(Dir, File, ExclMods) ->
 
 cover_compile_file(FileName) ->
     case catch(cover:compile_beam(FileName)) of
+        {'EXIT', Reason} ->
+            ?WARN("Cover compilation crashed: ~p", [Reason]);
         {error, Reason} ->
             ?WARN("Cover compilation failed: ~p", [Reason]);
         {ok, _} ->

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -717,7 +717,10 @@ update_code(Paths, Opts) ->
                                   code:add_patha(Path),
                                   case lists:member(soft_purge, Opts) of
                                       true  ->
-                                          [begin code:soft_purge(M), code:delete(M) end || M <- Modules];
+                                            %% only soft purge modules that were not
+                                            %% cover compiled, otherwise coverage is lost
+                                          [begin code:soft_purge(M), code:delete(M) end ||
+                                                M <- Modules, cover:is_compiled(M) =:= false];
                                       false ->
                                           [begin code:purge(M), code:delete(M) end || M <- Modules]
                                   end


### PR DESCRIPTION
When running ct tests (over relx for ex.) with coverage enabled
refrain from purging the modules that were just cover
compiled thus crippling the analysis.
