### PR TITLE
shell: don't crash apps that use release version operators

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -352,11 +352,15 @@ boot_apps(Apps) ->
 normalize_load_apps([]) -> [];
 normalize_load_apps([{App, _} | T]) -> [App | normalize_load_apps(T)];
 normalize_load_apps([{App, _Vsn, load} | T]) -> [App | normalize_load_apps(T)];
+normalize_load_apps([{App, _Vsn, Operator} | T]) when is_atom(Operator) ->
+    [App | normalize_load_apps(T)];
 normalize_load_apps([App | T]) when is_atom(App) -> [App | normalize_load_apps(T)].
 
 normalize_boot_apps([]) -> [];
 normalize_boot_apps([{_App, load} | T]) -> normalize_boot_apps(T);
 normalize_boot_apps([{_App, _Vsn, load} | T]) -> normalize_boot_apps(T);
+normalize_boot_apps([{App, _Vsn, Operator} | T]) when is_atom(Operator) ->
+    [App | normalize_boot_apps(T)];
 normalize_boot_apps([{App, _Vsn} | T]) -> [App | normalize_boot_apps(T)];
 normalize_boot_apps([App | T]) when is_atom(App) -> [App | normalize_boot_apps(T)].
 


### PR DESCRIPTION
Like for instance: {app, "0.1.0", '='}