### PR TITLE
Fix `mv` on windows

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -185,31 +185,100 @@ mv(Source, Dest) ->
                     ok
             end;
         {win32, _} ->
-            Cmd = case filelib:is_dir(Source) of
-                      true ->
-                          ?FMT("robocopy /move /e \"~s\" \"~s\" 1> nul",
-                               [rebar_utils:escape_double_quotes(filename:nativename(Source)),
-                                rebar_utils:escape_double_quotes(filename:nativename(Dest))]);
-                      false ->
-                          ?FMT("robocopy /move /e \"~s\" \"~s\" \"~s\" 1> nul",
-                               [rebar_utils:escape_double_quotes(filename:nativename(filename:dirname(Source))),
-                                rebar_utils:escape_double_quotes(filename:nativename(Dest)),
-                                rebar_utils:escape_double_quotes(filename:basename(Source))])
-                  end,
-            Res = rebar_utils:sh(Cmd,
-                        [{use_stdout, false}, return_on_error]),
-            case win32_ok(Res) of
-                true -> ok;
+            case filelib:is_dir(Source) of
+                true ->
+                    SrcDir = filename:nativename(Source),
+                    DestDir = filename:nativename(Dest),
+                    robocopy_dir(SrcDir, DestDir);
                 false ->
-                    {error, lists:flatten(
-                              io_lib:format("Failed to move ~s to ~s~n",
-                                            [Source, Dest]))}
+                    SrcDir = filename:nativename(filename:dirname(Source)),
+                    SrcName = filename:basename(Source),
+                    DestDir = filename:nativename(filename:dirname(Dest)),
+                    DestName = filename:basename(Dest),
+                    IsDestDir = filelib:is_dir(Dest),
+                    if IsDestDir ->
+                        %% if basename and target name are different because
+                        %% we move to a directory, then just move there.
+                        %% Similarly, if they are the same but we're going to
+                        %% a directory, let's just do that directly.
+                        FullDestDir = filename:nativename(Dest),
+                        robocopy_file(SrcDir, FullDestDir, SrcName)
+                    ;  SrcName =:= DestName ->
+                        %% if basename and target name are the same and both are files,
+                        %% we do a regular move with robocopy without rename.
+                        robocopy_file(SrcDir, DestDir, DestName)
+                    ;  SrcName =/= DestName->
+                        %% If we're moving a file and the origin and
+                        %% destination names are different:
+                        %%  - mktmp
+                        %%  - robocopy source_dir tmp_dir srcname
+                        %%  - rename srcname destname (to avoid clobbering)
+                        %%  - robocopy tmp_dir dest_dir destname
+                        %%  - remove tmp_dir
+                        case ec_file:insecure_mkdtemp() of
+                            {error, _Reason} ->
+                                {error, lists:flatten(
+                                         io_lib:format("Failed to move ~s to ~s (tmpdir failed)~n",
+                                                       [Source, Dest]))};
+                            TmpPath ->
+                                case robocopy_file(SrcDir, TmpPath, SrcName) of
+                                    {error, Reason} ->
+                                        {error, Reason};
+                                    ok ->
+                                        TmpSrc = filename:join(TmpPath, SrcName),
+                                        TmpDst = filename:join(TmpPath, DestName),
+                                        case file:rename(TmpSrc, TmpDst) of
+                                            {error, _} ->
+                                                {error, lists:flatten(
+                                                          io_lib:format("Failed to move ~s to ~s (via rename)~n",
+                                                                        [Source, Dest]))};
+                                            ok ->
+                                                case robocopy_file(TmpPath, DestDir, DestName) of
+                                                    Err = {error, _} -> Err;
+                                                    OK -> rm_rf(TmpPath), OK
+                                                end
+                                        end
+                                end
+                        end
+                    end
+
             end
