### PR TITLE
Ignore IntelliJ IDEA file

### DIFF
--- a/priv/templates/gitignore
+++ b/priv/templates/gitignore
@@ -14,4 +14,5 @@ erl_crash.dump
 logs
 _build
 .idea
+*.iml
 rebar3.crashdump


### PR DESCRIPTION
#1297 is not enough.
`*.iml` is module infomation file for IntelliJ IDEA.