### PR TITLE
REBAR_COLOR supports all ec_cmd_log intensity options

### DIFF
--- a/src/rebar_log.erl
+++ b/src/rebar_log.erl
@@ -57,6 +57,8 @@ intensity() ->
                         high;
                     "low" ->
                         low;
+                    "none" ->
+                        none;
                     _ ->
                         ?DFLT_INTENSITY
                 end,


### PR DESCRIPTION
As of 1.0.0 of erlware-commons it now supports 3 values for intensity

https://github.corp.openx.com/mirrors/erlware-erlware_commons/blob/1.0.0/src/ec_cmd_log.erl#L75

This just allows 'none' to be passed in via the REBAR_COLOR environment variable.