### PR TITLE
Fix git SHAs comparison for update.

### DIFF
--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -53,24 +53,22 @@ needs_update(Dir, {git, Url, {branch, Branch}}) ->
 needs_update(Dir, {git, Url, "master"}) ->
     needs_update(Dir, {git, Url, {branch, "master"}});
 needs_update(Dir, {git, _, Ref}) ->
-    {ok, Current} = rebar_utils:sh(?FMT("git rev-parse -q HEAD", []),
+    {ok, Current} = rebar_utils:sh(?FMT("git rev-parse --short=7 -q HEAD", []),
                                    [{cd, Dir}]),
     Current1 = string:strip(string:strip(Current, both, $\n), both, $\r),
 
     Ref2 = case Ref of
                {ref, Ref1} ->
                    Length = length(Current1),
-                   if
-                       Length >= 7 ->
-                           lists:sublist(Ref1, Length);
-                       true ->
-                           Ref1
+                   case Length >= 7 of
+                       true -> lists:sublist(Ref1, Length);
+                       false -> Ref1
                    end;
-               Ref1 ->
-                   Ref1
+               _ ->
+                   Ref
            end,
 
-    ?DEBUG("Comparing git ref ~s with ~s", [Ref1, Current1]),
+    ?DEBUG("Comparing git ref ~s with ~s", [Ref2, Current1]),
     (Current1 =/= Ref2).
 
 compare_url(Dir, Url) ->


### PR DESCRIPTION
Let me give you a bit of a context here:
- I found this while I was trying to use a test dependency which is not being locked;
- tried to remove this restriction https://github.com/erlang/rebar3/blob/master/src/rebar_prv_install_deps.erl#L383 and see what's happening;
- the version for my test dependency was set to a 7 chars short SHA;
- noticed that the comparison was always happening between the fully long SHA and the short SHA provided, hence it'll always return true for `needs_update`, and that means it'll always try to fetch the source for the dependency;
- this can be tested as well with a custom plugin hosted on github (see https://github.com/alinpopa/test_git_short_sha as an example for this)

Conditions to replicate this issue:
- make sure you have a dependency that is not locked by rebar3 (I used meck as a test dependency in https://github.com/alinpopa/test_git_short_sha);
- make sure you use a short (7 chars) SHA ref;
- make sure the `is_lock` restriction is removed from https://github.com/erlang/rebar3/blob/master/src/rebar_prv_install_deps.erl#L383, otherwise not being locked, this dependency will always be skipped.

Some other things I've considered while having this issue:
- why that `is_lock` restriction in place? if the responsibility of `needs_update` will stay entirely within the resolver, would that restriction still be needed?
- test dependencies and plugins are not locked, and this makes it quite hard to refresh the code for those using the resolver - is there any plan of addressing these sort of things?