### PR TITLE
Drop R15 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: erlang
 matrix:
   include:
     - os: linux
-      otp_release: R15B03
-    - os: linux
       otp_release: R16B03-1
     - os: linux
       otp_release: 17.5

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -567,9 +567,6 @@ get_tests_from_specs(Specs) ->
             case ct_testspec:collect_tests_from_file(Specs,true) of
                 Tests when is_list(Tests) ->
                     {ok,[{S,ct_testspec:prepare_tests(R)} || {S,R} <- Tests]};
-                R when is_tuple(R), element(1,R)==testspec ->
-                    %% R15
-                    {ok,[{Specs,ct_testspec:prepare_tests(R)}]};
                 Error ->
                     Error
             end


### PR DESCRIPTION
It can't even fetch packages from Hex anymore because of old SSL/TLS
libraries, and so it can't bootstrap anymore either. Plus R20 comes out
soon, and 5 major versions is quite enough.