### PR TITLE
disable warning for `export_all` usage

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -31,8 +31,7 @@
 {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
             {platform_define, "^(19|2)", rand_only},
             no_debug_info,
-            warnings_as_errors,
-            nowarn_export_all]}.
+            warnings_as_errors]}.
 
 %% Use OTP 18+ when dialyzing rebar3
 {dialyzer, [{warnings, [unknown]}]}.
@@ -40,7 +39,7 @@
 %% Profiles
 {profiles, [{test, [
                    {deps, [{meck, "0.8.2"}]},
-                   {erl_opts, [debug_info]}
+                   {erl_opts, [debug_info, nowarn_export_all]}
                    ]
             },
 

--- a/rebar.config
+++ b/rebar.config
@@ -31,7 +31,8 @@
 {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
             {platform_define, "^(19|2)", rand_only},
             no_debug_info,
-            warnings_as_errors]}.
+            warnings_as_errors,
+            nowarn_export_all]}.
 
 %% Use OTP 18+ when dialyzing rebar3
 {dialyzer, [{warnings, [unknown]}]}.


### PR DESCRIPTION
`export_all` is used in all the ct suites and that is now a warning on otp20. this should allow tests to pass on otp20+