### PR TITLE
Bump relx to 3.22.4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
         {providers,           "1.6.0"},
         {getopt,              "0.8.2"},
         {bbmustache,          "1.3.0"},
-        {relx,                "3.22.3"},
+        {relx,                "3.22.4"},
         {cf,                  "0.2.2"},
         {cth_readable,        "1.2.4"},
         {eunit_formatters,    "0.3.1"}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -7,7 +7,7 @@
  {<<"eunit_formatters">>,{pkg,<<"eunit_formatters">>,<<"0.3.1">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.6.0">>},0},
- {<<"relx">>,{pkg,<<"relx">>,<<"3.22.3">>},0},
+ {<<"relx">>,{pkg,<<"relx">>,<<"3.22.4">>},0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.1">>},0}]}.
 [
 {pkg_hash,[
@@ -19,6 +19,6 @@
  {<<"eunit_formatters">>, <<"7A6FC351EB5B873E2356B8852EB751E20C13A72FBCA03393CF682B8483509573">>},
  {<<"getopt">>, <<"B17556DB683000BA50370B16C0619DF1337E7AF7ECBF7D64FBF8D1D6BCE3109B">>},
  {<<"providers">>, <<"DB0E2F9043AE60C0155205FCD238D68516331D0E5146155E33D1E79DC452964A">>},
- {<<"relx">>, <<"36CB10F463E3834CE7BAF685F18D80D6B415BA9B227649E1140D091077A55246">>},
+ {<<"relx">>, <<"98D6AE6EEECB31F2018CD06AF574579BAF1C08E9A848F9184F7B95F35A480AC8">>},
  {<<"ssl_verify_fun">>, <<"28A4D65B7F59893BC2C7DE786DEC1E1555BD742D336043FE644AE956C3497FBE">>}]}
 ].


### PR DESCRIPTION
Just a re-tag of 3.22.3 which got wrongly pushed to hex without any dependencies