### PR TITLE
Fix usage decription of 'rebar3'

### DIFF
--- a/src/rebar_prv_help.erl
+++ b/src/rebar_prv_help.erl
@@ -57,7 +57,7 @@ format_error(Reason) ->
 help(State) ->
     ?CONSOLE("Rebar3 is a tool for working with Erlang projects.~n~n", []),
     OptSpecList = rebar3:global_option_spec_list(),
-    getopt:usage(OptSpecList, "rebar", "", []),
+    getopt:usage(OptSpecList, "rebar3", "", []),
     ?CONSOLE("~nSeveral tasks are available:~n", []),
 
     providers:help(rebar_state:providers(State)),


### PR DESCRIPTION
A very small fix of rebar3 usage description (`rebar` -> `rebar3`):

### Before
```
$ rebar3 help
Rebar3 is a tool for working with Erlang projects.

Usage: rebar [-h] [-v] [<task>]
...
```

### After
```
$ rebar3 help
Rebar3 is a tool for working with Erlang projects.

Usage: rebar3 [-h] [-v] [<task>]
...
```