### PR TITLE
Use rm_rf instead of ec_file:delete.

### DIFF
--- a/src/rebar_fetch.erl
+++ b/src/rebar_fetch.erl
@@ -46,7 +46,7 @@ download_source_(AppDir, Source, State) ->
         {ok, _} ->
             ec_file:mkdir_p(AppDir1),
             code:del_path(filename:absname(filename:join(AppDir1, "ebin"))),
-            ec_file:remove(filename:absname(AppDir1), [recursive]),
+            ok = rebar_file_utils:rm_rf(filename:absname(AppDir1)),
             ?DEBUG("Moving checkout ~p to ~p", [TmpDir, filename:absname(AppDir1)]),
             ok = rebar_file_utils:mv(TmpDir, filename:absname(AppDir1)),
             true;


### PR DESCRIPTION
In contrast to `ec_file:delete`, `rebar_file_utils:rm_rf` will also delete
write-protected files on Windows which is needed for git object files.

Fixes #1483.