### PR TITLE
Windows escripts get cmd autogenerated

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -52,21 +52,7 @@ main(_) ->
     rebar3:run(["escriptize"]),
 
     %% Done with compile, can turn back on error logger
-    error_logger:tty(true),
-
-    %% Finally, update executable perms for our script on *nix,
-    %%  or write out script files on win32.
-    ec_file:copy("_build/default/bin/rebar3", "./rebar3"),
-    case os:type() of
-        {unix,_} ->
-            [] = os:cmd("chmod u+x rebar3"),
-            ok;
-        {win32,_} ->
-            write_windows_scripts(),
-            ok;
-        _ ->
-            ok
-    end.
+    error_logger:tty(true).
 
 default_registry_file() ->
     {ok, [[Home]]} = init:get_argument(home),
@@ -304,14 +290,6 @@ reset_env() ->
     application:unset_env(rebar, providers),
     application:unload(rebar),
     application:load(rebar).
-
-write_windows_scripts() ->
-    CmdScript=
-        "@echo off\r\n"
-        "setlocal\r\n"
-        "set rebarscript=%~f0\r\n"
-        "escript.exe \"%rebarscript:.cmd=%\" %*\r\n",
-    ok = file:write_file("rebar3.cmd", CmdScript).
 
 get_deps() ->
     case file:consult("rebar.lock") of

--- a/rebar.config
+++ b/rebar.config
@@ -14,9 +14,11 @@
 
 {post_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)",
                escriptize,
-               "cp $REBAR_BUILD_DIR/bin/rebar3 ./rebar3"},
+               "cp \"$REBAR_BUILD_DIR/bin/rebar3\" ./rebar3"},
               {"win32",
-               "robocopy $REBAR_BUILD_DIR/bin/ ./ rebar3*"}
+               escriptize,
+               "robocopy \"%REBAR_BUILD_DIR%/bin/\" ./ rebar3* "
+               "/njs /njh /nfl /ndl & exit /b 0"} % silence things
              ]}.
 
 {escript_name, rebar3}.

--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,10 @@
 
 {post_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)",
                escriptize,
-               "cp $REBAR_BUILD_DIR/bin/rebar3 ./rebar3 && chmod u+x rebar3"}]}.
+               "cp $REBAR_BUILD_DIR/bin/rebar3 ./rebar3"},
+              {"win32",
+               "robocopy $REBAR_BUILD_DIR/bin/ ./ rebar3*"}
+             ]}.
 
 {escript_name, rebar3}.
 {escript_emu_args, "%%! +sbtu +A0\n"}.


### PR DESCRIPTION
This also patches up a problem for hooks when dealing with directories
with spaces in them, and reduces complexity of bootstrap file.

Fixes https://github.com/erlang/rebar3/issues/1491