### PR TITLE
See template local install same builtin as escript

### DIFF
--- a/src/rebar_prv_new.erl
+++ b/src/rebar_prv_new.erl
@@ -132,10 +132,13 @@ show_template({Name, Type, Location, Description, Vars}) ->
                format_vars(Vars)]).
 
 format_type(escript) -> "built-in";
+format_type(builtin) -> "built-in";
 format_type(plugin) -> "plugin";
 format_type(file) -> "custom".
 
 format_type(escript, _) ->
+    "built-in template";
+format_type(builtin, _) ->
     "built-in template";
 format_type(plugin, Loc) ->
     io_lib:format("plugin template (~s)", [Loc]);


### PR DESCRIPTION
When the `new` command is run from a locally installed rebar3 (`rebar3
local install`), the builtin templates would be labelled as custom
because of directories.

This patch fixes it by splitting off the rebar3 priv dir from the user's
configured plugin path for custom ones, and introducing a new internal
label for builtins (since handling must remain different from escripts)

This fixes issue #819