### PR TITLE
Issue #1416: Merge erl_files_first separately and avoid sorting.

### DIFF
--- a/src/rebar_opts.erl
+++ b/src/rebar_opts.erl
@@ -118,6 +118,10 @@ merge_opt({plugins, _}, NewValue, _OldValue) ->
     NewValue;
 merge_opt(profiles, NewValue, OldValue) ->
     dict:to_list(merge_opts(dict:from_list(NewValue), dict:from_list(OldValue)));
+merge_opt(erl_first_files, Value, Value) ->
+    Value;
+merge_opt(erl_first_files, NewValue, OldValue) ->
+    OldValue ++ NewValue;
 merge_opt(mib_first_files, Value, Value) ->
     Value;
 merge_opt(mib_first_files, NewValue, OldValue) ->


### PR DESCRIPTION
The order of the files listed in "erl_files_first" option is
important and should not be sorted. By handling the merge
similarly to mib_files_first, the sort order is preserved.