### PR TITLE
Properly warn on missing rebar3 deps: add inets

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -344,7 +344,7 @@ start_and_load_apps(Caller) ->
     ensure_running(asn1, Caller),
     ensure_running(public_key, Caller),
     ensure_running(ssl, Caller),
-    inets:start(),
+    ensure_running(inets, Caller),
     inets:start(httpc, [{profile, rebar}]).
 
 %% @doc Make sure a required app is running, or display an error message


### PR DESCRIPTION
In my OTP installation inets was not installed so I encountered into this #836 at runtime.

This patch fixes it (tested on 17, 18 and 19)

I noticed that in #838 inets was left out from the wrapper fun `ensure_running`, but I don't see any reason for doing that. If apologize if I'm missing something. 

Bye!
