### PR TITLE
Support canary build profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,19 @@ deploy:
       repo: erlang/rebar3
       branch: master
       condition: $TRAVIS_OTP_RELEASE = "R16B03-1"
+
+  - provider: s3
+    region: us-west-2
+    access_key_id: AKIAJAPYAQEFYCYSNL7Q
+    secret_access_key:
+      secure: "BUv2KQABv0Q4e8DAVNBRTc/lXHWt27yCN46Fdgo1IrcSSIiP+hq2yXzQcXLbPwkEu6pxUZQtL3mvKbt6l7uw3wFrcRfFAi1PGTITAW8MTmxtwcZIBcHSk3XOzDbkK+fYYcaddszmt7hDzzEFPtmYXiNgnaMIVeynhQLgcCcIRRQ="
+    skip_cleanup: true
+    local-dir: _build/canary/bin
+    bucket: "rebar3"
+    upload-dir: "canary"
+    acl: public_read
+    on:
+      repo: erlang/rebar3
+      branch: master
+      condition: $TRAVIS_OTP_RELEASE = "R16B03-1" && $TRAVIS_EVENT_TYPE = cron && $TRAVIS_CRON_PROFILE = canary
+

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Nightly compiled version:
 $ wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
 ```
 
+Canary build (using the latest dependencies):
+```bash
+$ wget https://s3.amazonaws.com/rebar3/canary/rebar3 && chmod +x rebar3
+```
+
 From Source (assuming you have a full Erlang install):
 
 ```bash

--- a/bootstrap
+++ b/bootstrap
@@ -31,8 +31,23 @@ main(_) ->
     %% not_purged errors in rebar_erlc_compiler:opts_changed/1
     error_logger:tty(false),
 
+    %% To check whether a build was triggered by cron, examine the TRAVIS_EVENT_TYPE
+    %% environment variable to see if it has the value cron.
+    %% https://docs.travis-ci.com/user/cron-jobs/
+    Profile = case os:getenv("TRAVIS_EVENT_TYPE") of
+                    "cron" ->
+                        %% each Travis cron job can have an env variable
+                        %% specifying the profile to be built, if none defined
+                        %% fallback on default bootstrap profile
+                        case os:getenv("TRAVIS_CRON_PROFILE") of
+                            false -> "bootstrap";
+                            P -> P
+                        end;
+                    _ -> "bootstrap"
+              end,
+
     setup_env(),
-    os:putenv("REBAR_PROFILE", "bootstrap"),
+    os:putenv("REBAR_PROFILE", Profile),
     RegistryFile = default_registry_file(),
     case filelib:is_file(RegistryFile) of
         true ->
@@ -49,14 +64,14 @@ main(_) ->
     code:add_pathsa(DepsPaths),
 
     rebar3:run(["clean", "-a"]),
-    rebar3:run(["escriptize"]),
+    rebar3:run(["as", Profile, "escriptize"]),
 
     %% Done with compile, can turn back on error logger
     error_logger:tty(true),
 
     %% Finally, update executable perms for our script on *nix,
     %%  or write out script files on win32.
-    ec_file:copy("_build/default/bin/rebar3", "./rebar3"),
+    ec_file:copy(filename:join(["_build", Profile, "bin", "rebar3"]), "./rebar3"),
     case os:type() of
         {unix,_} ->
             [] = os:cmd("chmod u+x rebar3"),

--- a/rebar.config
+++ b/rebar.config
@@ -40,6 +40,17 @@
 
             {bootstrap, []},
 
+            {canary, [
+              {deps, [
+                {relx, {git, "https://github.com/erlware/relx.git",
+                            {branch, "master"}}}
+              ]},
+              %% since relx is now located beneath the canary profile
+              %% we need to override this directive so it fetches the templates from
+              %% the right place
+              {escript_incl_extra, [{"relx/priv/templates/*", "_build/canary/lib/"}]}
+            ]},
+
             {dialyze, [{overrides, [{add, erlware_commons, [{erl_opts, [debug_info]}]},
                                     {add, ssl_verify_fun, [{erl_opts, [debug_info]}]},
                                     {add, certifi, [{erl_opts, [debug_info]}]},

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -179,6 +179,7 @@ get_app_beams(App, Path) ->
 
 get_extra(State) ->
     Extra = rebar_state:get(State, escript_incl_extra, []),
+    rebar_api:debug("including escript extra: ~p", [Extra]),
     lists:foldl(fun({Wildcard, Dir}, Files) ->
                         load_files(Wildcard, Dir) ++ Files
                 end, [], Extra).


### PR DESCRIPTION
Together with Travis's cron jobs a canary build of rebar3 can be uploaded to s3, the only dep whose master branch is being used is `relx`, more could be added eventually.
Canary builds are useful to plugin developers who might be interesting in running tests on the latest master (both rebar3's and relx's) thus indirectly also increasing rebar3's test coverage and providing early detection of possible regressions.

Still to do:
- [ ] activate daily Travis cron job on master branch
- [ ] add TRAVIS_CRON_PROFILE=canary on Travis->rebar3->Settings->Environment variable
