### PR TITLE
Fix cleanup_code_path for xref compile hook

### DIFF
--- a/src/rebar_prv_xref.erl
+++ b/src/rebar_prv_xref.erl
@@ -36,6 +36,7 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
+    OldPath = code:get_path(),
     code:add_pathsa(rebar_state:code_paths(State, all_deps)),
     XrefChecks = prepare(State),
     XrefIgnores = rebar_state:get(State, xref_ignores, []),
@@ -47,7 +48,7 @@ do(State) ->
     QueryChecks = rebar_state:get(State, xref_queries, []),
     QueryResults = lists:foldl(fun check_query/2, [], QueryChecks),
     stopped = xref:stop(xref),
-    rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
+    rebar_utils:cleanup_code_path(OldPath),
     case XrefResults =:= [] andalso QueryResults =:= [] of
         true ->
             {ok, State};


### PR DESCRIPTION
If deps app has xref post compile hook and you use include_lib in your app then compilation failed with an error `can't find include lib`.

App1 has `{provider_hooks, [{post, [{compile, xref}]}]}`.
App2 has this app1 in Dependencies and uses include_lib to include header file of app2.
Compilation of app2 failed with an error `can't find include lib`

You can reproduce this error by executing rebar3 compile for this project https://github.com/MikhailKalashnikov/rebar_issue2

This problem occurs because in `rebar_prv_xref:do` code path is reset to default `rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default))` and we lose pathes for compiled apps `ebin` which are added by rebar3 during compilation.