### PR TITLE
Fix incorrect call to ct_testspec:collect_tests_from_file/2

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -561,7 +561,7 @@ get_tests_from_specs(Specs) ->
         true ->
             ct_testspec:get_tests(Specs);
         false ->
-            case ct_testspec:collect_tests_from_file(Specs,true) of
+            case ct_testspec:collect_tests_from_file([Specs],true) of
                 Tests when is_list(Tests) ->
                     {ok,[{S,ct_testspec:prepare_tests(R)} || {S,R} <- Tests]};
                 R when is_tuple(R), element(1,R)==testspec ->


### PR DESCRIPTION
Seems to require a list of filenames.