+    end.
+
+robocopy_file(SrcPath, DestPath, FileName) ->
+    Cmd = ?FMT("robocopy /move /e \"~s\" \"~s\" \"~s\"",
+               [rebar_utils:escape_double_quotes(SrcPath),
+                rebar_utils:escape_double_quotes(DestPath),
+                rebar_utils:escape_double_quotes(FileName)]),
+    Res = rebar_utils:sh(Cmd, [{use_stdout, false}, return_on_error]),
+    case win32_ok(Res) of
+        false ->
+            {error, lists:flatten(
+                        io_lib:format("Failed to move ~s to ~s~n",
+                                      [filename:join(SrcPath, FileName),
+                                       filename:join(DestPath, FileName)]))};
+        true ->
+            ok
+    end.
+
+robocopy_dir(Source, Dest) ->
+    Cmd = ?FMT("robocopy /move /e \"~s\" \"~s\"",
+               [rebar_utils:escape_double_quotes(Source),
+                rebar_utils:escape_double_quotes(Dest)]),
+    Res = rebar_utils:sh(Cmd,
+                         [{use_stdout, false}, return_on_error]),
+    case win32_ok(Res) of
+        true -> ok;
+        false ->
+            {error, lists:flatten(
+                      io_lib:format("Failed to move ~s to ~s~n",
+                                    [Source, Dest]))}
     end.
 
 win32_ok({ok, _}) -> true;
 win32_ok({error, {Rc, _}}) when Rc<9; Rc=:=16 -> true;
 win32_ok(_) -> false.
+
 
 delete_each([]) ->
     ok;

--- a/test/rebar_file_utils_SUITE.erl
+++ b/test/rebar_file_utils_SUITE.erl
@@ -187,7 +187,7 @@ mv_dir(Config) ->
     %% move files from dir to empty dir
     F1 = filename:join(SrcDir, "file1"),
     F2 = filename:join(SrcDir, "subdir/file2"),
-    ec_file:mkdir_p(F2),
+    filelib:ensure_dir(F2),
     file:write_file(F1, "hello"),
     file:write_file(F2, "world"),
     DstDir2 = filename:join(BaseDir, "dst2/"),
@@ -197,17 +197,20 @@ mv_dir(Config) ->
     ?assertEqual(ok, rebar_file_utils:mv(SrcDir, DstDir2)),
     ?assert(filelib:is_file(D2F1)),
     ?assert(filelib:is_file(D2F2)),
-    
-    %% move files from dir to existing dir
-    ec_file:mkdir_p(F2),
+
+    %% move files from dir to existing dir moves it to
+    %% a subdir
+    filelib:ensure_dir(F2),
     file:write_file(F1, "hello"),
     file:write_file(F2, "world"),
     DstDir3 = filename:join(BaseDir, "dst3/"),
-    D3F1 = filename:join(DstDir3, "file1"),
-    D3F2 = filename:join(DstDir3, "subdir/file2"),
+    D3F1 = filename:join(DstDir3, "src/file1"),
+    D3F2 = filename:join(DstDir3, "src/subdir/file2"),
     ec_file:mkdir_p(DstDir3),
     ?assert(filelib:is_dir(DstDir3)),
     ?assertEqual(ok, rebar_file_utils:mv(SrcDir, DstDir3)),
+    ?assertNot(filelib:is_file(F1)),
+    ?assertNot(filelib:is_file(F2)),
     ?assert(filelib:is_file(D3F1)),
     ?assert(filelib:is_file(D3F2)),
     ?assertNot(filelib:is_dir(SrcDir)),
@@ -279,8 +282,9 @@ mv_file_dir_diff(Config) ->
     F = filename:join(SrcDir, "file"),
     file:write_file(F, "hello"),
     DstDir = filename:join(BaseDir, "dst/"),
+    ec_file:mkdir_p(DstDir),
     Dst = filename:join(DstDir, "file-rename"),
-    ?assertNot(filelib:is_dir(DstDir)),
+    ?assert(filelib:is_dir(DstDir)),
     ?assertNot(filelib:is_file(Dst)),
     ?assertEqual(ok, rebar_file_utils:mv(F, Dst)),
     ?assert(filelib:is_file(Dst)),


### PR DESCRIPTION
This is due to a stall a bunch of tests in appveyor and on windows in general.

Turns out a bunch of semantics for file moving were flat out wrong and different between windows and POSIX. This PR adds a bunch of tests for the expected behaviour that I roundtripped between a windows10 and a linux computer to make sure they agree on the behaviour and that it works the same.

There's some ugly stuff there, such as `xcopy` not handling long paths properly, forcing us to move to `robocopy`, which does not allow renaming as part of moving a file. This requires using temporary directories to rename files as an intermediary to avoid clobbering.

For directories this isn't a problem, but the `mv` behaviour has to be replicated still because it is not the default on windows with robocopy.