### PR TITLE
rebar_utils:escape_chars handles quotes

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -857,7 +857,7 @@ url_append_path(Url, ExtraPath) ->
 escape_chars(Str) when is_atom(Str) ->
     escape_chars(atom_to_list(Str));
 escape_chars(Str) ->
-    re:replace(Str, "([ ()?`!$&;])", "\\\\&", [global, {return, list}]).
+    re:replace(Str, "([ ()?`!$&;\"\'])", "\\\\&", [global, {return, list}]).
 
 %% "escape inside these"
 escape_double_quotes(Str) ->


### PR DESCRIPTION
rebar_file_utils:cp_r uses rebar_utils:escape_chars to ensure that the file names are safe to use, but it doesn't escape double and single quotes. If the file name includes those characters, they disappear when the shell processes them and we get "file not found" errors.

The main culprit here is eunit, that creates reports whose names are `TEST-file_"myfile.app".xml`, and I wish it didn't but I think escape_chars should still do its job all the way.