### PR TITLE
Rebar3 shell supports booting applications with type 'none'

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -360,8 +360,10 @@ boot_apps(Apps) ->
     ok.
 
 normalize_load_apps([]) -> [];
+normalize_load_apps([{_App, none} | T]) -> normalize_load_apps(T);
 normalize_load_apps([{App, _} | T]) -> [App | normalize_load_apps(T)];
 normalize_load_apps([{App, _Vsn, load} | T]) -> [App | normalize_load_apps(T)];
+normalize_load_apps([{_App, _Vsn, none} | T]) -> normalize_load_apps(T);
 normalize_load_apps([{App, _Vsn, Operator} | T]) when is_atom(Operator) ->
     [App | normalize_load_apps(T)];
 normalize_load_apps([App | T]) when is_atom(App) -> [App | normalize_load_apps(T)].
@@ -369,11 +371,12 @@ normalize_load_apps([App | T]) when is_atom(App) -> [App | normalize_load_apps(T
 normalize_boot_apps([]) -> [];
 normalize_boot_apps([{_App, load} | T]) -> normalize_boot_apps(T);
 normalize_boot_apps([{_App, _Vsn, load} | T]) -> normalize_boot_apps(T);
+normalize_boot_apps([{_App, none} | T]) -> normalize_boot_apps(T);
+normalize_boot_apps([{_App, _Vsn, none} | T]) -> normalize_boot_apps(T);
 normalize_boot_apps([{App, _Vsn, Operator} | T]) when is_atom(Operator) ->
     [App | normalize_boot_apps(T)];
 normalize_boot_apps([{App, _Vsn} | T]) -> [App | normalize_boot_apps(T)];
 normalize_boot_apps([App | T]) when is_atom(App) -> [App | normalize_boot_apps(T)].
-
 
 remove_error_handler(0) ->
     ?WARN("Unable to remove simple error_logger handler", []);


### PR DESCRIPTION
I noticed this when trying to include entop in a release. Entop uses
cecho which takes over the terminal, so you do not want it loaded or
started.  According to http://erlang.org/doc/man/rel.html, when you
specify a Type of none it should not load or start, but the code for
it's modules should be loaded.  This patch ensures the code is not
loaded or started, but doesn't do anything with the code paths.
At the very least this allows me to start a shell in the case where
I have an application of type none, and the application is neither
loaded nor started.