### PR TITLE
recompile only if new option effects code generation

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -279,7 +279,7 @@ gather_src(Opts, BaseDirParts, [Dir|Rest], Srcs, CompileOpts) ->
              end,
     DirRecursive = dir_recursive(Opts, RelDir, CompileOpts),
     gather_src(Opts, BaseDirParts, Rest, Srcs ++ rebar_utils:find_files(Dir, ?RE_PREFIX".*\\.erl\$", DirRecursive), CompileOpts).
-    
+
 %% Get files which need to be compiled first, i.e. those specified in erl_first_files
 %% and parse_transform options.  Also produce specific erl_opts for these first
 %% files, so that yet to be compiled parse transformations are excluded from it.
@@ -351,8 +351,23 @@ opts_changed(NewOpts, Target) ->
         false -> NewOpts
     end,
     case compile_info(Target) of
-        {ok, Opts} -> lists:sort(Opts) =/= lists:sort(TotalOpts);
+        {ok, Opts} -> lists:any(fun effects_code_generation/1, lists:usort(TotalOpts) -- lists:usort(Opts));
         _          -> true
+    end.
+
+effects_code_generation(Option) ->
+    case Option of
+        beam -> false;
+        report_warnings -> false;
+        report_errors -> false;
+        return_errors-> false;
+        return_warnings-> false;
+        warnings_as_errors -> false;
+        binary -> false;
+        verbose -> false;
+        {cwd,_} -> false;
+        {outdir, _} -> false;
+        _ -> true
     end.
 
 compile_info(Target) ->


### PR DESCRIPTION
This was technically an issue before OTP20 but the changes here https://github.com/erlang/otp/pull/1367/files#diff-7a0a8b020276e896d2ae816ccfcfe62eL1481 resulted it modules being recompiled on every run with no changes by the user.

The issue is Erlang does not store all options in the beam chunks, before this was not noticed because the ones it leaves out are not commonly used. With the above changes this was always the case because rebar3 adds an `{outdir, ...}` option. So when comparing the past compilation options to the new it would find they have changed and recompile every module.

This patch instead checks that any of the new options are those considered to effect compilation by Erlang and only then is the module recompiled.

In my opinion `warnings_as_errors` should be removed from the list and the function should be exported by `compile` but that is an issue to be taken up with a PR to OTP.