### PR TITLE
add `get-deps` provider

### DIFF
--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -52,6 +52,7 @@
                      rebar_prv_edoc,
                      rebar_prv_escriptize,
                      rebar_prv_eunit,
+                     rebar_prv_get_deps,
                      rebar_prv_help,
                      rebar_prv_install_deps,
                      rebar_prv_local_install,

--- a/src/rebar_prv_get_deps.erl
+++ b/src/rebar_prv_get_deps.erl
@@ -1,0 +1,37 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+-module(rebar_prv_get_deps).
+
+-behaviour(provider).
+
+-export([init/1,
+         do/1,
+         format_error/1]).
+
+-define(PROVIDER, 'get-deps').
+-define(DEPS, [lock]).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([{name, ?PROVIDER},
+                                 {module, ?MODULE},
+                                 {deps, ?DEPS},
+                                 {bare, true},
+                                 {example, "rebar3 get-deps"},
+                                 {short_desc, "Fetch dependencies."},
+                                 {desc, "Fetch project dependencies."},
+                                 {opts, []},
+                                 {profiles, []}]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()}.
+do(State) -> {ok, State}.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).


### PR DESCRIPTION
a no-op provider that depends on lock that is slightly more discoverable and user friendly