### PR TITLE
Relative dialyzer paths

### DIFF
--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -27,6 +27,7 @@
 -define(REMOTE_PACKAGE_DIR, "tarballs").
 -define(REMOTE_REGISTRY_FILE, "registry.ets.gz").
 -define(LOCK_FILE, "rebar.lock").
+-define(DEFAULT_COMPILER_SOURCE_FORMAT, relative).
 
 -define(PACKAGE_INDEX_VERSION, 3).
 -define(PACKAGE_TABLE, package_index).

--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -35,7 +35,6 @@
          error_tuple/4,
          format_error_source/2]).
 
--define(DEFAULT_COMPILER_SOURCE_FORMAT, relative).
 -type desc() :: term().
 -type loc() :: {line(), col()} | line().
 -type line() :: integer().
@@ -138,28 +137,7 @@ error_tuple(Source, Es, Ws, Opts) ->
 -spec format_error_source(file:filename(), rebar_dict() | [{_,_}]) ->
     file:filename().
 format_error_source(Path, Opts) ->
-    Type = case rebar_opts:get(Opts, compiler_source_format,
-                               ?DEFAULT_COMPILER_SOURCE_FORMAT) of
-        V when V == absolute; V == relative; V == build ->
-            V;
-        Other ->
-            ?WARN("Invalid argument ~p for compiler_source_format - "
-                  "assuming ~s~n", [Other, ?DEFAULT_COMPILER_SOURCE_FORMAT]),
-            ?DEFAULT_COMPILER_SOURCE_FORMAT
-    end,
-    case Type of
-        absolute -> resolve_linked_source(Path);
-        build -> Path;
-        relative ->
-            Cwd = rebar_dir:get_cwd(),
-            rebar_dir:make_relative_path(resolve_linked_source(Path), Cwd)
-    end.
-
-%% @private takes a filename and canonicalizes its path if it is a link.
--spec resolve_linked_source(file:filename()) -> file:filename().
-resolve_linked_source(Src) ->
-    {Dir, Base} = rebar_file_utils:split_dirname(Src),
-    filename:join(rebar_file_utils:resolve_link(Dir), Base).
+    rebar_dir:format_source_file_name(Path, Opts).
 
 %% ===================================================================
 %% Internal functions

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -478,7 +478,8 @@ run_dialyzer(State, Opts, Output) ->
                      {check_plt, false} |
                      Opts],
             ?DEBUG("Running dialyzer with options: ~p~n", [Opts2]),
-            Warnings = format_warnings(Output, dialyzer:run(Opts2)),
+            Warnings = format_warnings(rebar_state:opts(State),
+                                       Output, dialyzer:run(Opts2)),
             {Warnings, State};
         false ->
             Opts2 = [{warnings, no_warnings()},
@@ -497,8 +498,8 @@ legacy_warnings(Warnings) ->
             Warnings
     end.
 
-format_warnings(Output, Warnings) ->
-    Warnings1 = rebar_dialyzer_format:format_warnings(Warnings),
+format_warnings(Opts, Output, Warnings) ->
+    Warnings1 = rebar_dialyzer_format:format_warnings(Opts, Warnings),
     console_warnings(Warnings1),
     file_warnings(Output, Warnings),
     length(Warnings).


### PR DESCRIPTION
1.  Extract code path formatting out of compiler: this allows to reuse the code for any provider that formats source files out to the user, without worry of introducing new weird bugs. The option to configure it does remain compiler-centric for backwards compatibility.

2.  Enable path reformatting for Dialyzer

It may break backwards compat with projects that manually called the dialyzer formatter out of rebar3, but we never documented or expected this to be exposed so I'm not too worried about the risk.

Before:

```
===> Analyzing 8 files with "/home/ferd/code/self/shunk/_build/default/rebar3_18.1.5_plt"...

_build/default/lib/shunk/src/shunk_tcp_client.erl
  24: Invalid type specification for function shunk_tcp_client:diff/2. The success typing is (atom(),port()) -> 'todo'
  43: Function full_table/2 has no local return
  43: The attempt to match a term of type shunk_tab_serv:vsn_ref() against the pattern {_, Vsn} breaks the opaqueness of the term
  55: Function diff_top/4 will never be called
  64: Function diff_range/4 will never be called
===> Warnings written to /home/ferd/code/self/shunk/_build/default/18.1.5.dialyzer_warnings
```

After:

```
===> Analyzing 8 files with "/home/ferd/code/self/shunk/_build/default/rebar3_18.1.5_plt"...

src/shunk_tcp_client.erl
  24: Invalid type specification for function shunk_tcp_client:diff/2. The success typing is (atom(),port()) -> 'todo'
  43: Function full_table/2 has no local return
  43: The attempt to match a term of type shunk_tab_serv:vsn_ref() against the pattern {_, Vsn} breaks the opaqueness of the term
  55: Function diff_top/4 will never be called
  64: Function diff_range/4 will never be called
===> Warnings written to /home/ferd/code/self/shunk/_build/default/18.1.5.dialyzer_warnings
```

The change only impacts the display of paths, everything else works the same internally.

This fixes issue #880