### PR TITLE
Add support for behaviors, and not just behaviours

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -668,6 +668,8 @@ process_attr(include_lib, Form, Includes, Dir) ->
     [FileNode] = erl_syntax:attribute_arguments(Form),
     RawFile = erl_syntax:string_value(FileNode),
     maybe_expand_include_lib_path(RawFile, Dir) ++ Includes;
+process_attr(behavior, Form, Includes, _Dir) ->
+    process_attr(behaviour, Form, Includes, _Dir);
 process_attr(behaviour, Form, Includes, _Dir) ->
     [FileNode] = erl_syntax:attribute_arguments(Form),
     File = module_to_erl(erl_syntax:atom_value(FileNode)),

--- a/src/rebar_prv_xref.erl
+++ b/src/rebar_prv_xref.erl
@@ -165,7 +165,8 @@ keyall(Key, List) ->
     lists:flatmap(fun({K, L}) when Key =:= K -> L; (_) -> [] end, List).
 
 get_behaviour_callbacks(exports_not_used, Attributes) ->
-    [B:behaviour_info(callbacks) || B <- keyall(behaviour, Attributes)];
+    [B:behaviour_info(callbacks) || B <- keyall(behaviour, Attributes) ++
+                                         keyall(behavior, Attributes)];
 get_behaviour_callbacks(_XrefCheck, _Attributes) ->
     [].
 

--- a/test/rebar_xref_SUITE.erl
+++ b/test/rebar_xref_SUITE.erl
@@ -150,7 +150,7 @@ get_module_body(mymod, AppName, IgnoreXref) ->
      ["-ignore_xref([{other2,1},{localfunc2,0},{fdeprecated,0}]).\n"
       || X <- [IgnoreXref], X =:= true],
      "-behaviour(", AppName, "_behaviour1).\n",     % 2 behaviours
-     "-behaviour(", AppName, "_behaviour2).\n",
+     "-behavior(", AppName, "_behaviour2).\n",
      "-deprecated({fdeprecated,0}).\n",      % deprecated function
      "bh1_a(A) -> localfunc1(bh1_a, A).\n", % behaviour functions
      "bh1_b(A) -> localfunc1(bh1_b, A).\n",


### PR DESCRIPTION
At @inaka, sometimes we implement behaviours but sometimes we implement _behaviors_, because we like to live on the edge (o_O).

rebar3 uses behaviours to determine which modules to compile first and it also treats them nicely when running xref. This PR adds support for doing the same things with _behaviors_.