### PR TITLE
Fix regex match for ignored file

### DIFF
--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -54,7 +54,7 @@ run(Config, FirstFiles, SourceDir, SourceExt, TargetDir, TargetExt,
 run(Config, FirstFiles, SourceDir, SourceExt, TargetDir, TargetExt,
     Compile3Fn, Opts) ->
     %% Convert simple extension to proper regex
-    SourceExtRe = "^(?!._).*\\" ++ SourceExt ++ [$$],
+    SourceExtRe = "^(?!\\._).*\\" ++ SourceExt ++ [$$],
 
     Recursive = proplists:get_value(recursive, Opts, true),
     %% Find all possible source files

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -48,7 +48,7 @@
 -type compile_opt() :: {recursive, boolean()}.
 
 -define(DEFAULT_OUTDIR, "ebin").
--define(RE_PREFIX, "^(?!._)").
+-define(RE_PREFIX, "^(?!\\._)").
 
 %% ===================================================================
 %% Public API

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -18,7 +18,7 @@
 %% we need to modify app_info state before compile
 -define(DEPS, [lock]).
 
--define(DEFAULT_TEST_REGEX, "^(?!._).*\\.erl\$").
+-define(DEFAULT_TEST_REGEX, "^(?!\\._).*\\.erl\$").
 
 %% ===================================================================
 %% Public API

--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -33,7 +33,7 @@
 
 -include("rebar.hrl").
 
--define(TEMPLATE_RE, "^(?!._).*\\.template\$").
+-define(TEMPLATE_RE, "^(?!\\._).*\\.template\$").
 
 %% ===================================================================
 %% Public API


### PR DESCRIPTION
The regex mistakenly matched too many files (any character followed by
an underscore) rather than only files starting in '._'

This properly escapes the expressions to work in all cases.

Fixes #1410 