### PR TITLE
Improve merge of command line options and config options in CT

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -554,6 +554,7 @@ get_dirs_from_specs(Specs) ->
     end.
 
 get_tests_from_specs(Specs) ->
+    _ = ct_testspec:module_info(), % make sure ct_testspec is loaded
     case erlang:function_exported(ct_testspec,get_tests,1) of
         true ->
             ct_testspec:get_tests(Specs);

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -100,7 +100,9 @@ format_error({badconfig, Msg}) ->
     io_lib:format(Msg, []);
 format_error({multiple_errors, Errors}) ->
     io_lib:format(lists:concat(["Error running tests:"] ++
-                               lists:map(fun(Error) -> "~n  " ++ Error end, Errors)), []).
+                               lists:map(fun(Error) -> "~n  " ++ Error end, Errors)), []);
+format_error({error_reading_testspec, Reason}) ->
+    io_lib:format("Error reading testspec: ~p", [Reason]).
 
 %% ===================================================================
 %% Internal functions
@@ -549,8 +551,8 @@ get_dirs_from_specs(Specs) ->
             RunList = lists:append([R || {_,R,_} <- NodeRunSkipList]),
             DirList = [element(1,R) || R <- RunList],
             {ok,{SpecList,DirList}};
-        Error ->
-            Error
+        {error,Reason} ->
+            {error,{?MODULE,{error_reading_testspec,Reason}}}
     end.
 
 get_tests_from_specs(Specs) ->

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -529,25 +529,12 @@ translate_paths(_State, _Type, [], Acc) -> lists:reverse(Acc);
 translate_paths(State, Type, [{Type, Val}|Rest], Acc) when is_integer(hd(Val)) ->
     %% single file or dir
     translate_paths(State, Type, [{Type, [Val]}|Rest], Acc);
-translate_paths(State, dir, [{dir, Dirs}|Rest], Acc) ->
-    Apps = rebar_state:project_apps(State),
-    New = {dir, lists:map(fun(Dir) -> translate(State, Apps, Dir) end, Dirs)},
-    translate_paths(State, dir, Rest, [New|Acc]);
 translate_paths(State, Type, [{Type, Files}|Rest], Acc) ->
-    %% Type = suites | specs
     Apps = rebar_state:project_apps(State),
-    New = {Type, lists:map(fun(File) -> translate_file(State, Apps, File) end, Files)},
+    New = {Type, lists:map(fun(File) -> translate(State, Apps, File) end, Files)},
     translate_paths(State, Type, Rest, [New|Acc]);
 translate_paths(State, Type, [Test|Rest], Acc) ->
     translate_paths(State, Type, Rest, [Test|Acc]).
-
-translate_file(State, Apps, File) ->
-    Dirname = filename:dirname(File),
-    Basename = filename:basename(File),
-    case Dirname of
-        "." -> File;
-        _   -> filename:join([translate(State, Apps, Dirname), Basename])
-    end.
 
 translate(State, [App|Rest], Path) ->
     case rebar_file_utils:path_from_ancestor(Path, rebar_app_info:dir(App)) of

--- a/test/rebar_ct_SUITE.erl
+++ b/test/rebar_ct_SUITE.erl
@@ -693,7 +693,33 @@ suite_at_root(Config) ->
     true = filelib:is_dir(DataDir),
 
     DataFile = filename:join([AppDir, "_build", "test", "extras", "root_SUITE_data", "some_data.txt"]),
-    true = filelib:is_file(DataFile).
+    true = filelib:is_file(DataFile),
+
+    %% Same test again, but using relative path to the suite from the
+    %% project root
+    {ok,Cwd} = file:get_cwd(),
+    ok = file:set_cwd(AppDir),
+    rebar_file_utils:rm_rf("_build"),
+
+    {ok, GetOptResult2} = getopt:parse(GetOptSpec, ["--suite=" ++ "root_SUITE"]),
+
+    State3 = rebar_state:command_parsed_args(State1, GetOptResult2),
+
+    Tests2 = rebar_prv_common_test:prepare_tests(State3),
+    {ok, NewState2} = rebar_prv_common_test:compile(State3, Tests2),
+    {ok, T2} = Tests2,
+    Opts2 = rebar_prv_common_test:translate_paths(NewState2, T2),
+
+    ok = file:set_cwd(Cwd),
+
+    Suite2 = proplists:get_value(suite, Opts2),
+    [Expected] = Suite2,
+    true = filelib:is_file(TestHrl),
+    true = filelib:is_file(TestBeam),
+    true = filelib:is_dir(DataDir),
+    true = filelib:is_file(DataFile),
+
+    ok.
 
 suite_at_app_root(Config) ->
     AppDir = ?config(apps, Config),
@@ -730,7 +756,32 @@ suite_at_app_root(Config) ->
     true = filelib:is_dir(DataDir),
 
     DataFile = filename:join([AppDir, "_build", "test", "lib", Name2, "app_root_SUITE_data", "some_data.txt"]),
-    true = filelib:is_file(DataFile).
+    true = filelib:is_file(DataFile),
+
+    %% Same test again using relative path to the suite from the project root
+    {ok,Cwd} = file:get_cwd(),
+    ok = file:set_cwd(AppDir),
+    rebar_file_utils:rm_rf("_build"),
+
+    {ok, GetOptResult2} = getopt:parse(GetOptSpec, ["--suite=" ++ filename:join(["apps", Name2, "app_root_SUITE"])]),
+
+    State3 = rebar_state:command_parsed_args(State1, GetOptResult2),
+
+    Tests2 = rebar_prv_common_test:prepare_tests(State3),
+    {ok, NewState2} = rebar_prv_common_test:compile(State3, Tests2),
+    {ok, T2} = Tests2,
+    Opts2 = rebar_prv_common_test:translate_paths(NewState2, T2),
+
+    ok = file:set_cwd(Cwd),
+
+    Suite2 = proplists:get_value(suite, Opts2),
+    [Expected] = Suite2,
+    true = filelib:is_file(TestHrl),
+    true = filelib:is_file(TestBeam),
+    true = filelib:is_dir(DataDir),
+    true = filelib:is_file(DataFile),
+
+    ok.
 
 %% this test probably only fails when this suite is run via rebar3 with the --cover flag
 data_dir_correct(Config) ->


### PR DESCRIPTION
Bug: option 'spec' is not specifically handled when merging options
from the command line with options from rebar.config. Due to this, if
the config specifies a 'spec', then this will take precedence over any
'dir' and/or 'suite' on the command line.

This commit takes special care of all options that can be used to
select tests - meaning that if any of the options 'spec', 'dir',
'suite', 'group' or 'case' are specified on the command line, then all
'spec', 'dir', 'suite', 'group' and 'case' options in rebar.config
will be ignored.

See also https://github.com/erlang/rebar3/issues/1389