### PR TITLE
Let relx know about application erl opts

### DIFF
--- a/src/rebar_relx.erl
+++ b/src/rebar_relx.erl
@@ -26,19 +26,21 @@ do(Module, Command, Provider, State) ->
     AllOptions = string:join([Command | Options], " "),
     Cwd = rebar_state:dir(State),
     Providers = rebar_state:providers(State),
+    RebarOpts = rebar_state:opts(State),
+    ErlOpts = rebar_opts:erl_opts(RebarOpts),
     rebar_hooks:run_project_and_app_hooks(Cwd, pre, Provider, Providers, State),
     try
         case rebar_state:get(State, relx, []) of
             [] ->
                 relx:main([{lib_dirs, LibDirs}
                           ,{caller, api}
-                          ,{log_level, LogLevel} | output_dir(OutputDir, Options)], AllOptions);
+                          ,{log_level, LogLevel} | output_dir(OutputDir, Options)] ++ ErlOpts, AllOptions);
             Config ->
                 Config1 = merge_overlays(Config),
                 relx:main([{lib_dirs, LibDirs}
                           ,{config, Config1}
                           ,{caller, api}
-                          ,{log_level, LogLevel} | output_dir(OutputDir, Options)], AllOptions)
+                          ,{log_level, LogLevel} | output_dir(OutputDir, Options)] ++ ErlOpts, AllOptions)
         end,
         rebar_hooks:run_project_and_app_hooks(Cwd, post, Provider, Providers, State),
         {ok, State}


### PR DESCRIPTION
This is so that some of them can be enforced
(such as warnings_as_errors) on relx's task like
generating a release or a release upgrade.

Continuation of work started in relx in the context of issue erlware/relx#554 and subsequent fix erlware/relx#559