### PR TITLE
Unify different styles of missing_package error

### DIFF
--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -216,7 +216,7 @@ handle_single_vsn(Pkg, PkgVsn, Dep, Vsn, Constraint) ->
             {ok, Vsn}
     end.
 
-format_error({missing_package, {Name, Vsn}}) ->
+format_error({missing_package, Name, Vsn}) ->
     io_lib:format("Package not found in registry: ~s-~s.", [ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)]);
 format_error({missing_package, Dep}) ->
     io_lib:format("Package not found in registry: ~p.", [Dep]).


### PR DESCRIPTION
This is to fix the following bug:
```
$ DEBUG=1 rebar3 upgrade
===> Load global config file /Users/waisbrot/.config/rebar3/rebar.config
===> Expanded command sequence to be run: [{default,app_discovery},
                                                  {default,install_deps},
                                                  {default,lock},
                                                  {default,upgrade}]
===> Evaluating config script "/Users/waisbrot/git/webhooks-hub/_build/default/lib/dogstatsd/rebar.config.script"
===> Evaluating config script "/Users/waisbrot/git/webhooks-hub/_build/default/lib/erlcloud/rebar.config.script"
===> Evaluating config script "/Users/waisbrot/git/webhooks-hub/_build/default/lib/jsx/rebar.config.script"
===> Verifying dependencies...
===> Evaluating config script "/Users/waisbrot/git/webhooks-hub/_build/default/lib/dogstatsd/rebar.config.script"
===> Evaluating config script "/Users/waisbrot/git/webhooks-hub/_build/default/lib/erlcloud/rebar.config.script"
===> Evaluating config script "/Users/waisbrot/git/webhooks-hub/_build/default/lib/jsx/rebar.config.script"
===> Evaluating config script "/Users/waisbrot/git/webhooks-hub/_build/default/lib/eini/rebar.config.script"
===> Evaluating config script "/Users/waisbrot/git/webhooks-hub/_build/default/lib/jsx/rebar.config.script"
===> Evaluating config script "/Users/waisbrot/git/webhooks-hub/_build/default/lib/eini/rebar.config.script"
===> Evaluating config script "/Users/waisbrot/git/webhooks-hub/_build/default/lib/jsx/rebar.config.script"
===> Evaluating config script "/Users/waisbrot/git/webhooks-hub/_build/default/lib/erlcloud/rebar.config.script"
===> Package dogstatsde-0.7.2 not found. Fetching registry updates and trying again...
===> Updating package registry...
===> Fetching registry from "https://repo.hex.pm:443/registry.ets.gz?"
===> Writing registry to /Users/waisbrot/.cache/rebar3/hex/default/registry
===> Generating package index...
===> [cloudi_service_oauth1:1.5.1] Only existing version of cloudi_service_db_riak is 1.3.3 which does not match constraint ~> 1.5.1. Using anyway, but it is not guaranteed to work.
===> Writing index to /Users/waisbrot/.cache/rebar3/hex/default/packages.idx
{"init terminating in do_boot",{function_clause,[{rebar_packages,format_error,[{missing_package,<<"dogstatsde">>,<<"0.7.2">>}],[{file,"/home/tristan/Devel/rebar3/_build/default/lib/rebar/src/rebar_packages.erl"},{line,219}]},{rebar3,handle_error,1,[{file,"/home/tristan/Devel/rebar3/_build/default/lib/rebar/src/rebar3.erl"},{line,280}]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}
init terminating in do_boot ()

Crash dump is being written to: erl_crash.dump...done
```

----

The `missing_package` error appears in three styles:
* `{missing_package, {Name, Vsn}}`
* `{missing_package, Name, Vsn}`
* `{missing_package, Dep}`

The first two styles overlap, and this change selects the first as
the correct style over the second.

**TODO**: Did I pick the correct style, or would `{missing_package, Name, Vsn}` be preferred?