### PR TITLE
Add 'recursive' option

### DIFF
--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -310,7 +310,7 @@ maybe_inject_test_dir(State, AppAcc, [], Dir) ->
 
 inject_test_dir(Opts, Dir) ->
     %% append specified test targets to app defined `extra_src_dirs`
-    ExtraSrcDirs = rebar_dir:extra_src_dirs(Opts),
+    ExtraSrcDirs = rebar_opts:get(Opts, extra_src_dirs, []),
     rebar_opts:set(Opts, extra_src_dirs, ExtraSrcDirs ++ [Dir]).
 
 compile({error, _} = Error) -> Error;


### PR DESCRIPTION
This pull request adds the option {recursive,boolean()}, indicating whether or not rebar3 should search recursively for source files to compile. The options can be set on two levels:

top level - sets the default for the project: 
` {erlc_compiler,[{recursive,boolean()}]}.`

per source directory:
`{src_dirs,[{"src",[{recursive,boolean()}]}]}.`
`{extra_src_dirs,[{"test",[{recursive,boolean()}]}]}.`

The variants are chosen after the discussion in [issue #1345](https://github.com/erlang/rebar3/issues/1345).

This feature is needed for testing of split-out applications from erlang/OTP, where data dirs (*_SUITE_data) in test contain .erl files that must not be compiled by rebar3. Reasons for this can be

a) the files should not be compiled at all, e.g. because the test suite operates on the .erl files.
b) the files must be compiled with specific options which shall not be applied to other source files (e.g. specific output directories)

For b) we need to let the test suite itself do the compilation. Earlier this was solved with a Makefile and some internal code in our test environment, but we are probably aiming at removing this.