### PR TITLE
consult_config/2 calls itself, adjust for backwards compatibility change

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -137,3 +137,4 @@ Stefan Grundmann
 Carlos Eduardo de Paula
 Derek Brown
 Heinz N. Gies
+Alexander Sedov

--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -74,10 +74,13 @@ consult_config(State, Filename) ->
     end,
     JoinedConfig = lists:flatmap(
         fun (SubConfig) when is_list(SubConfig) ->
-            case lists:suffix(".config", SubConfig) of
+            %% Backwards compatibility :(
+            [Entries] = case lists:suffix(".config", SubConfig) of
                 false -> consult_config(State, SubConfig ++ ".config");
                 true -> consult_config(State, SubConfig)
-            end;
+            end,
+            Entries;
+
             (Entry) -> [Entry]
       end, Config),
     %% Backwards compatibility


### PR DESCRIPTION
When adding last-minute backwards-compatibility changes, be sure to test them, or you're forced to have an embarassing epiphany a month later.