### PR TITLE
Upgrade certifi & ssl_verify_fun dependencies

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -16,7 +16,7 @@ main(_) ->
                ,{getopt, []}
                ,{cf, []}
                ,{erlware_commons, ["ec_dictionary.erl", "ec_vsn.erl"]}
-               ,{certifi, []}],
+               ,{certifi, ["certifi_pt.erl"]}],
     Deps = get_deps(),
     [fetch_and_compile(Dep, Deps) || Dep <- BaseDeps],
 

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 ft=erlang et
 
 {deps, [{erlware_commons,     "1.0.0"},
-        {ssl_verify_fun,      "1.1.1"},
+        {ssl_verify_fun,      "1.1.2"},
         {certifi,             "2.0.0"},
         {providers,           "1.6.0"},
         {getopt,              "0.8.2"},

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 
 {deps, [{erlware_commons,     "1.0.0"},
         {ssl_verify_fun,      "1.1.1"},
-        {certifi,             "0.4.0"},
+        {certifi,             "2.0.0"},
         {providers,           "1.6.0"},
         {getopt,              "0.8.2"},
         {bbmustache,          "1.3.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.6.0">>},0},
  {<<"relx">>,{pkg,<<"relx">>,<<"3.23.1">>},0},
- {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.1">>},0}]}.
+ {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.2">>},0}]}.
 [
 {pkg_hash,[
  {<<"bbmustache">>, <<"2010ADAE78830992A4C69680115ECD7D475DD03A72C076BBADDCCBF2D4B32035">>},
@@ -20,5 +20,5 @@
  {<<"getopt">>, <<"B17556DB683000BA50370B16C0619DF1337E7AF7ECBF7D64FBF8D1D6BCE3109B">>},
  {<<"providers">>, <<"DB0E2F9043AE60C0155205FCD238D68516331D0E5146155E33D1E79DC452964A">>},
  {<<"relx">>, <<"8AF4433934D9BB664E8282D2E45AC5DEAFF44859DDAABBE50CD7D885581CD24D">>},
- {<<"ssl_verify_fun">>, <<"28A4D65B7F59893BC2C7DE786DEC1E1555BD742D336043FE644AE956C3497FBE">>}]}
+ {<<"ssl_verify_fun">>, <<"01289CAD67B280B7F8F7E87117966995FAD19236367386BE2A9D7716E92CE7FF">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 {"1.1.0",
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.3.0">>},0},
- {<<"certifi">>,{pkg,<<"certifi">>,<<"0.4.0">>},0},
+ {<<"certifi">>,{pkg,<<"certifi">>,<<"2.0.0">>},0},
  {<<"cf">>,{pkg,<<"cf">>,<<"0.2.2">>},0},
  {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.2.6">>},0},
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"1.0.0">>},0},
@@ -12,7 +12,7 @@
 [
 {pkg_hash,[
  {<<"bbmustache">>, <<"2010ADAE78830992A4C69680115ECD7D475DD03A72C076BBADDCCBF2D4B32035">>},
- {<<"certifi">>, <<"A7966EFB868B179023618D29A407548F70C52466BF1849B9E8EBD0E34B7EA11F">>},
+ {<<"certifi">>, <<"A0C0E475107135F76B8C1D5BC7EFB33CD3815CB3CF3DEA7AEFDD174DABEAD064">>},
  {<<"cf">>, <<"7F2913FFF90ABCABD0F489896CFEB0B0674F6C8DF6C10B17A83175448029896C">>},
  {<<"cth_readable">>, <<"D3DADD65A639F5A54F4F20B9F8D1DB6AD38E3D9FEB836A4A1E29590246D6C860">>},
  {<<"erlware_commons">>, <<"087467DE5833C0BB5B3CCDD387F9E9C1FB816A75B7A709629BF24B5ED3246C51">>},


### PR DESCRIPTION
Get more up-to-date root certs. This was blocked for a while because
certifi wouldn't build on windows, but this is now fixed, with minimal
changes to the use case -- only a small change in the bootstrap script
is required.

The new certifi lib is also a few megabytes lighter than before, which
is good for rebar3.