### PR TITLE
Prevent xref crashes with undef behaviours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _checkouts
 .rebar3
 rebar3
+rebar3.cmd
 _build
 .depsolver_plt
 *.beam

--- a/src/rebar_prv_xref.erl
+++ b/src/rebar_prv_xref.erl
@@ -168,8 +168,15 @@ keyall(Key, List) ->
     lists:flatmap(fun({K, L}) when Key =:= K -> L; (_) -> [] end, List).
 
 get_behaviour_callbacks(exports_not_used, Attributes) ->
-    [B:behaviour_info(callbacks) || B <- keyall(behaviour, Attributes) ++
-                                         keyall(behavior, Attributes)];
+    lists:map(fun(Mod) ->
+        try
+            Mod:behaviour_info(callbacks)
+        catch
+            error:undef ->
+                ?WARN("Behaviour ~p is used but cannot be found.", [Mod]),
+                []
+        end
+    end, keyall(behaviour, Attributes) ++ keyall(behavior, Attributes));
 get_behaviour_callbacks(_XrefCheck, _Attributes) ->
     [].
 


### PR DESCRIPTION
When a given behaviour module does not exist, rebar3 brutally crashes.
This patch makes it so instead, there is a warning output menitoning the
missing behaviour, and this one is omitted from the unused function
calls check. This means that unused calls will instead be shown for the
module implementing a non-existing behaviour, as if no behaviour were
declared in the first place.

Fixes #1570