### PR TITLE
Unicode support in all the places

### DIFF
--- a/priv/templates/Makefile
+++ b/priv/templates/Makefile
@@ -6,9 +6,9 @@ BASEDIR := $(abspath $(CURDIR)/..)
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))
 
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)]).")
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, include)]).")
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, lib)]).")
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -183,11 +183,11 @@ init_config() ->
     GlobalConfigFile = rebar_dir:global_config(),
     State = case filelib:is_regular(GlobalConfigFile) of
                 true ->
-                    ?DEBUG("Load global config file ~s", [GlobalConfigFile]),
+                    ?DEBUG("Load global config file ~ts", [GlobalConfigFile]),
                     try state_from_global_config(Config1, GlobalConfigFile)
                     catch
                         _:_ ->
-                            ?WARN("Global config ~s exists but can not be read. Ignoring global config values.", [GlobalConfigFile]),
+                            ?WARN("Global config ~ts exists but can not be read. Ignoring global config values.", [GlobalConfigFile]),
                             rebar_state:new(Config1)
                     end;
                 false ->
@@ -270,7 +270,7 @@ log_level() ->
 -spec version() -> ok.
 version() ->
     {ok, Vsn} = application:get_key(rebar, vsn),
-    ?CONSOLE("rebar ~s on Erlang/OTP ~s Erts ~s",
+    ?CONSOLE("rebar ~ts on Erlang/OTP ~ts Erts ~ts",
              [Vsn, erlang:system_info(otp_release), erlang:system_info(version)]).
 
 %% @private set global flag based on getopt option boolean value
@@ -311,11 +311,11 @@ handle_error({error, {Module, Reason}}) ->
             ?DEBUG("Uncaught error: ~p ~p", [Module, Reason]),
             ?INFO("When submitting a bug report, please include the output of `rebar3 report \"your command\"`", []);
         _ ->
-            ?ERROR("~s", [Module:format_error(Reason)])
+            ?ERROR("~ts", [Module:format_error(Reason)])
     end,
     erlang:halt(1);
 handle_error({error, Error}) when is_list(Error) ->
-    ?ERROR("~s", [Error]),
+    ?ERROR("~ts", [Error]),
     erlang:halt(1);
 handle_error(Error) ->
     %% Nothing should percolate up from rebar_core;

--- a/src/rebar_agent.erl
+++ b/src/rebar_agent.erl
@@ -157,7 +157,7 @@ refresh_paths(RState) ->
                 {ok, Mods} ->
                     case {length(Mods), length(Mods -- Blacklist)} of
                         {X,X} ->
-                            ?DEBUG("reloading ~p from ~s", [Modules, Path]),
+                            ?DEBUG("reloading ~p from ~ts", [Modules, Path]),
                             code:replace_path(App, Path),
                             reload_modules(Modules);
                         {_,_} ->

--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -60,7 +60,7 @@ do(State, LibDirs) ->
                                 rebar_state:project_apps(StateAcc1
                                                         ,rebar_app_info:deps(AppInfo2, ProjectDeps1));
                             false ->
-                                ?INFO("Ignoring ~s", [Name]),
+                                ?INFO("Ignoring ~ts", [Name]),
                                 StateAcc
                         end
                 end, State1, SortedApps).
@@ -233,7 +233,7 @@ app_dirs(LibDir, SrcDirs) ->
     EbinPath = filename:join([LibDir, "ebin", "*.app"]),
 
     lists:usort(lists:foldl(fun(Path, Acc) ->
-                                Files = filelib:wildcard(ec_cnv:to_list(Path)),
+                                Files = filelib:wildcard(rebar_utils:to_list(Path)),
                                 [{app_dir(File), SrcDirs}
                                  || File <- Files] ++ Acc
                             end, [], [EbinPath | Paths])).
@@ -386,7 +386,7 @@ try_handle_app_file(AppInfo0, [File], AppDir, AppSrcFile, _, Validate) ->
             end
     catch
         throw:{error, {Module, Reason}} ->
-            ?DEBUG("Falling back to app.src file because .app failed: ~s", [Module:format_error(Reason)]),
+            ?DEBUG("Falling back to app.src file because .app failed: ~ts", [Module:format_error(Reason)]),
             try_handle_app_src_file(AppInfo0, File, AppDir, AppSrcFile, Validate)
     end;
 try_handle_app_file(_AppInfo, Other, _AppDir, _AppSrcFile, _, _Validate) ->

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -107,43 +107,43 @@ new() ->
 -spec new(atom() | binary() | string()) ->
                  {ok, t()}.
 new(AppName) ->
-    {ok, #app_info_t{name=ec_cnv:to_binary(AppName)}}.
+    {ok, #app_info_t{name=rebar_utils:to_binary(AppName)}}.
 
 %% @doc Build a new app info value with only the name and version set.
 -spec new(atom() | binary() | string(), binary() | string()) ->
                  {ok, t()}.
 new(AppName, Vsn) ->
-    {ok, #app_info_t{name=ec_cnv:to_binary(AppName),
+    {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
                      original_vsn=Vsn}}.
 
 %% @doc build a complete version of the app info with all fields set.
 -spec new(atom() | binary() | string(), binary() | string(), file:name()) ->
                  {ok, t()}.
 new(AppName, Vsn, Dir) ->
-    {ok, #app_info_t{name=ec_cnv:to_binary(AppName),
+    {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
                      original_vsn=Vsn,
-                     dir=ec_cnv:to_list(Dir),
-                     out_dir=ec_cnv:to_list(Dir)}}.
+                     dir=rebar_utils:to_list(Dir),
+                     out_dir=rebar_utils:to_list(Dir)}}.
 
 %% @doc build a complete version of the app info with all fields set.
 -spec new(atom() | binary() | string(), binary() | string(), file:name(), list()) ->
                  {ok, t()}.
 new(AppName, Vsn, Dir, Deps) ->
-    {ok, #app_info_t{name=ec_cnv:to_binary(AppName),
+    {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
                      original_vsn=Vsn,
-                     dir=ec_cnv:to_list(Dir),
-                     out_dir=ec_cnv:to_list(Dir),
+                     dir=rebar_utils:to_list(Dir),
+                     out_dir=rebar_utils:to_list(Dir),
                      deps=Deps}}.
 
 %% @doc build a complete version of the app info with all fields set.
 -spec new(atom() | binary(), atom() | binary() | string(), binary() | string(), file:name(), list()) ->
                  {ok, t()}.
 new(Parent, AppName, Vsn, Dir, Deps) ->
-    {ok, #app_info_t{name=ec_cnv:to_binary(AppName),
+    {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
                      parent=Parent,
                      original_vsn=Vsn,
-                     dir=ec_cnv:to_list(Dir),
-                     out_dir=ec_cnv:to_list(Dir),
+                     dir=rebar_utils:to_list(Dir),
+                     out_dir=rebar_utils:to_list(Dir),
                      deps=Deps}}.
 
 %% @doc update the opts based on the contents of a config
@@ -199,7 +199,7 @@ name(#app_info_t{name=Name}) ->
 %% @doc set the name of the app.
 -spec name(t(), atom() | binary() | string()) -> t().
 name(AppInfo=#app_info_t{}, AppName) ->
-    AppInfo#app_info_t{name=ec_cnv:to_binary(AppName)}.
+    AppInfo#app_info_t{name=rebar_utils:to_binary(AppName)}.
 
 %% @doc get the dictionary of options for the app.
 -spec opts(t()) -> rebar_dict().
@@ -249,14 +249,14 @@ set(AppInfo=#app_info_t{opts=Opts}, Key, Value) ->
 %% @doc finds the .app.src file for an app, if any.
 -spec app_file_src(t()) -> file:filename_all() | undefined.
 app_file_src(#app_info_t{app_file_src=undefined, dir=Dir, name=Name, opts=Opts}) ->
-    CandidatePaths = [filename:join([ec_cnv:to_list(Dir), Src, ec_cnv:to_list(Name)++".app.src"])
+    CandidatePaths = [filename:join([rebar_utils:to_list(Dir), Src, rebar_utils:to_list(Name)++".app.src"])
                       || Src <- rebar_opts:get(Opts, src_dirs, ["src"])],
     case lists:dropwhile(fun(Path) -> not filelib:is_file(Path) end, CandidatePaths) of
         [] -> undefined;
         [AppFileSrc|_] -> AppFileSrc
     end;
 app_file_src(#app_info_t{app_file_src=AppFileSrc}) ->
-    ec_cnv:to_list(AppFileSrc).
+    rebar_utils:to_list(AppFileSrc).
 
 %% @doc sets the .app.src file for an app. An app without such a file
 %% can explicitly be set with `undefined'.
@@ -264,12 +264,12 @@ app_file_src(#app_info_t{app_file_src=AppFileSrc}) ->
 app_file_src(AppInfo=#app_info_t{}, undefined) ->
     AppInfo#app_info_t{app_file_src=undefined};
 app_file_src(AppInfo=#app_info_t{}, AppFileSrc) ->
-    AppInfo#app_info_t{app_file_src=ec_cnv:to_list(AppFileSrc)}.
+    AppInfo#app_info_t{app_file_src=rebar_utils:to_list(AppFileSrc)}.
 
 %% @doc finds the .app.src.script file for an app, if any.
 -spec app_file_src_script(t()) -> file:filename_all() | undefined.
 app_file_src_script(#app_info_t{app_file_src_script=undefined, dir=Dir, name=Name}) ->
-    AppFileSrcScript = filename:join([ec_cnv:to_list(Dir), "src", ec_cnv:to_list(Name)++".app.src.script"]),
+    AppFileSrcScript = filename:join([rebar_utils:to_list(Dir), "src", rebar_utils:to_list(Name)++".app.src.script"]),
     case filelib:is_file(AppFileSrcScript) of
         true ->
             AppFileSrcScript;
@@ -277,7 +277,7 @@ app_file_src_script(#app_info_t{app_file_src_script=undefined, dir=Dir, name=Nam
             undefined
     end;
 app_file_src_script(#app_info_t{app_file_src_script=AppFileSrcScript}) ->
-    ec_cnv:to_list(AppFileSrcScript).
+    rebar_utils:to_list(AppFileSrcScript).
 
 %% @doc sets the .app.src.script file for an app. An app without such a file
 %% can explicitly be set with `undefined'.
@@ -285,12 +285,12 @@ app_file_src_script(#app_info_t{app_file_src_script=AppFileSrcScript}) ->
 app_file_src_script(AppInfo=#app_info_t{}, undefined) ->
     AppInfo#app_info_t{app_file_src_script=undefined};
 app_file_src_script(AppInfo=#app_info_t{}, AppFileSrcScript) ->
-    AppInfo#app_info_t{app_file_src_script=ec_cnv:to_list(AppFileSrcScript)}.
+    AppInfo#app_info_t{app_file_src_script=rebar_utils:to_list(AppFileSrcScript)}.
 
 %% @doc finds the .app file for an app, if any.
 -spec app_file(t()) -> file:filename_all() | undefined.
 app_file(#app_info_t{app_file=undefined, out_dir=Dir, name=Name}) ->
-    AppFile = filename:join([ec_cnv:to_list(Dir), "ebin", ec_cnv:to_list(Name)++".app"]),
+    AppFile = filename:join([rebar_utils:to_list(Dir), "ebin", rebar_utils:to_list(Name)++".app"]),
     case filelib:is_file(AppFile) of
         true ->
             AppFile;
@@ -317,7 +317,7 @@ app_details(AppInfo=#app_info_t{app_details=[]}) ->
                 rebar_file_utils:try_consult(AppFile)
             catch
                 throw:{error, {Module, Reason}} ->
-                    ?DEBUG("Warning, falling back to .app.src because of: ~s",
+                    ?DEBUG("Warning, falling back to .app.src because of: ~ts",
                           [Module:format_error(Reason)]),
                     rebar_file_utils:try_consult(app_file_src(AppInfo))
             end
@@ -404,10 +404,10 @@ dir(#app_info_t{dir=Dir}) ->
 %% @doc sets the directory that contains the app.
 -spec dir(t(), file:name()) -> t().
 dir(AppInfo=#app_info_t{out_dir=undefined}, Dir) ->
-    AppInfo#app_info_t{dir=ec_cnv:to_list(Dir),
-                       out_dir=ec_cnv:to_list(Dir)};
+    AppInfo#app_info_t{dir=rebar_utils:to_list(Dir),
+                       out_dir=rebar_utils:to_list(Dir)};
 dir(AppInfo=#app_info_t{}, Dir) ->
-    AppInfo#app_info_t{dir=ec_cnv:to_list(Dir)}.
+    AppInfo#app_info_t{dir=rebar_utils:to_list(Dir)}.
 
 %% @doc returns the directory where build artifacts for the app
 %% should go
@@ -419,17 +419,17 @@ out_dir(#app_info_t{out_dir=OutDir}) ->
 %% should go
 -spec out_dir(t(), file:name()) -> t().
 out_dir(AppInfo=#app_info_t{}, OutDir) ->
-    AppInfo#app_info_t{out_dir=ec_cnv:to_list(OutDir)}.
+    AppInfo#app_info_t{out_dir=rebar_utils:to_list(OutDir)}.
 
 %% @doc gets the directory where ebin files for the app should go
 -spec ebin_dir(t()) -> file:name().
 ebin_dir(#app_info_t{out_dir=OutDir}) ->
-    ec_cnv:to_list(filename:join(OutDir, "ebin")).
+    rebar_utils:to_list(filename:join(OutDir, "ebin")).
 
 %% @doc gets the directory where private files for the app should go
 -spec priv_dir(t()) -> file:name().
 priv_dir(#app_info_t{out_dir=OutDir}) ->
-    ec_cnv:to_list(filename:join(OutDir, "priv")).
+    rebar_utils:to_list(filename:join(OutDir, "priv")).
 
 %% @doc returns whether the app is source app or a package app.
 -spec resource_type(t()) -> pkg | src.
@@ -519,7 +519,7 @@ all(Dir, Context, [File|Artifacts]) ->
     FilePath = filename:join(Dir, rebar_templater:render(File, Context)),
     case filelib:is_regular(FilePath) of
         false ->
-            ?DEBUG("Missing artifact ~s", [FilePath]),
+            ?DEBUG("Missing artifact ~ts", [FilePath]),
             {false, File};
         true ->
             all(Dir, Context, Artifacts)

--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -199,15 +199,15 @@ compile_each([], _Config, _CompileFn) ->
 compile_each([Source | Rest], Config, CompileFn) ->
     case CompileFn(Source, Config) of
         ok ->
-            ?DEBUG("~sCompiled ~s", [rebar_utils:indent(1), filename:basename(Source)]);
+            ?DEBUG("~tsCompiled ~ts", [rebar_utils:indent(1), filename:basename(Source)]);
         {ok, Warnings} ->
             report(Warnings),
-            ?DEBUG("~sCompiled ~s", [rebar_utils:indent(1), filename:basename(Source)]);
+            ?DEBUG("~tsCompiled ~ts", [rebar_utils:indent(1), filename:basename(Source)]);
         skipped ->
-            ?DEBUG("~sSkipped ~s", [rebar_utils:indent(1), filename:basename(Source)]);
+            ?DEBUG("~tsSkipped ~ts", [rebar_utils:indent(1), filename:basename(Source)]);
         Error ->
             NewSource = format_error_source(Source, Config),
-            ?ERROR("Compiling ~s failed", [NewSource]),
+            ?ERROR("Compiling ~ts failed", [NewSource]),
             maybe_report(Error),
             ?DEBUG("Compilation failed: ~p", [Error]),
             ?FAIL
@@ -258,7 +258,7 @@ maybe_report(_) ->
 %% @private Outputs a bunch of strings, including a newline
 -spec report([string()]) -> ok.
 report(Messages) ->
-    lists:foreach(fun(Msg) -> io:format("~s~n", [Msg]) end, Messages).
+    lists:foreach(fun(Msg) -> io:format("~ts~n", [Msg]) end, Messages).
 
 %% private format compiler errors into proper outputtable strings
 -spec format_errors(_, Extra, [err_or_warn()]) -> [string()] when
@@ -274,10 +274,10 @@ format_errors(_MainSource, Extra, Errors) ->
       Extra :: string().
 format_error(Source, Extra, {{Line, Column}, Mod, Desc}) ->
     ErrorDesc = Mod:format_error(Desc),
-    ?FMT("~s:~w:~w: ~s~s~n", [Source, Line, Column, Extra, ErrorDesc]);
+    ?FMT("~ts:~w:~w: ~ts~ts~n", [Source, Line, Column, Extra, ErrorDesc]);
 format_error(Source, Extra, {Line, Mod, Desc}) ->
     ErrorDesc = Mod:format_error(Desc),
-    ?FMT("~s:~w: ~s~s~n", [Source, Line, Extra, ErrorDesc]);
+    ?FMT("~ts:~w: ~ts~ts~n", [Source, Line, Extra, ErrorDesc]);
 format_error(Source, Extra, {Mod, Desc}) ->
     ErrorDesc = Mod:format_error(Desc),
-    ?FMT("~s: ~s~s~n", [Source, Extra, ErrorDesc]).
+    ?FMT("~ts: ~ts~ts~n", [Source, Extra, ErrorDesc]).

--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -120,7 +120,7 @@ write_lock_file(LockFile, Locks) ->
             file:write_file(LockFile, io_lib:format("~p.~n", [NewLocks]));
         _ ->
             file:write_file(LockFile,
-                            io_lib:format("{~p,~n~p}.~n[~n~s~n].~n",
+                            io_lib:format("{~p,~n~p}.~n[~n~ts~n].~n",
                                           [?CONFIG_VERSION, NewLocks,
                                            format_attrs(Attrs)]))
     end.
@@ -359,7 +359,7 @@ check_newly_added_({Name, Source}, LockedDeps) ->
             false
     end;
 check_newly_added_(Dep, LockedDeps) when is_atom(Dep) ->
-    Name = ec_cnv:to_binary(Dep),
+    Name = rebar_utils:to_binary(Dep),
     case lists:keyfind(Name, 1, LockedDeps) of
         false ->
             {true, Name};
@@ -368,8 +368,8 @@ check_newly_added_(Dep, LockedDeps) when is_atom(Dep) ->
                 0 ->
                     {true, Name};
                 _ ->
-                    ?WARN("Newly added dep ~s is locked at a lower level. "
-                          "If you really want to unlock it, use 'rebar3 upgrade ~s'",
+                    ?WARN("Newly added dep ~ts is locked at a lower level. "
+                          "If you really want to unlock it, use 'rebar3 upgrade ~ts'",
                           [Name, Name]),
                     false
             end

--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -119,11 +119,11 @@ process_command(State, Command) ->
                             State2 = rebar_state:command_parsed_args(State1, Args),
                             do(TargetProviders, State2);
                         {error, {invalid_option, Option}} ->
-                            {error, io_lib:format("Invalid option ~s on task ~p", [Option, Command])};
+                            {error, io_lib:format("Invalid option ~ts on task ~p", [Option, Command])};
                         {error, {invalid_option_arg, {Option, Arg}}} ->
-                            {error, io_lib:format("Invalid argument ~s to option ~s", [Arg, Option])};
+                            {error, io_lib:format("Invalid argument ~ts to option ~ts", [Arg, Option])};
                         {error, {missing_option_arg, Option}} ->
-                            {error, io_lib:format("Missing argument to option ~s", [Option])}
+                            {error, io_lib:format("Missing argument to option ~ts", [Option])}
                     end
             end
     end.
@@ -173,6 +173,6 @@ do([ProviderName | Rest], State) ->
 %% @doc convert a given exception's payload into an io description.
 -spec format_error(any()) -> iolist().
 format_error({bad_provider_namespace, {Namespace, Name}}) ->
-    io_lib:format("Undefined command ~s in namespace ~s", [Name, Namespace]);
+    io_lib:format("Undefined command ~ts in namespace ~ts", [Name, Namespace]);
 format_error({bad_provider_namespace, Name}) ->
-    io_lib:format("Undefined command ~s", [Name]).
+    io_lib:format("Undefined command ~ts", [Name]).

--- a/src/rebar_dialyzer_format.erl
+++ b/src/rebar_dialyzer_format.erl
@@ -31,7 +31,7 @@ format_warnings(Opts, Warnings) ->
 format_warning_(_Opts, Warning = {_Tag, {File, Line}, Msg}, {File, Acc}) ->
     try
         String = message_to_string(Msg),
-        {File, [lists:flatten(fmt("~!c~4w~!!: ~s", [Line, String])) | Acc]}
+        {File, [lists:flatten(fmt("~!c~4w~!!: ~ts", [Line, String])) | Acc]}
     catch
         Error:Reason ->
             ?DEBUG("Failed to pretty format warning: ~p:~p",
@@ -47,11 +47,11 @@ format_warning_(Opts, Warning = {_Tag, {SrcFile, Line}, Msg}, {_LastFile, Acc}) 
         Dir = filename:dirname(File),
         Root = filename:rootname(Base),
         Ext = filename:extension(Base),
-        Path = re:replace(Dir, "^.*/_build/", "_build/", [{return, list}]),
-        Base1 = fmt("~!_c~s~!!~!__~s", [Root, Ext]),
-        F = fmt("~!__~s", [filename:join(Path, Base1)]),
+        Path = re:replace(Dir, "^.*/_build/", "_build/", [{return, list}, unicode]),
+        Base1 = fmt("~!_c~ts~!!~!__~ts", [Root, Ext]),
+        F = fmt("~!__~ts", [filename:join(Path, Base1)]),
         String = message_to_string(Msg),
-        {SrcFile, [lists:flatten(fmt("~n~s~n~!c~4w~!!: ~s", [F, Line, String])) | Acc]}
+        {SrcFile, [lists:flatten(fmt("~n~ts~n~!c~4w~!!: ~ts", [F, Line, String])) | Acc]}
     catch
         Error:Reason ->
             ?DEBUG("Failed to pretty format warning: ~p:~p~n~p",
@@ -72,53 +72,53 @@ fmt(Fmt, Args) ->
 %%----- Warnings for general discrepancies ----------------
 message_to_string({apply, [Args, ArgNs, FailReason,
                            SigArgs, SigRet, Contract]}) ->
-    fmt("~!^Fun application with arguments ~!!~s ",
+    fmt("~!^Fun application with arguments ~!!~ts ",
         [bad_arg(ArgNs, Args)]) ++
         call_or_apply_to_string(ArgNs, FailReason, SigArgs, SigRet, Contract);
 message_to_string({app_call, [M, F, Args, Culprit, ExpectedType, FoundType]}) ->
-    fmt("~!^The call~!! ~s:~s~s ~!^requires that"
-        "~!! ~s ~!^is of type ~!g~s~!^ not ~!r~s",
+    fmt("~!^The call~!! ~ts:~ts~ts ~!^requires that"
+        "~!! ~ts ~!^is of type ~!g~ts~!^ not ~!r~ts",
         [M, F, Args, Culprit, ExpectedType, FoundType]);
 message_to_string({bin_construction, [Culprit, Size, Seg, Type]}) ->
-    fmt("~!^Binary construction will fail since the ~!b~s~!^ field~!!"
-        " ~s~!^ in segment~!! ~s~!^ has type~!! ~s",
+    fmt("~!^Binary construction will fail since the ~!b~ts~!^ field~!!"
+        " ~ts~!^ in segment~!! ~ts~!^ has type~!! ~ts",
         [Culprit, Size, Seg, Type]);
 message_to_string({call, [M, F, Args, ArgNs, FailReason,
                           SigArgs, SigRet, Contract]}) ->
-    fmt("~!^The call~!! ~w:~w~s ", [M, F, bad_arg(ArgNs, Args)]) ++
+    fmt("~!^The call~!! ~w:~w~ts ", [M, F, bad_arg(ArgNs, Args)]) ++
         call_or_apply_to_string(ArgNs, FailReason, SigArgs, SigRet, Contract);
 message_to_string({call_to_missing, [M, F, A]}) ->
     fmt("~!^Call to missing or unexported function ~!!~w:~w/~w",
         [M, F, A]);
 message_to_string({exact_eq, [Type1, Op, Type2]}) ->
-    fmt("~!^The test ~!!~s ~s ~s~!^ can never evaluate to 'true'",
+    fmt("~!^The test ~!!~ts ~ts ~ts~!^ can never evaluate to 'true'",
         [Type1, Op, Type2]);
 message_to_string({fun_app_args, [Args, Type]}) ->
-    fmt("~!^Fun application with arguments ~!!~s~!^ will fail"
-        " since the function has type ~!!~s", [Args, Type]);
+    fmt("~!^Fun application with arguments ~!!~ts~!^ will fail"
+        " since the function has type ~!!~ts", [Args, Type]);
 message_to_string({fun_app_no_fun, [Op, Type, Arity]}) ->
-    fmt("~!^Fun application will fail since ~!!~s ~!^::~!! ~s"
+    fmt("~!^Fun application will fail since ~!!~ts ~!^::~!! ~ts"
         " is not a function of arity ~!!~w", [Op, Type, Arity]);
 message_to_string({guard_fail, []}) ->
     "~!^Clause guard cannot succeed.~!!";
 message_to_string({guard_fail, [Arg1, Infix, Arg2]}) ->
-    fmt("~!^Guard test ~!!~s ~s ~s~!^ can never succeed",
+    fmt("~!^Guard test ~!!~ts ~ts ~ts~!^ can never succeed",
         [Arg1, Infix, Arg2]);
 message_to_string({neg_guard_fail, [Arg1, Infix, Arg2]}) ->
-    fmt("~!^Guard test not(~!!~s ~s ~s~!^) can never succeed",
+    fmt("~!^Guard test not(~!!~ts ~ts ~ts~!^) can never succeed",
         [Arg1, Infix, Arg2]);
 message_to_string({guard_fail, [Guard, Args]}) ->
-    fmt("~!^Guard test ~!!~w~s~!^ can never succeed",
+    fmt("~!^Guard test ~!!~w~ts~!^ can never succeed",
         [Guard, Args]);
 message_to_string({neg_guard_fail, [Guard, Args]}) ->
-    fmt("~!^Guard test not(~!!~w~s~!^) can never succeed",
+    fmt("~!^Guard test not(~!!~w~ts~!^) can never succeed",
         [Guard, Args]);
 message_to_string({guard_fail_pat, [Pat, Type]}) ->
-    fmt("~!^Clause guard cannot succeed. The ~!!~s~!^ was matched"
-        " against the type ~!!~s", [Pat, Type]);
+    fmt("~!^Clause guard cannot succeed. The ~!!~ts~!^ was matched"
+        " against the type ~!!~ts", [Pat, Type]);
 message_to_string({improper_list_constr, [TlType]}) ->
     fmt("~!^Cons will produce an improper list"
-        " since its ~!b2~!!nd~!^ argument is~!! ~s", [TlType]);
+        " since its ~!b2~!!nd~!^ argument is~!! ~ts", [TlType]);
 message_to_string({no_return, [Type|Name]}) ->
     NameString =
         case Name of
@@ -126,59 +126,59 @@ message_to_string({no_return, [Type|Name]}) ->
             [F, A] -> fmt("~!^Function ~!r~w/~w ", [F, A])
         end,
     case Type of
-        no_match -> fmt("~s~!^has no clauses that will ever match",[NameString]);
-        only_explicit -> fmt("~s~!^only terminates with explicit exception", [NameString]);
-        only_normal -> fmt("~s~!^has no local return", [NameString]);
-        both -> fmt("~s~!^has no local return", [NameString])
+        no_match -> fmt("~ts~!^has no clauses that will ever match",[NameString]);
+        only_explicit -> fmt("~ts~!^only terminates with explicit exception", [NameString]);
+        only_normal -> fmt("~ts~!^has no local return", [NameString]);
+        both -> fmt("~ts~!^has no local return", [NameString])
     end;
 message_to_string({record_constr, [RecConstr, FieldDiffs]}) ->
-    fmt("~!^Record construction ~!!~s~!^ violates the"
-        " declared type of field ~!!~s", [RecConstr, FieldDiffs]);
+    fmt("~!^Record construction ~!!~ts~!^ violates the"
+        " declared type of field ~!!~ts", [RecConstr, FieldDiffs]);
 message_to_string({record_constr, [Name, Field, Type]}) ->
     fmt("~!^Record construction violates the declared type for ~!!#~w{}~!^"
-        " since ~!!~s~!^ cannot be of type ~!!~s",
+        " since ~!!~ts~!^ cannot be of type ~!!~ts",
         [Name, Field, Type]);
 message_to_string({record_matching, [String, Name]}) ->
-    fmt("~!^The ~!!~s~!^ violates the"
+    fmt("~!^The ~!!~ts~!^ violates the"
         " declared type for ~!!#~w{}", [String, Name]);
 message_to_string({record_match, [Pat, Type]}) ->
-    fmt("~!^Matching of ~!!~s~!^ tagged with a record name violates the"
-        " declared type of ~!!~s", [Pat, Type]);
+    fmt("~!^Matching of ~!!~ts~!^ tagged with a record name violates the"
+        " declared type of ~!!~ts", [Pat, Type]);
 message_to_string({pattern_match, [Pat, Type]}) ->
-    fmt("~!^The ~s~!^ can never match the type ~!g~s",
+    fmt("~!^The ~ts~!^ can never match the type ~!g~ts",
         [bad_pat(Pat), Type]);
 message_to_string({pattern_match_cov, [Pat, Type]}) ->
-    fmt("~!^The ~s~!^ can never match since previous"
-        " clauses completely covered the type ~!g~s",
+    fmt("~!^The ~ts~!^ can never match since previous"
+        " clauses completely covered the type ~!g~ts",
         [bad_pat(Pat), Type]);
 message_to_string({unmatched_return, [Type]}) ->
-    fmt("~!^Expression produces a value of type ~!!~s~!^,"
+    fmt("~!^Expression produces a value of type ~!!~ts~!^,"
         " but this value is unmatched", [Type]);
 message_to_string({unused_fun, [F, A]}) ->
     fmt("~!^Function ~!r~w/~w~!!~!^ will never be called", [F, A]);
 %%----- Warnings for specs and contracts -------------------
 message_to_string({contract_diff, [M, F, _A, Contract, Sig]}) ->
-    fmt("~!^Type specification ~!!~w:~w~s~!^"
-        " is not equal to the success typing: ~!!~w:~w~s",
+    fmt("~!^Type specification ~!!~w:~w~ts~!^"
+        " is not equal to the success typing: ~!!~w:~w~ts",
         [M, F, Contract, M, F, Sig]);
 message_to_string({contract_subtype, [M, F, _A, Contract, Sig]}) ->
-    fmt("~!^Type specification ~!!~w:~w~s~!^"
-        " is a subtype of the success typing: ~!!~w:~w~s",
+    fmt("~!^Type specification ~!!~w:~w~ts~!^"
+        " is a subtype of the success typing: ~!!~w:~w~ts",
         [M, F, Contract, M, F, Sig]);
 message_to_string({contract_supertype, [M, F, _A, Contract, Sig]}) ->
-    fmt("~!^Type specification ~!!~w:~w~s~!^"
-        " is a supertype of the success typing: ~!!~w:~w~s",
+    fmt("~!^Type specification ~!!~w:~w~ts~!^"
+        " is a supertype of the success typing: ~!!~w:~w~ts",
         [M, F, Contract, M, F, Sig]);
 message_to_string({contract_range, [Contract, M, F, ArgStrings, Line, CRet]}) ->
-    fmt("~!^The contract ~!!~w:~w~s~!^ cannot be right because the"
-        " inferred return for ~!!~w~s~!^ on line ~!!~w~!^ is ~!!~s",
+    fmt("~!^The contract ~!!~w:~w~ts~!^ cannot be right because the"
+        " inferred return for ~!!~w~ts~!^ on line ~!!~w~!^ is ~!!~ts",
         [M, F, Contract, F, ArgStrings, Line, CRet]);
 message_to_string({invalid_contract, [M, F, A, Sig]}) ->
     fmt("~!^Invalid type specification for function~!! ~w:~w/~w."
-        "~!^ The success typing is~!! ~s", [M, F, A, Sig]);
+        "~!^ The success typing is~!! ~ts", [M, F, A, Sig]);
 message_to_string({extra_range, [M, F, A, ExtraRanges, SigRange]}) ->
     fmt("~!^The specification for ~!!~w:~w/~w~!^ states that the function"
-        " might also return ~!!~s~!^ but the inferred return is ~!!~s",
+        " might also return ~!!~ts~!^ but the inferred return is ~!!~ts",
         [M, F, A, ExtraRanges, SigRange]);
 message_to_string({overlapping_contract, [M, F, A]}) ->
     fmt("~!^Overloaded contract for ~!!~w:~w/~w~!^ has overlapping"
@@ -189,62 +189,62 @@ message_to_string({spec_missing_fun, [M, F, A]}) ->
         [M, F, A]);
 %%----- Warnings for opaque type violations -------------------
 message_to_string({call_with_opaque, [M, F, Args, ArgNs, ExpArgs]}) ->
-    fmt("~!^The call ~!!~w:~w~s~!^ contains ~!!~s~!^ when ~!!~s",
+    fmt("~!^The call ~!!~w:~w~ts~!^ contains ~!!~ts~!^ when ~!!~ts",
         [M, F, bad_arg(ArgNs, Args), form_positions(ArgNs), form_expected(ExpArgs)]);
 message_to_string({call_without_opaque, [M, F, Args, [{N,_,_}|_] = ExpectedTriples]}) ->
-    fmt("~!^The call ~!!~w:~w~s ~!^does not have~!! ~s",
+    fmt("~!^The call ~!!~w:~w~ts ~!^does not have~!! ~ts",
         [M, F, bad_arg(N, Args), form_expected_without_opaque(ExpectedTriples)]);
 message_to_string({opaque_eq, [Type, _Op, OpaqueType]}) ->
-    fmt("~!^Attempt to test for equality between a term of type ~!!~s~!^"
-        " and a term of opaque type ~!!~s", [Type, OpaqueType]);
+    fmt("~!^Attempt to test for equality between a term of type ~!!~ts~!^"
+        " and a term of opaque type ~!!~ts", [Type, OpaqueType]);
 message_to_string({opaque_guard, [Arg1, Infix, Arg2, ArgNs]}) ->
-    fmt("~!^Guard test ~!!~s ~s ~s~!^ contains ~!!~s",
+    fmt("~!^Guard test ~!!~ts ~ts ~ts~!^ contains ~!!~ts",
         [Arg1, Infix, Arg2, form_positions(ArgNs)]);
 message_to_string({opaque_guard, [Guard, Args]}) ->
-    fmt("~!^Guard test ~!!~w~s~!^ breaks the opaqueness of its"
+    fmt("~!^Guard test ~!!~w~ts~!^ breaks the opaqueness of its"
         " argument", [Guard, Args]);
 message_to_string({opaque_match, [Pat, OpaqueType, OpaqueTerm]}) ->
     Term = if OpaqueType =:= OpaqueTerm -> "the term";
               true -> OpaqueTerm
            end,
-    fmt("~!^The attempt to match a term of type ~!!~s~!^ against the"
-        "~!! ~s~!^ breaks the opaqueness of ~!!~s",
+    fmt("~!^The attempt to match a term of type ~!!~ts~!^ against the"
+        "~!! ~ts~!^ breaks the opaqueness of ~!!~ts",
         [OpaqueType, Pat, Term]);
 message_to_string({opaque_neq, [Type, _Op, OpaqueType]}) ->
-    fmt("~!^Attempt to test for inequality between a term of type ~!!~s"
-        "~!^ and a term of opaque type ~!!~s", [Type, OpaqueType]);
+    fmt("~!^Attempt to test for inequality between a term of type ~!!~ts"
+        "~!^ and a term of opaque type ~!!~ts", [Type, OpaqueType]);
 message_to_string({opaque_type_test, [Fun, Args, Arg, ArgType]}) ->
-    fmt("~!^The type test ~!!~s~s~!^ breaks the opaqueness of the term "
-        "~!!~s~s", [Fun, Args, Arg, ArgType]);
+    fmt("~!^The type test ~!!~ts~ts~!^ breaks the opaqueness of the term "
+        "~!!~ts~ts", [Fun, Args, Arg, ArgType]);
 message_to_string({opaque_size, [SizeType, Size]}) ->
-    fmt("~!^The size ~!!~s~!^ breaks the opaqueness of ~!!~s",
+    fmt("~!^The size ~!!~ts~!^ breaks the opaqueness of ~!!~ts",
         [SizeType, Size]);
 message_to_string({opaque_call, [M, F, Args, Culprit, OpaqueType]}) ->
-    fmt("~!^The call ~!!~s:~s~s~!^ breaks the opaqueness of the term~!!"
-        " ~s :: ~s", [M, F, Args, Culprit, OpaqueType]);
+    fmt("~!^The call ~!!~ts:~ts~ts~!^ breaks the opaqueness of the term~!!"
+        " ~ts :: ~ts", [M, F, Args, Culprit, OpaqueType]);
 %%----- Warnings for concurrency errors --------------------
 message_to_string({race_condition, [M, F, Args, Reason]}) ->
-    fmt("~!^The call ~!!~w:~w~s ~s", [M, F, Args, Reason]);
+    fmt("~!^The call ~!!~w:~w~ts ~ts", [M, F, Args, Reason]);
 %%----- Warnings for behaviour errors --------------------
 message_to_string({callback_type_mismatch, [B, F, A, ST, CT]}) ->
-    fmt("~!^The inferred return type of~!! ~w/~w (~s) ~!^"
-        "has nothing in common with~!! ~s, ~!^which is the expected"
+    fmt("~!^The inferred return type of~!! ~w/~w (~ts) ~!^"
+        "has nothing in common with~!! ~ts, ~!^which is the expected"
         " return type for the callback of~!! ~w ~!^behaviour",
         [F, A, ST, CT, B]);
 message_to_string({callback_arg_type_mismatch, [B, F, A, N, ST, CT]}) ->
-    fmt("~!^The inferred type for the~!! ~s ~!^argument of~!!"
-        " ~w/~w (~s) ~!^is not a supertype of~!! ~s~!^, which is"
+    fmt("~!^The inferred type for the~!! ~ts ~!^argument of~!!"
+        " ~w/~w (~ts) ~!^is not a supertype of~!! ~ts~!^, which is"
         "expected type for this argument in the callback of the~!! ~w "
         "~!^behaviour",
         [ordinal(N), F, A, ST, CT, B]);
 message_to_string({callback_spec_type_mismatch, [B, F, A, ST, CT]}) ->
-    fmt("~!^The return type ~!!~s~!^ in the specification of ~!!"
-        "~w/~w~!^ is not a subtype of ~!!~s~!^, which is the expected"
+    fmt("~!^The return type ~!!~ts~!^ in the specification of ~!!"
+        "~w/~w~!^ is not a subtype of ~!!~ts~!^, which is the expected"
         " return type for the callback of ~!!~w~!^ behaviour",
         [ST, F, A, CT, B]);
 message_to_string({callback_spec_arg_type_mismatch, [B, F, A, N, ST, CT]}) ->
-    fmt("~!^The specified type for the ~!!~s~!^ argument of ~!!"
-        "~w/~w (~s)~!^ is not a supertype of ~!!~s~!^, which is"
+    fmt("~!^The specified type for the ~!!~ts~!^ argument of ~!!"
+        "~w/~w (~ts)~!^ is not a supertype of ~!!~ts~!^, which is"
         " expected type for this argument in the callback of the ~!!~w"
         "~!^ behaviour", [ordinal(N), F, A, ST, CT, B]);
 message_to_string({callback_missing, [B, F, A]}) ->
@@ -274,26 +274,26 @@ call_or_apply_to_string(ArgNs, FailReason, SigArgs, SigRet,
                 true ->
                     %% We do not know which argument(s) caused the failure
                     fmt("~!^will never return since the success typing arguments"
-                        " are ~!!~s", [SigArgs]);
+                        " are ~!!~ts", [SigArgs]);
                 false ->
                     fmt("~!^will never return since it differs in the~!!"
-                        " ~s ~!^argument from the success typing"
-                        " arguments:~!! ~s",
+                        " ~ts ~!^argument from the success typing"
+                        " arguments:~!! ~ts",
                         [PositionString, good_arg(ArgNs, SigArgs)])
             end;
         only_contract ->
             case (ArgNs =:= []) orelse IsOverloaded of
                 true ->
                     %% We do not know which arguments caused the failure
-                    fmt("~!^breaks the contract~!! ~s", [good_arg(ArgNs, Contract)]);
+                    fmt("~!^breaks the contract~!! ~ts", [good_arg(ArgNs, Contract)]);
                 false ->
-                    fmt("~!^breaks the contract~!! ~s ~!^in the~!!"
-                        " ~s ~!^argument",
+                    fmt("~!^breaks the contract~!! ~ts ~!^in the~!!"
+                        " ~ts ~!^argument",
                         [good_arg(ArgNs, Contract), PositionString])
             end;
         both ->
             fmt("~!^will never return since the success typing is "
-                "~!!~s ~!^->~!! ~s ~!^and the contract is ~!!~s",
+                "~!!~ts ~!^->~!! ~ts ~!^and the contract is ~!!~ts",
                 [good_arg(ArgNs, SigArgs), SigRet,
                  good_arg(ArgNs, Contract)])
     end.
@@ -301,8 +301,8 @@ call_or_apply_to_string(ArgNs, FailReason, SigArgs, SigRet,
 form_positions(ArgNs) ->
     ArgS = form_position_string(ArgNs),
     case ArgNs of
-        [_] ->     fmt("~!^an opaque term as ~!!~s~!^ argument", [ArgS]);
-        [_,_|_] -> fmt("~!^opaque terms as ~!!~s~!^ arguments", [ArgS])
+        [_] ->     fmt("~!^an opaque term as ~!!~ts~!^ argument", [ArgS]);
+        [_,_|_] -> fmt("~!^opaque terms as ~!!~ts~!^ arguments", [ArgS])
     end.
 
 %% We know which positions N are to blame;
@@ -310,9 +310,9 @@ form_positions(ArgNs) ->
 form_expected_without_opaque([{N, T, TStr}]) ->
     FStr = case erl_types:t_is_opaque(T) of
                true  ->
-                   "~!^an opaque term of type~!g ~s ~!^as ";
+                   "~!^an opaque term of type~!g ~ts ~!^as ";
                false ->
-                   "~!^a term of type ~!g~s ~!^(with opaque subterms) as "
+                   "~!^a term of type ~!g~ts ~!^(with opaque subterms) as "
            end ++ form_position_string([N]) ++ "~!^ argument",
     fmt(FStr, [TStr]);
 
@@ -325,9 +325,9 @@ form_expected(ExpectedArgs) ->
         [T] ->
             TS = erl_types:t_to_string(T),
             case erl_types:t_is_opaque(T) of
-                true  -> fmt("~!^an opaque term of type ~!!~s~!^ is"
+                true  -> fmt("~!^an opaque term of type ~!!~ts~!^ is"
                              " expected", [TS]);
-                false -> fmt("~!^a structured term of type ~!!~s~!^ is"
+                false -> fmt("~!^a structured term of type ~!!~ts~!^ is"
                              " expected", [TS])
             end;
         [_,_|_] -> fmt("~!^terms of different types are expected in these"
@@ -340,7 +340,7 @@ form_position_string(ArgNs) ->
         [N1] -> ordinal(N1);
         [_,_|_] ->
             [Last|Prevs] = lists:reverse(ArgNs),
-            ", " ++ Head = lists:flatten([fmt(", ~s",[ordinal(N)]) ||
+            ", " ++ Head = lists:flatten([fmt(", ~ts",[ordinal(N)]) ||
                                              N <- lists:reverse(Prevs)]),
             Head ++ " and " ++ ordinal(Last)
     end.
@@ -352,11 +352,11 @@ ordinal(N) when is_integer(N) -> fmt("~!B~w~!!th", [N]).
 
 %% Format a pattern ad highlight errorous part in red.
 bad_pat("pattern " ++ P) ->
-    fmt("pattern ~!r~s",[P]);
+    fmt("pattern ~!r~ts",[P]);
 bad_pat("variable " ++ P) ->
-    fmt("variable ~!r~s",[P]);
+    fmt("variable ~!r~ts",[P]);
 bad_pat(P) ->
-    fmt("~!r~s",[P]).
+    fmt("~!r~ts",[P]).
 
 
 bad_arg(N, Args) ->
@@ -378,10 +378,10 @@ highlight([], _N, _C, Rest) ->
     Rest;
 
 highlight([N | Nr], N, g, [Arg | Rest]) ->
-    [fmt("~!g~s", [Arg]) | highlight(Nr, N+1, g, Rest)];
+    [fmt("~!g~ts", [Arg]) | highlight(Nr, N+1, g, Rest)];
 
 highlight([N | Nr], N, r, [Arg | Rest]) ->
-    [fmt("~!r~s", [Arg]) | highlight(Nr, N+1, r, Rest)];
+    [fmt("~!r~ts", [Arg]) | highlight(Nr, N+1, r, Rest)];
 
 highlight(Ns, N, C, [Arg | Rest]) ->
     [Arg | highlight(Ns, N + 1, C, Rest)].

--- a/src/rebar_digraph.erl
+++ b/src/rebar_digraph.erl
@@ -53,9 +53,9 @@ add(Graph, {PkgName, Deps}) ->
     lists:foreach(fun(DepName) ->
                           Name1 = case DepName of
                                       {Name, _Vsn} ->
-                                          ec_cnv:to_binary(Name);
+                                          rebar_utils:to_binary(Name);
                                       Name ->
-                                          ec_cnv:to_binary(Name)
+                                          rebar_utils:to_binary(Name)
                                   end,
                           V3 = case digraph:vertex(Graph, Name1) of
                                    false ->

--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -41,7 +41,7 @@ base_dir(State) ->
 %% of profiles.
 -spec profile_dir(rebar_dict(), [atom()]) -> file:filename_all().
 profile_dir(Opts, Profiles) ->
-    {BaseDir, ProfilesStrings} = case [ec_cnv:to_list(P) || P <- Profiles] of
+    {BaseDir, ProfilesStrings} = case [rebar_utils:to_list(P) || P <- Profiles] of
         ["global" | _] -> {?MODULE:global_cache_dir(Opts), [""]};
         ["bootstrap", "default"] -> {rebar_opts:get(Opts, base_dir, ?DEFAULT_BASE_DIR), ["default"]};
         ["default"] -> {rebar_opts:get(Opts, base_dir, ?DEFAULT_BASE_DIR), ["default"]};
@@ -363,7 +363,7 @@ warn_source_format_once(Format) ->
             ok;
         true ->
             ?WARN("Invalid argument ~p for compiler_source_format - "
-                  "assuming ~s~n", [Format, ?DEFAULT_COMPILER_SOURCE_FORMAT])
+                  "assuming ~ts~n", [Format, ?DEFAULT_COMPILER_SOURCE_FORMAT])
     end.
 
 %% @private takes a filename and canonicalizes its path if it is a link.

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -92,7 +92,7 @@ compile(AppInfo) when element(1, AppInfo) == app_info_t ->
 %% @doc compile an individual application.
 -spec compile(rebar_app_info:t(), compile_opts()) -> ok.
 compile(AppInfo, CompileOpts) when element(1, AppInfo) == app_info_t ->
-    Dir = ec_cnv:to_list(rebar_app_info:out_dir(AppInfo)),
+    Dir = rebar_utils:to_list(rebar_app_info:out_dir(AppInfo)),
     RebarOpts = rebar_app_info:opts(AppInfo),
 
     SrcOpts = [check_last_mod,
@@ -237,8 +237,8 @@ clean(AppInfo) ->
 
     YrlFiles = rebar_utils:find_files(filename:join([AppDir, "src"]), ?RE_PREFIX".*\\.[x|y]rl\$"),
     rebar_file_utils:delete_each(
-      [ binary_to_list(iolist_to_binary(re:replace(F, "\\.[x|y]rl$", ".erl")))
-        || F <- YrlFiles ]),
+      [rebar_utils:to_list(re:replace(F, "\\.[x|y]rl$", ".erl", [unicode]))
+       || F <- YrlFiles]),
 
     BinDirs = ["ebin"|rebar_dir:extra_src_dirs(rebar_app_info:opts(AppInfo))],
     ok = clean_dirs(AppDir, BinDirs),
@@ -339,7 +339,7 @@ maybe_rm_beam_and_edge(G, OutDir, Source) ->
             false;
         false ->
             Target = target_base(OutDir, Source) ++ ".beam",
-            ?DEBUG("Source ~s is gone, deleting previous beam file if it exists ~s", [Source, Target]),
+            ?DEBUG("Source ~ts is gone, deleting previous beam file if it exists ~ts", [Source, Target]),
             file:delete(Target),
             digraph:del_vertex(G, Source),
             true
@@ -400,7 +400,7 @@ init_erlcinfo(InclDirs, Erls, Dir, OutDir) ->
     try restore_erlcinfo(G, InclDirs, Dir)
     catch
         _:_ ->
-            ?WARN("Failed to restore ~s file. Discarding it.~n", [erlcinfo_file(Dir)]),
+            ?WARN("Failed to restore ~ts file. Discarding it.~n", [erlcinfo_file(Dir)]),
             file:delete(erlcinfo_file(Dir))
     end,
     Dirs = source_and_include_dirs(InclDirs, Erls),

--- a/src/rebar_fetch.erl
+++ b/src/rebar_fetch.erl
@@ -41,7 +41,7 @@ download_source_(AppDir, Source, State) ->
     Resources = rebar_state:resources(State),
     Module = get_resource_type(Source, Resources),
     TmpDir = ec_file:insecure_mkdtemp(),
-    AppDir1 = ec_cnv:to_list(AppDir),
+    AppDir1 = rebar_utils:to_list(AppDir),
     case Module:download(TmpDir, Source, State) of
         {ok, _} ->
             ec_file:mkdir_p(AppDir1),
@@ -66,25 +66,25 @@ needs_update(AppDir, Source, State) ->
     end.
 
 format_error({bad_download, CachePath}) ->
-    io_lib:format("Download of package does not match md5sum from server: ~s", [CachePath]);
+    io_lib:format("Download of package does not match md5sum from server: ~ts", [CachePath]);
 format_error({unexpected_hash, CachePath, Expected, Found}) ->
-    io_lib:format("The checksum for package at ~s (~s) does not match the "
-                  "checksum previously locked (~s). Either unlock or "
+    io_lib:format("The checksum for package at ~ts (~ts) does not match the "
+                  "checksum previously locked (~ts). Either unlock or "
                   "upgrade the package, or make sure you fetched it from "
                   "the same index from which it was initially fetched.",
                   [CachePath, Found, Expected]);
 format_error({failed_extract, CachePath}) ->
-    io_lib:format("Failed to extract package: ~s", [CachePath]);
+    io_lib:format("Failed to extract package: ~ts", [CachePath]);
 format_error({bad_etag, Source}) ->
-    io_lib:format("MD5 Checksum comparison failed for: ~s", [Source]);
+    io_lib:format("MD5 Checksum comparison failed for: ~ts", [Source]);
 format_error({fetch_fail, Name, Vsn}) ->
-    io_lib:format("Failed to fetch and copy dep: ~s-~s", [Name, Vsn]);
+    io_lib:format("Failed to fetch and copy dep: ~ts-~ts", [Name, Vsn]);
 format_error({fetch_fail, Source}) ->
     io_lib:format("Failed to fetch and copy dep: ~p", [Source]);
 format_error({bad_checksum, File}) ->
-    io_lib:format("Checksum mismatch against tarball in ~s", [File]);
+    io_lib:format("Checksum mismatch against tarball in ~ts", [File]);
 format_error({bad_registry_checksum, File}) ->
-    io_lib:format("Checksum mismatch against registry in ~s", [File]).
+    io_lib:format("Checksum mismatch against registry in ~ts", [File]).
 
 get_resource_type({Type, Location}, Resources) ->
     find_resource_module(Type, Location, Resources);
@@ -100,7 +100,7 @@ find_resource_module(Type, Location, Resources) ->
         false ->
             case code:which(Type) of
                 non_existing ->
-                    {error, io_lib:format("Cannot handle dependency ~s.~n"
+                    {error, io_lib:format("Cannot handle dependency ~ts.~n"
                                          "     No module for resource type ~p", [Location, Type])};
                 _ ->
                     Type

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -17,7 +17,7 @@
 lock(AppDir, {git, Url, _}) ->
     lock(AppDir, {git, Url});
 lock(AppDir, {git, Url}) ->
-    AbortMsg = lists:flatten(io_lib:format("Locking of git dependency failed in ~s", [AppDir])),
+    AbortMsg = lists:flatten(io_lib:format("Locking of git dependency failed in ~ts", [AppDir])),
     Dir = rebar_utils:escape_double_quotes(AppDir),
     {ok, VsnString} =
         case os:type() of
@@ -38,17 +38,17 @@ needs_update(Dir, {git, Url, {tag, Tag}}) ->
                                    [{cd, Dir}]),
     Current1 = string:strip(string:strip(Current, both, $\n), both, $\r),
 
-    ?DEBUG("Comparing git tag ~s with ~s", [Tag, Current1]),
+    ?DEBUG("Comparing git tag ~ts with ~ts", [Tag, Current1]),
     not ((Current1 =:= Tag) andalso compare_url(Dir, Url));
 needs_update(Dir, {git, Url, {branch, Branch}}) ->
     %% Fetch remote so we can check if the branch has changed
     SafeBranch = rebar_utils:escape_chars(Branch),
-    {ok, _} = rebar_utils:sh(?FMT("git fetch origin ~s", [SafeBranch]),
+    {ok, _} = rebar_utils:sh(?FMT("git fetch origin ~ts", [SafeBranch]),
                              [{cd, Dir}]),
     %% Check for new commits to origin/Branch
-    {ok, Current} = rebar_utils:sh(?FMT("git log HEAD..origin/~s --oneline", [SafeBranch]),
+    {ok, Current} = rebar_utils:sh(?FMT("git log HEAD..origin/~ts --oneline", [SafeBranch]),
                                    [{cd, Dir}]),
-    ?DEBUG("Checking git branch ~s for updates", [Branch]),
+    ?DEBUG("Checking git branch ~ts for updates", [Branch]),
     not ((Current =:= []) andalso compare_url(Dir, Url));
 needs_update(Dir, {git, Url, "master"}) ->
     needs_update(Dir, {git, Url, {branch, "master"}});
@@ -68,7 +68,7 @@ needs_update(Dir, {git, _, Ref}) ->
                    Ref
            end,
 
-    ?DEBUG("Comparing git ref ~s with ~s", [Ref2, Current1]),
+    ?DEBUG("Comparing git ref ~ts with ~ts", [Ref2, Current1]),
     (Current1 =/= Ref2).
 
 compare_url(Dir, Url) ->
@@ -82,7 +82,7 @@ compare_url(Dir, Url) ->
 
 parse_git_url(Url) ->
     %% Checks for standard scp style git remote
-    case re:run(Url, ?SCP_PATTERN, [{capture, [host, path], list}]) of
+    case re:run(Url, ?SCP_PATTERN, [{capture, [host, path], list}, unicode]) of
         {match, [Host, Path]} ->
             {ok, {Host, filename:rootname(Path, ".git")}};
         nomatch ->
@@ -119,41 +119,41 @@ download(Dir, {git, Url, Rev}, _State) ->
 
 %% Use different git clone commands depending on git --version
 git_clone(branch,Vsn,Url,Dir,Branch) when Vsn >= {1,7,10}; Vsn =:= undefined ->
-    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s --single-branch",
+    rebar_utils:sh(?FMT("git clone ~ts ~ts -b ~ts --single-branch",
                         [rebar_utils:escape_chars(Url),
                          rebar_utils:escape_chars(filename:basename(Dir)),
                          rebar_utils:escape_chars(Branch)]),
                    [{cd, filename:dirname(Dir)}]);
 git_clone(branch,_Vsn,Url,Dir,Branch) ->
-    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s",
+    rebar_utils:sh(?FMT("git clone ~ts ~ts -b ~ts",
                         [rebar_utils:escape_chars(Url),
                          rebar_utils:escape_chars(filename:basename(Dir)),
                          rebar_utils:escape_chars(Branch)]),
                    [{cd, filename:dirname(Dir)}]);
 git_clone(tag,Vsn,Url,Dir,Tag) when Vsn >= {1,7,10}; Vsn =:= undefined ->
-    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s --single-branch",
+    rebar_utils:sh(?FMT("git clone ~ts ~ts -b ~ts --single-branch",
                         [rebar_utils:escape_chars(Url),
                          rebar_utils:escape_chars(filename:basename(Dir)),
                          rebar_utils:escape_chars(Tag)]),
                    [{cd, filename:dirname(Dir)}]);
 git_clone(tag,_Vsn,Url,Dir,Tag) ->
-    rebar_utils:sh(?FMT("git clone ~s ~s -b ~s",
+    rebar_utils:sh(?FMT("git clone ~ts ~ts -b ~ts",
                         [rebar_utils:escape_chars(Url),
                          rebar_utils:escape_chars(filename:basename(Dir)),
                          rebar_utils:escape_chars(Tag)]),
                    [{cd, filename:dirname(Dir)}]);
 git_clone(ref,_Vsn,Url,Dir,Ref) ->
-    rebar_utils:sh(?FMT("git clone -n ~s ~s",
+    rebar_utils:sh(?FMT("git clone -n ~ts ~ts",
                         [rebar_utils:escape_chars(Url),
                          rebar_utils:escape_chars(filename:basename(Dir))]),
                    [{cd, filename:dirname(Dir)}]),
-    rebar_utils:sh(?FMT("git checkout -q ~s", [Ref]), [{cd, Dir}]);
+    rebar_utils:sh(?FMT("git checkout -q ~ts", [Ref]), [{cd, Dir}]);
 git_clone(rev,_Vsn,Url,Dir,Rev) ->
-    rebar_utils:sh(?FMT("git clone -n ~s ~s",
+    rebar_utils:sh(?FMT("git clone -n ~ts ~ts",
                         [rebar_utils:escape_chars(Url),
                          rebar_utils:escape_chars(filename:basename(Dir))]),
                    [{cd, filename:dirname(Dir)}]),
-    rebar_utils:sh(?FMT("git checkout -q ~s", [rebar_utils:escape_chars(Rev)]),
+    rebar_utils:sh(?FMT("git checkout -q ~ts", [rebar_utils:escape_chars(Rev)]),
                    [{cd, Dir}]).
 
 git_vsn() ->
@@ -168,7 +168,7 @@ git_vsn() ->
 git_vsn_fetch() ->
     case rebar_utils:sh("git --version",[]) of
         {ok, VsnStr} ->
-            case re:run(VsnStr, "git version\\h+(\\d)\\.(\\d)\\.(\\d).*",[{capture,[1,2,3],list}]) of
+            case re:run(VsnStr, "git version\\h+(\\d)\\.(\\d)\\.(\\d).*", [{capture,[1,2,3],list}, unicode]) of
                 {match,[Maj,Min,Patch]} ->
                     {list_to_integer(Maj),
                      list_to_integer(Min),
@@ -198,7 +198,7 @@ collect_default_refcount(Dir) ->
                         return_on_error,
                         {cd, Dir}]) of
         {error, _} ->
-            ?WARN("Getting log of git dependency failed in ~s. Falling back to version 0.0.0", [rebar_dir:get_cwd()]),
+            ?WARN("Getting log of git dependency failed in ~ts. Falling back to version 0.0.0", [rebar_dir:get_cwd()]),
             {plain, "0.0.0"};
         {ok, String} ->
             RawRef = string:strip(String, both, $\n),
@@ -222,21 +222,20 @@ collect_default_refcount(Dir) ->
 build_vsn_string(Vsn, RawRef, Count) ->
     %% Cleanup the tag and the Ref information. Basically leading 'v's and
     %% whitespace needs to go away.
-    RefTag = [".ref", re:replace(RawRef, "\\s", "", [global])],
+    RefTag = [".ref", re:replace(RawRef, "\\s", "", [global, unicode])],
 
     %% Create the valid [semver](http://semver.org) version from the tag
     case Count of
         0 ->
-            erlang:binary_to_list(erlang:iolist_to_binary(Vsn));
+            rebar_utils:to_list(Vsn);
         _ ->
-            erlang:binary_to_list(erlang:iolist_to_binary([Vsn, "+build.",
-                                                           integer_to_list(Count), RefTag]))
+            rebar_utils:to_list([Vsn, "+build.", integer_to_list(Count), RefTag])
     end.
 
 get_patch_count(Dir, RawRef) ->
     AbortMsg = "Getting rev-list of git dep failed in " ++ Dir,
-    Ref = re:replace(RawRef, "\\s", "", [global]),
-    Cmd = io_lib:format("git rev-list ~s..HEAD",
+    Ref = re:replace(RawRef, "\\s", "", [global, unicode]),
+    Cmd = io_lib:format("git rev-list ~ts..HEAD",
                         [rebar_utils:escape_chars(Ref)]),
     {ok, PatchLines} = rebar_utils:sh(Cmd,
                                         [{use_stdout, false},
@@ -252,7 +251,7 @@ parse_tags(Dir) ->
         {error, _} ->
             {undefined, "0.0.0"};
         {ok, Line} ->
-            case re:run(Line, "(\\(|\\s)(HEAD[^,]*,\\s)tag:\\s(v?([^,\\)]+))", [{capture, [3, 4], list}]) of
+            case re:run(Line, "(\\(|\\s)(HEAD[^,]*,\\s)tag:\\s(v?([^,\\)]+))", [{capture, [3, 4], list}, unicode]) of
                 {match,[Tag, Vsn]} ->
                     {Tag, Vsn};
                 nomatch ->

--- a/src/rebar_hg_resource.erl
+++ b/src/rebar_hg_resource.erl
@@ -22,7 +22,7 @@ lock(AppDir, {hg, Url}) ->
 needs_update(Dir, {hg, Url, {tag, Tag}}) ->
     Ref = get_ref(Dir),
     {ClosestTag, Distance} = get_tag_distance(Dir, Ref),
-    ?DEBUG("Comparing hg tag ~s with ref ~s (closest tag is ~s at distance ~s)",
+    ?DEBUG("Comparing hg tag ~ts with ref ~ts (closest tag is ~ts at distance ~ts)",
            [Tag, Ref, ClosestTag, Distance]),
     not ((Distance =:= "0") andalso (Tag =:= ClosestTag)
          andalso compare_url(Dir, Url));
@@ -45,7 +45,7 @@ needs_update(Dir, {hg, Url, Ref}) ->
         Ref1 ->
             Ref1
     end,
-    ?DEBUG("Comparing hg ref ~s with ~s", [Ref1, LocalRef]),
+    ?DEBUG("Comparing hg ref ~ts with ~ts", [Ref1, LocalRef]),
     not ((LocalRef =:= TargetRef) andalso compare_url(Dir, Url)).
 
 download(Dir, {hg, Url}, State) ->
@@ -56,28 +56,28 @@ download(Dir, {hg, Url, ""}, State) ->
     download(Dir, {hg, Url, {branch, "default"}}, State);
 download(Dir, {hg, Url, {branch, Branch}}, _State) ->
     ok = filelib:ensure_dir(Dir),
-    rebar_utils:sh(?FMT("hg clone -q -b ~s ~s ~s",
+    rebar_utils:sh(?FMT("hg clone -q -b ~ts ~ts ~ts",
                        [rebar_utils:escape_chars(Branch),
                         rebar_utils:escape_chars(Url),
                         rebar_utils:escape_chars(filename:basename(Dir))]),
                    [{cd, filename:dirname(Dir)}]);
 download(Dir, {hg, Url, {tag, Tag}}, _State) ->
     ok = filelib:ensure_dir(Dir),
-    rebar_utils:sh(?FMT("hg clone -q -u ~s ~s ~s",
+    rebar_utils:sh(?FMT("hg clone -q -u ~ts ~ts ~ts",
                         [rebar_utils:escape_chars(Tag),
                          rebar_utils:escape_chars(Url),
                          rebar_utils:escape_chars(filename:basename(Dir))]),
                    [{cd, filename:dirname(Dir)}]);
 download(Dir, {hg, Url, {ref, Ref}}, _State) ->
     ok = filelib:ensure_dir(Dir),
-    rebar_utils:sh(?FMT("hg clone -q -r ~s ~s ~s",
+    rebar_utils:sh(?FMT("hg clone -q -r ~ts ~ts ~ts",
                         [rebar_utils:escape_chars(Ref),
                          rebar_utils:escape_chars(Url),
                          rebar_utils:escape_chars(filename:basename(Dir))]),
                    [{cd, filename:dirname(Dir)}]);
 download(Dir, {hg, Url, Rev}, _State) ->
     ok = filelib:ensure_dir(Dir),
-    rebar_utils:sh(?FMT("hg clone -q -r ~s ~s ~s",
+    rebar_utils:sh(?FMT("hg clone -q -r ~ts ~ts ~ts",
                         [rebar_utils:escape_chars(Rev),
                          rebar_utils:escape_chars(Url),
                          rebar_utils:escape_chars(filename:basename(Dir))]),
@@ -88,7 +88,7 @@ make_vsn(Dir) ->
     Ref = get_ref(Dir),
     Cmd = BaseHg ++ "log --template \"{latesttag}+build.{latesttagdistance}.rev.{node|short}\""
           " --rev " ++ Ref,
-    AbortMsg = io_lib:format("Version resolution of hg dependency failed in ~s", [Dir]),
+    AbortMsg = io_lib:format("Version resolution of hg dependency failed in ~ts", [Dir]),
     {ok, VsnString} =
         rebar_utils:sh(Cmd,
                        [{use_stdout, false}, {debug_abort_on_error, AbortMsg}]),
@@ -108,14 +108,14 @@ compare_url(Dir, Url) ->
     parse_hg_url(CurrentUrl1) =:= parse_hg_url(Url).
 
 get_ref(Dir) ->
-    AbortMsg = io_lib:format("Get ref of hg dependency failed in ~s", [Dir]),
+    AbortMsg = io_lib:format("Get ref of hg dependency failed in ~ts", [Dir]),
     {ok, RefString} =
         rebar_utils:sh("hg -R \"" ++ rebar_utils:escape_double_quotes(Dir) ++ "\" --debug id -i",
                        [{use_stdout, false}, {debug_abort_on_error, AbortMsg}]),
     string:strip(RefString, both, $\n).
 
 get_tag_distance(Dir, Ref) ->
-    AbortMsg = io_lib:format("Get tag distance of hg dependency failed in ~s", [Dir]),
+    AbortMsg = io_lib:format("Get tag distance of hg dependency failed in ~ts", [Dir]),
     {ok, LogString} =
         rebar_utils:sh("hg -R \"" ++ rebar_utils:escape_double_quotes(Dir) ++ "\" "
                       "log --template \"{latesttag}-{latesttagdistance}\n\" "
@@ -123,11 +123,12 @@ get_tag_distance(Dir, Ref) ->
                       [{use_stdout, false}, {debug_abort_on_error, AbortMsg}]),
     Log = string:strip(LogString,
                        both, $\n),
-    [Tag, Distance] = re:split(Log, "-([0-9]+)$", [{parts,0}, {return, list}]),
+    [Tag, Distance] = re:split(Log, "-([0-9]+)$",
+                               [{parts,0}, {return,list}, unicode]),
     {Tag, Distance}.
 
 get_branch_ref(Dir, Branch) ->
-    AbortMsg = io_lib:format("Get branch ref of hg dependency failed in ~s", [Dir]),
+    AbortMsg = io_lib:format("Get branch ref of hg dependency failed in ~ts", [Dir]),
     {ok, BranchRefString} =
         rebar_utils:sh("hg -R \"" ++ rebar_utils:escape_double_quotes(Dir) ++
                        "\" log --template \"{node}\n\" --rev " ++ rebar_utils:escape_chars(Branch),

--- a/src/rebar_hooks.erl
+++ b/src/rebar_hooks.erl
@@ -57,9 +57,9 @@ run_provider_hooks_(Dir, Type, Command, Providers, TypeHooks, State) ->
     end.
 
 format_error({bad_provider, Type, Command, {Name, Namespace}}) ->
-    io_lib:format("Unable to run ~s hooks for '~p', command '~p' in namespace '~p' not found.", [Type, Command, Namespace, Name]);
+    io_lib:format("Unable to run ~ts hooks for '~p', command '~p' in namespace '~p' not found.", [Type, Command, Namespace, Name]);
 format_error({bad_provider, Type, Command, Name}) ->
-    io_lib:format("Unable to run ~s hooks for '~p', command '~p' not found.", [Type, Command, Name]).
+    io_lib:format("Unable to run ~ts hooks for '~p', command '~p' not found.", [Type, Command, Name]).
 
 %% @doc The following environment variables are exported when running
 %% a hook (absolute paths):
@@ -143,7 +143,7 @@ join_dirs(BaseDir, Dirs) ->
     string:join([ filename:join(BaseDir, Dir) || Dir <- Dirs ], ":").
 
 re_version(Path) ->
-    case re:run(Path, "^.*-(?<VER>[^/-]*)$", [{capture, [1], list}]) of
+    case re:run(Path, "^.*-(?<VER>[^/-]*)$", [{capture,[1],list}, unicode]) of
         nomatch -> "";
         {match, [Ver]} -> Ver
     end.

--- a/src/rebar_log.erl
+++ b/src/rebar_log.erl
@@ -94,7 +94,7 @@ get_level() ->
 
 log(Level = error, Str, Args) ->
     {ok, LogState} = application:get_env(rebar, log),
-    ec_cmd_log:Level(LogState, lists:flatten(cf:format("~!^~s~n", [Str])), Args);
+    ec_cmd_log:Level(LogState, lists:flatten(cf:format("~!^~ts~n", [Str])), Args);
 log(Level, Str, Args) ->
     {ok, LogState} = application:get_env(rebar, log),
     ec_cmd_log:Level(LogState, Str++"~n", Args).

--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -58,11 +58,11 @@ compile(State, App) ->
     validate_app(State, App1).
 
 format_error({missing_app_file, Filename}) ->
-    io_lib:format("App file is missing: ~s", [Filename]);
+    io_lib:format("App file is missing: ~ts", [Filename]);
 format_error({file_read, File, Reason}) ->
-    io_lib:format("Failed to read required file ~s for processing: ~s", [File, file:format_error(Reason)]);
+    io_lib:format("Failed to read required file ~ts for processing: ~ts", [File, file:format_error(Reason)]);
 format_error({invalid_name, File, AppName}) ->
-    io_lib:format("Invalid ~s: name of application (~p) must match filename.", [File, AppName]).
+    io_lib:format("Invalid ~ts: name of application (~p) must match filename.", [File, AppName]).
 
 %% ===================================================================
 %% Internal functions
@@ -222,7 +222,7 @@ app_vsn(AppData, AppFile, State) ->
 get_value(Key, AppInfo, AppFile) ->
     case proplists:get_value(Key, AppInfo) of
         undefined ->
-            ?ABORT("Failed to get app value '~p' from '~s'~n", [Key, AppFile]);
+            ?ABORT("Failed to get app value '~p' from '~ts'~n", [Key, AppFile]);
         Value ->
             Value
     end.

--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -72,12 +72,12 @@ deps(Name, Vsn, State) ->
 
 deps_(Name, Vsn, State) ->
     ?MODULE:verify_table(State),
-    ets:lookup_element(?PACKAGE_TABLE, {ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)}, 2).
+    ets:lookup_element(?PACKAGE_TABLE, {rebar_utils:to_binary(Name), rebar_utils:to_binary(Vsn)}, 2).
 
 handle_missing_package(Dep, State, Fun) ->
     case Dep of
         {Name, Vsn} ->
-            ?INFO("Package ~s-~s not found. Fetching registry updates and trying again...", [Name, Vsn]);
+            ?INFO("Package ~ts-~ts not found. Fetching registry updates and trying again...", [Name, Vsn]);
         _ ->
             ?INFO("Package ~p not found. Fetching registry updates and trying again...", [Dep])
     end,
@@ -128,7 +128,7 @@ registry_checksum({pkg, Name, Vsn, _Hash}, State) ->
         ets:lookup_element(?PACKAGE_TABLE, {Name, Vsn}, 3)
     catch
         _:_ ->
-            throw(?PRV_ERROR({missing_package, ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)}))
+            throw(?PRV_ERROR({missing_package, rebar_utils:to_binary(Name), rebar_utils:to_binary(Vsn)}))
     end.
 
 %% Hex supports use of ~> to specify the version required for a dependency.
@@ -207,17 +207,17 @@ handle_single_vsn(Pkg, PkgVsn, Dep, Vsn, Constraint) ->
         false ->
             case {Pkg, PkgVsn} of
                 {undefined, undefined} ->
-                    ?DEBUG("Only existing version of ~s is ~s which does not match constraint ~~> ~s. "
+                    ?DEBUG("Only existing version of ~ts is ~ts which does not match constraint ~~> ~ts. "
                           "Using anyway, but it is not guaranteed to work.", [Dep, Vsn, Constraint]);
                 _ ->
-                    ?DEBUG("[~s:~s] Only existing version of ~s is ~s which does not match constraint ~~> ~s. "
+                    ?DEBUG("[~ts:~ts] Only existing version of ~ts is ~ts which does not match constraint ~~> ~ts. "
                           "Using anyway, but it is not guaranteed to work.", [Pkg, PkgVsn, Dep, Vsn, Constraint])
             end,
             {ok, Vsn}
     end.
 
 format_error({missing_package, Name, Vsn}) ->
-    io_lib:format("Package not found in registry: ~s-~s.", [ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)]);
+    io_lib:format("Package not found in registry: ~ts-~ts.", [rebar_utils:to_binary(Name), rebar_utils:to_binary(Vsn)]);
 format_error({missing_package, Dep}) ->
     io_lib:format("Package not found in registry: ~p.", [Dep]).
 

--- a/src/rebar_prv_app_discovery.erl
+++ b/src/rebar_prv_app_discovery.erl
@@ -49,19 +49,19 @@ do(State) ->
 
 -spec format_error(any()) -> iolist().
 format_error({multiple_app_files, Files}) ->
-    io_lib:format("Multiple app files found in one app dir: ~s", [string:join(Files, " and ")]);
+    io_lib:format("Multiple app files found in one app dir: ~ts", [string:join(Files, " and ")]);
 format_error({invalid_app_file, File, Reason}) ->
     case Reason of
         {Line, erl_parse, Description} ->
-            io_lib:format("Invalid app file ~s at line ~b: ~p",
+            io_lib:format("Invalid app file ~ts at line ~b: ~p",
                 [File, Line, lists:flatten(Description)]);
         _ ->
-            io_lib:format("Invalid app file ~s: ~p", [File, Reason])
+            io_lib:format("Invalid app file ~ts: ~p", [File, Reason])
     end;
 %% Provide a slightly more informative error message for consult of app file failure
 format_error({rebar_file_utils, {bad_term_file, AppFile, Reason}}) ->
-    io_lib:format("Error in app file ~s: ~s", [rebar_dir:make_relative_path(AppFile,
-                                                                            rebar_dir:get_cwd()),
-                                               file:format_error(Reason)]);
+    io_lib:format("Error in app file ~ts: ~ts", [rebar_dir:make_relative_path(AppFile,
+                                                                              rebar_dir:get_cwd()),
+                                                 file:format_error(Reason)]);
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).

--- a/src/rebar_prv_as.erl
+++ b/src/rebar_prv_as.erl
@@ -64,7 +64,7 @@ args_to_profiles_and_tasks(Args) ->
 
 first_profile([]) -> {[], []};
 first_profile([ProfileList|Rest]) ->
-    case re:split(ProfileList, ",", [{return, list}, {parts, 2}]) of
+    case re:split(ProfileList, ",", [{return, list}, {parts, 2}, unicode]) of
         %% `foo, bar`
         [P, ""]   -> profiles(Rest, [P]);
         %% `foo,bar`
@@ -75,7 +75,7 @@ first_profile([ProfileList|Rest]) ->
 
 profiles([], Acc) -> {lists:reverse(Acc), rebar_utils:args_to_tasks([])};
 profiles([ProfileList|Rest], Acc) ->
-    case re:split(ProfileList, ",", [{return, list}, {parts, 2}]) of
+    case re:split(ProfileList, ",", [{return, list}, {parts, 2}, unicode]) of
         %% `foo, bar`
         [P, ""]   -> profiles(Rest, [P|Acc]);
         %% `foo,bar`
@@ -101,5 +101,5 @@ warn_on_empty_profile(Profiles, State) ->
     ProjectApps = rebar_state:project_apps(State),
     DefinedProfiles = rebar_state:get(State, profiles, []) ++
         lists:flatten([rebar_app_info:get(AppInfo, profiles, []) || AppInfo <- ProjectApps]),
-    [?WARN("No entry for profile ~s in config.", [Profile]) ||
+    [?WARN("No entry for profile ~ts in config.", [Profile]) ||
         Profile <- Profiles, not(lists:keymember(list_to_atom(Profile), 1, DefinedProfiles))].

--- a/src/rebar_prv_clean.erl
+++ b/src/rebar_prv_clean.erl
@@ -68,7 +68,7 @@ format_error(Reason) ->
 
 clean_apps(State, Providers, Apps) ->
     [begin
-         ?INFO("Cleaning out ~s...", [rebar_app_info:name(AppInfo)]),
+         ?INFO("Cleaning out ~ts...", [rebar_app_info:name(AppInfo)]),
          AppDir = rebar_app_info:dir(AppInfo),
          AppInfo1 = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER, Providers, AppInfo, State),
          rebar_erlc_compiler:clean(AppInfo1),

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -684,7 +684,7 @@ format_result({Passed, 0, {0, 0}}) ->
 format_result({Passed, Failed, Skipped}) ->
     Format = [format_failed(Failed), format_skipped(Skipped),
               format_passed(Passed)],
-    ?CONSOLE("~s", [Format]);
+    ?CONSOLE("~ts", [Format]);
 format_result(_Unknown) ->
     %% Happens when CT itself encounters a bug
     ok.

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -73,7 +73,7 @@ do(State) ->
 
 -spec format_error(any()) -> iolist().
 format_error({missing_artifact, File}) ->
-    io_lib:format("Missing artifact ~s", [File]);
+    io_lib:format("Missing artifact ~ts", [File]);
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
@@ -114,7 +114,7 @@ compile(State, AppInfo) ->
     compile(State, rebar_state:providers(State), AppInfo).
 
 compile(State, Providers, AppInfo) ->
-    ?INFO("Compiling ~s", [rebar_app_info:name(AppInfo)]),
+    ?INFO("Compiling ~ts", [rebar_app_info:name(AppInfo)]),
     AppDir = rebar_app_info:dir(AppInfo),
     AppInfo1 = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER,  Providers, AppInfo, State),
 
@@ -173,8 +173,8 @@ has_all_artifacts(AppInfo1) ->
     end.
 
 copy_app_dirs(AppInfo, OldAppDir, AppDir) ->
-    case ec_cnv:to_binary(filename:absname(OldAppDir)) =/=
-        ec_cnv:to_binary(filename:absname(AppDir)) of
+    case rebar_utils:to_binary(filename:absname(OldAppDir)) =/=
+        rebar_utils:to_binary(filename:absname(AppDir)) of
         true ->
             EbinDir = filename:join([OldAppDir, "ebin"]),
             %% copy all files from ebin if it exists

--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -278,7 +278,7 @@ write_index(State, Coverage) ->
 write_index_section(_F, []) -> ok;
 write_index_section(F, [{Section, DataFile, Mods}|Rest]) ->
     %% Write the report
-    ok = file:write(F, ?FMT("<h1>~s summary</h1>\n", [Section])),
+    ok = file:write(F, ?FMT("<h1>~ts summary</h1>\n", [Section])),
     ok = file:write(F, "coverage calculated from:\n<ul>"),
     ok = lists:foreach(fun(D) -> ok = file:write(F, io_lib:format("<li>~ts</li>", [D])) end,
                        DataFile),
@@ -303,7 +303,7 @@ strip_coverdir(File) ->
                                               2))).
 
 cover_compile(State, apps) ->
-    ExclApps = [list_to_binary(A) || A <- rebar_state:get(State, cover_excl_apps, [])],
+    ExclApps = [rebar_utils:to_binary(A) || A <- rebar_state:get(State, cover_excl_apps, [])],
     Apps = filter_checkouts_and_excluded(rebar_state:project_apps(State), ExclApps),
     AppDirs = app_dirs(Apps),
     cover_compile(State, lists:filter(fun(D) -> ec_file:is_dir(D) end, AppDirs));

--- a/src/rebar_prv_deps.erl
+++ b/src/rebar_prv_deps.erl
@@ -55,7 +55,7 @@ merge(Deps, SourceDeps) ->
 normalize(Name) when is_binary(Name) ->
     Name;
 normalize(Name) when is_atom(Name) ->
-    ec_cnv:to_binary(Name);
+    atom_to_binary(Name, unicode);
 normalize(Dep) when is_tuple(Dep) ->
     Name = element(1, Dep),
     setelement(1, Dep, normalize(Name)).
@@ -87,31 +87,31 @@ display_deps(State, Deps) ->
 
 %% packages
 display_dep(_State, {Name, Vsn}) when is_list(Vsn) ->
-    ?CONSOLE("~s* (package ~s)", [ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)]);
+    ?CONSOLE("~ts* (package ~ts)", [rebar_utils:to_binary(Name), rebar_utils:to_binary(Vsn)]);
 display_dep(_State, Name) when is_binary(Name) ->
-    ?CONSOLE("~s* (package)", [Name]);
+    ?CONSOLE("~ts* (package)", [Name]);
 display_dep(_State, {Name, Source}) when is_tuple(Source) ->
-    ?CONSOLE("~s* (~s source)", [ec_cnv:to_binary(Name), type(Source)]);
+    ?CONSOLE("~ts* (~ts source)", [rebar_utils:to_binary(Name), type(Source)]);
 display_dep(_State, {Name, _Vsn, Source}) when is_tuple(Source) ->
-    ?CONSOLE("~s* (~s source)", [ec_cnv:to_binary(Name), type(Source)]);
+    ?CONSOLE("~ts* (~ts source)", [rebar_utils:to_binary(Name), type(Source)]);
 display_dep(_State, {Name, _Vsn, Source, _Opts}) when is_tuple(Source) ->
-    ?CONSOLE("~s* (~s source)", [ec_cnv:to_binary(Name), type(Source)]);
+    ?CONSOLE("~ts* (~ts source)", [rebar_utils:to_binary(Name), type(Source)]);
 %% Locked
 display_dep(State, {Name, Source={pkg, _, Vsn}, Level}) when is_integer(Level) ->
     DepsDir = rebar_dir:deps_dir(State),
-    AppDir = filename:join([DepsDir, ec_cnv:to_binary(Name)]),
+    AppDir = filename:join([DepsDir, rebar_utils:to_binary(Name)]),
     NeedsUpdate = case rebar_fetch:needs_update(AppDir, Source, State) of
         true -> "*";
         false -> ""
     end,
-    ?CONSOLE("~s~s (locked package ~s)", [Name, NeedsUpdate, Vsn]);
+    ?CONSOLE("~ts~ts (locked package ~ts)", [Name, NeedsUpdate, Vsn]);
 display_dep(State, {Name, Source, Level}) when is_tuple(Source), is_integer(Level) ->
     DepsDir = rebar_dir:deps_dir(State),
-    AppDir = filename:join([DepsDir, ec_cnv:to_binary(Name)]),
+    AppDir = filename:join([DepsDir, rebar_utils:to_binary(Name)]),
     NeedsUpdate = case rebar_fetch:needs_update(AppDir, Source, State) of
         true -> "*";
         false -> ""
     end,
-    ?CONSOLE("~s~s (locked ~s source)", [Name, NeedsUpdate, type(Source)]).
+    ?CONSOLE("~ts~ts (locked ~ts source)", [Name, NeedsUpdate, type(Source)]).
 
 type(Source) when is_tuple(Source) -> element(1, Source).

--- a/src/rebar_prv_deps_tree.erl
+++ b/src/rebar_prv_deps_tree.erl
@@ -90,7 +90,7 @@ type(Source, Verbose) when is_tuple(Source) ->
         {pkg, _} ->
             "hex package";
         {Other, false} ->
-            io_lib:format("~s repo", [Other]);
+            io_lib:format("~ts repo", [Other]);
         {_, true} ->
-            io_lib:format("~s", [element(2, Source)])
+            io_lib:format("~ts", [element(2, Source)])
     end.

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -116,18 +116,18 @@ maybe_fix_env() ->
 
 -spec format_error(any()) -> iolist().
 format_error({error_processing_apps, Error}) ->
-    io_lib:format("Error in dialyzing apps: ~s", [Error]);
+    io_lib:format("Error in dialyzing apps: ~ts", [Error]);
 format_error({dialyzer_warnings, Warnings}) ->
     io_lib:format("Warnings occurred running dialyzer: ~b", [Warnings]);
 format_error({unknown_application, App}) ->
-    io_lib:format("Could not find application: ~s", [App]);
+    io_lib:format("Could not find application: ~ts", [App]);
 format_error({unknown_module, Mod}) ->
-    io_lib:format("Could not find module: ~s", [Mod]);
+    io_lib:format("Could not find module: ~ts", [Mod]);
 format_error({duplicate_module, Mod, File1, File2}) ->
-    io_lib:format("Duplicates of module ~s: ~s ~s", [Mod, File1, File2]);
+    io_lib:format("Duplicates of module ~ts: ~ts ~ts", [Mod, File1, File2]);
 format_error({output_file_error, File, Error}) ->
     Error1 = file:format_error(Error),
-    io_lib:format("Failed to write to ~s: ~s", [File, Error1]);
+    io_lib:format("Failed to write to ~ts: ~ts", [File, Error1]);
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
@@ -155,7 +155,7 @@ do(State, Plt) ->
         0 ->
             {ok, State2};
         TotalWarnings ->
-            ?INFO("Warnings written to ~s", [Output]),
+            ?INFO("Warnings written to ~ts", [Output]),
             throw({dialyzer_warnings, TotalWarnings})
     end.
 
@@ -229,7 +229,7 @@ apps_files([AppName | DepApps], SkipApps, Files) ->
             apps_files(DepApps, SkipApps, Files);
         false ->
             AppFiles = app_files(AppName),
-            ?DEBUG("~s modules: ~p", [AppName, dict:fetch_keys(AppFiles)]),
+            ?DEBUG("~ts modules: ~p", [AppName, dict:fetch_keys(AppFiles)]),
             Files2 = merge_files(Files, AppFiles),
             apps_files(DepApps, [AppName | SkipApps], Files2)
     end.
@@ -505,7 +505,7 @@ format_warnings(Opts, Output, Warnings) ->
     length(Warnings).
 
 console_warnings(Warnings) ->
-    _ = [?CONSOLE("~s", [Warning]) || Warning <- Warnings],
+    _ = [?CONSOLE("~ts", [Warning]) || Warning <- Warnings],
     ok.
 
 file_warnings(_, []) ->

--- a/src/rebar_prv_edoc.erl
+++ b/src/rebar_prv_edoc.erl
@@ -42,8 +42,8 @@ do(State) ->
     Res = try
         lists:foldl(fun(AppInfo, EdocOptsAcc) ->
                     rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, AppInfo, State),
-                    AppName = ec_cnv:to_list(rebar_app_info:name(AppInfo)),
-                    ?INFO("Running edoc for ~s", [AppName]),
+                    AppName = rebar_utils:to_list(rebar_app_info:name(AppInfo)),
+                    ?INFO("Running edoc for ~ts", [AppName]),
                     AppDir = rebar_app_info:dir(AppInfo),
                     AppRes = (catch edoc:application(list_to_atom(AppName), AppDir, EdocOptsAcc)),
                     rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, AppInfo, State),
@@ -74,7 +74,7 @@ do(State) ->
 
 -spec format_error(any()) -> iolist().
 format_error({app_failed, AppName}) ->
-    io_lib:format("Failed to generate documentation for app '~s'", [AppName]);
+    io_lib:format("Failed to generate documentation for app '~ts'", [AppName]);
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -104,22 +104,22 @@ do_(State) ->
 %% @doc convert a given exception's payload into an io description.
 -spec format_error(any()) -> iolist().
 format_error({dep_app_not_found, AppDir, AppName}) ->
-    io_lib:format("Dependency failure: Application ~s not found at the top level of directory ~s", [AppName, AppDir]);
+    io_lib:format("Dependency failure: Application ~ts not found at the top level of directory ~ts", [AppName, AppDir]);
 format_error({load_registry_fail, Dep}) ->
-    io_lib:format("Error loading registry to resolve version of ~s. Try fixing by running 'rebar3 update'", [Dep]);
+    io_lib:format("Error loading registry to resolve version of ~ts. Try fixing by running 'rebar3 update'", [Dep]);
 format_error({bad_constraint, Name, Constraint}) ->
-    io_lib:format("Unable to parse version for package ~s: ~s", [Name, Constraint]);
+    io_lib:format("Unable to parse version for package ~ts: ~ts", [Name, Constraint]);
 format_error({parse_dep, Dep}) ->
     io_lib:format("Failed parsing dep ~p", [Dep]);
 format_error({not_rebar_package, Package, Version}) ->
-    io_lib:format("Package not buildable with rebar3: ~s-~s", [Package, Version]);
+    io_lib:format("Package not buildable with rebar3: ~ts-~ts", [Package, Version]);
 format_error({missing_package, Package, Version}) ->
-    io_lib:format("Package not found in registry: ~s-~s", [Package, Version]);
+    io_lib:format("Package not found in registry: ~ts-~ts", [Package, Version]);
 format_error({missing_package, Package}) ->
-    io_lib:format("Package not found in registry: ~s", [Package]);
+    io_lib:format("Package not found in registry: ~ts", [Package]);
 format_error({cycles, Cycles}) ->
     Prints = [["applications: ",
-               [io_lib:format("~s ", [Dep]) || Dep <- Cycle],
+               [io_lib:format("~ts ", [Dep]) || Dep <- Cycle],
                "depend on each other\n"]
               || Cycle <- Cycles],
     ["Dependency cycle(s) detected:\n", Prints];
@@ -291,7 +291,7 @@ handle_dep(State, Profile, DepsDir, AppInfo, Locks, Level) ->
 -spec maybe_fetch(rebar_app_info:t(), atom(), boolean(),
                   sets:set(binary()), rebar_state:t()) -> {boolean(), rebar_app_info:t()}.
 maybe_fetch(AppInfo, Profile, Upgrade, Seen, State) ->
-    AppDir = ec_cnv:to_list(rebar_app_info:dir(AppInfo)),
+    AppDir = rebar_utils:to_list(rebar_app_info:dir(AppInfo)),
     %% Don't fetch dep if it exists in the _checkouts dir
     case rebar_app_info:is_checkout(AppInfo) of
         true ->
@@ -346,7 +346,7 @@ symlink_dep(State, From, To) ->
         ok ->
             RelativeFrom = make_relative_to_root(State, From),
             RelativeTo = make_relative_to_root(State, To),
-            ?INFO("Linking ~s to ~s", [RelativeFrom, RelativeTo]),
+            ?INFO("Linking ~ts to ~ts", [RelativeFrom, RelativeTo]),
             ok;
         exists ->
             ok
@@ -359,7 +359,7 @@ make_relative_to_root(State, Path) when is_list(Path) ->
     rebar_dir:make_relative_path(Path, Root).
 
 fetch_app(AppInfo, AppDir, State) ->
-    ?INFO("Fetching ~s (~p)", [rebar_app_info:name(AppInfo),
+    ?INFO("Fetching ~ts (~p)", [rebar_app_info:name(AppInfo),
                                format_source(rebar_app_info:source(AppInfo))]),
     Source = rebar_app_info:source(AppInfo),
     true = rebar_fetch:download_source(AppDir, Source, State).
@@ -384,12 +384,12 @@ maybe_upgrade(AppInfo, AppDir, Upgrade, State) ->
         true ->
             case rebar_fetch:needs_update(AppDir, Source, State) of
                 true ->
-                    ?INFO("Upgrading ~s (~p)", [rebar_app_info:name(AppInfo), rebar_app_info:source(AppInfo)]),
+                    ?INFO("Upgrading ~ts (~p)", [rebar_app_info:name(AppInfo), rebar_app_info:source(AppInfo)]),
                     true = rebar_fetch:download_source(AppDir, Source, State);
                 false ->
                     case Upgrade of
                         true ->
-                            ?INFO("No upgrade needed for ~s", [rebar_app_info:name(AppInfo)]),
+                            ?INFO("No upgrade needed for ~ts", [rebar_app_info:name(AppInfo)]),
                             false;
                         false ->
                             false
@@ -400,7 +400,7 @@ maybe_upgrade(AppInfo, AppDir, Upgrade, State) ->
     end.
 
 warn_skip_deps(AppInfo, State) ->
-    Msg = "Skipping ~s (from ~p) as an app of the same name "
+    Msg = "Skipping ~ts (from ~p) as an app of the same name "
           "has already been fetched",
     Args = [rebar_app_info:name(AppInfo),
             rebar_app_info:source(AppInfo)],

--- a/src/rebar_prv_local_install.erl
+++ b/src/rebar_prv_local_install.erl
@@ -60,7 +60,7 @@ format_error(Reason) ->
 bin_contents(OutputDir) ->
     <<"#!/usr/bin/env sh
 
-erl -pz ", (ec_cnv:to_binary(OutputDir))/binary,"/*/ebin +sbtu +A0 -noshell -boot start_clean -s rebar3 main $REBAR3_ERL_ARGS -extra \"$@\"
+erl -pz ", (rebar_utils:to_binary(OutputDir))/binary,"/*/ebin +sbtu +A0 -noshell -boot start_clean -s rebar3 main $REBAR3_ERL_ARGS -extra \"$@\"
 ">>.
 
 extract_escript(State, ScriptPath) ->
@@ -73,7 +73,7 @@ extract_escript(State, ScriptPath) ->
     OutputDir = filename:join(rebar_dir:global_cache_dir(Opts), "lib"),
     filelib:ensure_dir(filename:join(OutputDir, "empty")),
 
-    ?INFO("Extracting rebar3 libs to ~s...", [OutputDir]),
+    ?INFO("Extracting rebar3 libs to ~ts...", [OutputDir]),
     zip:extract(Archive, [{cwd, OutputDir}]),
 
     BinDir = filename:join(rebar_dir:global_cache_dir(Opts), "bin"),
@@ -84,12 +84,12 @@ extract_escript(State, ScriptPath) ->
                     uid = Uid,
                     gid = Gid}} = file:read_file_info(ScriptPath),
 
-    ?INFO("Writing rebar3 run script ~s...", [BinFile]),
+    ?INFO("Writing rebar3 run script ~ts...", [BinFile]),
     file:write_file(BinFile, bin_contents(OutputDir)),
     ok = file:write_file_info(BinFile, #file_info{mode=33277,
                                                   uid=Uid,
                                                   gid=Gid}),
 
-    ?INFO("Add to $PATH for use: export PATH=~s:$PATH", [BinDir]),
+    ?INFO("Add to $PATH for use: export PATH=~ts:$PATH", [BinDir]),
 
     {ok, State}.

--- a/src/rebar_prv_new.erl
+++ b/src/rebar_prv_new.erl
@@ -60,7 +60,7 @@ do(State) ->
 
 -spec format_error(any()) -> iolist().
 format_error({consult, File, Reason}) ->
-    io_lib:format("Error consulting file at ~s for reason ~p", [File, Reason]);
+    io_lib:format("Error consulting file at ~ts for reason ~p", [File, Reason]);
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
@@ -70,7 +70,7 @@ format_error(Reason) ->
 
 list_templates(State) ->
     lists:foldl(fun({error, {consult, File, Reason}}, Acc) ->
-                    ?WARN("Error consulting template file ~s for reason ~p",
+                    ?WARN("Error consulting template file ~ts for reason ~p",
                           [File, Reason]),
                     Acc
                 ;  (Tpl, Acc) ->
@@ -116,16 +116,16 @@ show_short_templates(List) ->
     lists:map(fun show_short_template/1, lists:sort(List)).
 
 show_short_template({Name, Type, _Location, Description, _Vars}) ->
-    io:format("~s (~s): ~s~n",
+    io:format("~ts (~ts): ~ts~n",
               [Name,
                format_type(Type),
                format_description(Description)]).
 
 show_template({Name, Type, Location, Description, Vars}) ->
-    io:format("~s:~n"
-              "\t~s~n"
-              "\tDescription: ~s~n"
-              "\tVariables:~n~s~n",
+    io:format("~ts:~n"
+              "\t~ts~n"
+              "\tDescription: ~ts~n"
+              "\tVariables:~n~ts~n",
               [Name,
                format_type(Type, Location),
                format_description(Description),
@@ -141,9 +141,9 @@ format_type(escript, _) ->
 format_type(builtin, _) ->
     "built-in template";
 format_type(plugin, Loc) ->
-    io_lib:format("plugin template (~s)", [Loc]);
+    io_lib:format("plugin template (~ts)", [Loc]);
 format_type(file, Loc) ->
-    io_lib:format("custom template (~s)", [Loc]).
+    io_lib:format("custom template (~ts)", [Loc]).
 
 format_description(Description) ->
     case Description of
@@ -156,4 +156,4 @@ format_vars(Vars) -> [format_var(Var) || Var <- Vars].
 format_var({Var, Default}) ->
     io_lib:format("\t\t~p=~p~n",[Var, Default]);
 format_var({Var, Default, Doc}) ->
-    io_lib:format("\t\t~p=~p (~s)~n", [Var, Default, Doc]).
+    io_lib:format("\t\t~p=~p (~ts)~n", [Var, Default, Doc]).

--- a/src/rebar_prv_packages.erl
+++ b/src/rebar_prv_packages.erl
@@ -30,7 +30,7 @@ do(State) ->
     rebar_packages:packages(State),
     case rebar_state:command_args(State) of
         [Name] ->
-            print_packages(get_packages(iolist_to_binary(Name)));
+            print_packages(get_packages(rebar_utils:to_binary(Name)));
         _ ->
             print_packages(sort_packages())
     end,
@@ -47,7 +47,7 @@ print_packages(Pkgs) ->
                                                                      ,ec_semver:parse(B))
                                                 end, Vsns),
                         VsnStr = join(SortedVsns, <<", ">>),
-                        ?CONSOLE("~s:~n    Versions: ~s~n", [Name, VsnStr])
+                        ?CONSOLE("~ts:~n    Versions: ~ts~n", [Name, VsnStr])
                 end, Pkgs).
 
 sort_packages() ->
@@ -71,4 +71,4 @@ join([Bin | T], Sep) ->
 
 
 info(Description) ->
-    io_lib:format("~s.~n", [Description]).
+    io_lib:format("~ts.~n", [Description]).

--- a/src/rebar_prv_path.erl
+++ b/src/rebar_prv_path.erl
@@ -75,23 +75,23 @@ paths([{src, true}|Rest], Apps, State, Acc) ->
 paths([{rel, true}|Rest], Apps, State, Acc) ->
     paths(Rest, Apps, State, [rel_dir(State)|Acc]).
 
-base_dir(State) -> io_lib:format("~s", [rebar_dir:base_dir(State)]).
-bin_dir(State)  -> io_lib:format("~s/bin", [rebar_dir:base_dir(State)]).
-lib_dir(State)  -> io_lib:format("~s", [rebar_dir:deps_dir(State)]).
-rel_dir(State)  -> io_lib:format("~s/rel", [rebar_dir:base_dir(State)]).
+base_dir(State) -> io_lib:format("~ts", [rebar_dir:base_dir(State)]).
+bin_dir(State)  -> io_lib:format("~ts/bin", [rebar_dir:base_dir(State)]).
+lib_dir(State)  -> io_lib:format("~ts", [rebar_dir:deps_dir(State)]).
+rel_dir(State)  -> io_lib:format("~ts/rel", [rebar_dir:base_dir(State)]).
 
 ebin_dirs(Apps, State) ->
-    lists:map(fun(App) -> io_lib:format("~s/~s/ebin", [rebar_dir:deps_dir(State), App]) end, Apps).
+    lists:map(fun(App) -> io_lib:format("~ts/~ts/ebin", [rebar_dir:deps_dir(State), App]) end, Apps).
 priv_dirs(Apps, State) ->
-    lists:map(fun(App) -> io_lib:format("~s/~s/priv", [rebar_dir:deps_dir(State), App]) end, Apps).
+    lists:map(fun(App) -> io_lib:format("~ts/~ts/priv", [rebar_dir:deps_dir(State), App]) end, Apps).
 src_dirs(Apps, State) ->
-    lists:map(fun(App) -> io_lib:format("~s/~s/src", [rebar_dir:deps_dir(State), App]) end, Apps).
+    lists:map(fun(App) -> io_lib:format("~ts/~ts/src", [rebar_dir:deps_dir(State), App]) end, Apps).
 
 print_paths_if_exist(Paths, State) ->
     {RawOpts, _} = rebar_state:command_parsed_args(State),
     Sep = proplists:get_value(separator, RawOpts, " "),
     RealPaths = lists:filter(fun(P) -> ec_file:is_dir(P) end, Paths),
-    io:format("~s", [string:join(RealPaths, Sep)]).
+    io:format("~ts", [string:join(RealPaths, Sep)]).
 
 project_deps(State) ->
     Profiles = rebar_state:current_profiles(State),

--- a/src/rebar_prv_plugins.erl
+++ b/src/rebar_prv_plugins.erl
@@ -55,19 +55,19 @@ format_error(Reason) ->
 display_plugins(_Header, _Apps, []) ->
     ok;
 display_plugins(Header, Apps, Plugins) ->
-    ?CONSOLE("--- ~s ---", [Header]),
+    ?CONSOLE("--- ~ts ---", [Header]),
     display_plugins(Apps, Plugins),
     ?CONSOLE("", []).
 
 display_plugins(Apps, Plugins) ->
     lists:foreach(fun(Plugin) ->
-                          Name = if is_atom(Plugin) -> ec_cnv:to_binary(Plugin);
-                                    is_tuple(Plugin) -> ec_cnv:to_binary(element(1, Plugin))
+                          Name = if is_atom(Plugin) -> atom_to_binary(Plugin, unicode);
+                                    is_tuple(Plugin) -> rebar_utils:to_binary(element(1, Plugin))
                                  end,
                           case rebar_app_utils:find(Name, Apps) of
                               {ok, _App} ->
-                                  ?CONSOLE("~s", [Name]);
+                                  ?CONSOLE("~ts", [Name]);
                               error ->
-                                  ?DEBUG("Unable to find plugin ~s", [Name])
+                                  ?DEBUG("Unable to find plugin ~ts", [Name])
                           end
                   end, Plugins).

--- a/src/rebar_prv_plugins_upgrade.erl
+++ b/src/rebar_prv_plugins_upgrade.erl
@@ -44,7 +44,7 @@ do(State) ->
 format_error(no_plugin_arg) ->
     io_lib:format("Must give an installed plugin to upgrade as an argument", []);
 format_error({not_found, Plugin}) ->
-    io_lib:format("Plugin to upgrade not found: ~s", [Plugin]);
+    io_lib:format("Plugin to upgrade not found: ~ts", [Plugin]);
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 

--- a/src/rebar_prv_report.erl
+++ b/src/rebar_prv_report.erl
@@ -44,7 +44,7 @@ do(State) ->
     {ok, Vsn} = application:get_key(rebar, vsn),
     {ok, Apps} = application:get_key(rebar, applications),
     [application:load(App) || App <- Apps],
-    Vsns = [io_lib:format("~p: ~s~n", [App, AVsn])
+    Vsns = [io_lib:format("~p: ~ts~n", [App, AVsn])
             || App <- lists:sort(Apps),
                {ok, AVsn} <- [application:get_key(App, vsn)]],
     %% Show OS and versions
@@ -59,10 +59,10 @@ do(State) ->
     %%
     ?CONSOLE(
         "Rebar3 report~n"
-        " version ~s~n"
-        " generated at ~s~n"
+        " version ~ts~n"
+        " generated at ~ts~n"
         "=================~n"
-        "Please submit this along with your issue at ~s "
+        "Please submit this along with your issue at ~ts "
         "(and feel free to edit out private information, if any)~n"
         "-----------------~n"
         "Task: ~ts~n"
@@ -75,11 +75,11 @@ do(State) ->
         "Library directory: ~ts~n"
         "-----------------~n"
         "Loaded Applications:~n"
-        "~s~n"
+        "~ts~n"
         "-----------------~n"
         "Escript path: ~ts~n"
         "Providers:~n"
-        "  ~s",
+        "  ~ts",
         [Vsn, time_to_string(UTC),
          ?ISSUES_URL, Command, Task,
          OS, ERTS, Root, Lib,
@@ -100,4 +100,4 @@ time_to_string({{Y,M,D},{H,Min,S}}) ->
                   [Y,M,D,H,Min,S])).
 
 parse_task(Str) ->
-    hd(re:split(Str, " ")).
+    hd(re:split(Str, " ", [unicode])).

--- a/src/rebar_prv_unlock.erl
+++ b/src/rebar_prv_unlock.erl
@@ -66,7 +66,7 @@ format_error(Reason) ->
 
 handle_unlocks(State, Locks, LockFile) ->
     {Args, _} = rebar_state:command_parsed_args(State),
-    Names = parse_names(ec_cnv:to_binary(proplists:get_value(package, Args, <<"">>))),
+    Names = parse_names(rebar_utils:to_binary(proplists:get_value(package, Args, <<"">>))),
     case [Lock || Lock = {Name, _, _} <- Locks, not lists:member(Name, Names)] of
         [] ->
             file:delete(LockFile);
@@ -77,7 +77,7 @@ handle_unlocks(State, Locks, LockFile) ->
     end.
 
 parse_names(Bin) ->
-    case lists:usort(re:split(Bin, <<" *, *">>, [trim])) of
+    case lists:usort(re:split(Bin, <<" *, *">>, [trim, unicode])) of
         [<<"">>] -> []; % nothing submitted
         Other -> Other
     end.

--- a/src/rebar_prv_update.erl
+++ b/src/rebar_prv_update.erl
@@ -150,7 +150,7 @@ update_deps_list(Pkg, PkgVsn, Deps, HexRegistry, State) ->
                             %% and doubled since spaces seem not to be
                             %% enforced
                             {false, Vsn} ->
-                                ?WARN("[~s:~s], Bad dependency version for ~s: ~s.",
+                                ?WARN("[~ts:~ts], Bad dependency version for ~ts: ~ts.",
                                       [Pkg, PkgVsn, Dep, Vsn]),
                                 DepsListAcc;
                             {_, <<"~>", Vsn/binary>>} ->
@@ -202,14 +202,14 @@ valid_vsn(Vsn) ->
     SemVerRegExp = "v?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))?"
         "(-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9a-z-]+(\\.[0-9a-z-]+)*)?",
     SupportedVersions = "^(>=?|<=?|~>|==)?\\s*" ++ SemVerRegExp ++ "$",
-    re:run(Vsn, SupportedVersions) =/= nomatch.
+    re:run(Vsn, SupportedVersions, [unicode]) =/= nomatch.
 
 highest_matching({Pkg, PkgVsn, Dep, App}, Vsn, HexRegistry, State, DepsListAcc) ->
     case rebar_packages:find_highest_matching(Pkg, PkgVsn, Dep, Vsn, HexRegistry, State) of
         {ok, HighestDepVsn} ->
             [{App, {pkg, Dep, HighestDepVsn, undefined}} | DepsListAcc];
         none ->
-            ?WARN("[~s:~s] Missing registry entry for package ~s. Try to fix with `rebar3 update`",
+            ?WARN("[~ts:~ts] Missing registry entry for package ~ts. Try to fix with `rebar3 update`",
                   [Pkg, PkgVsn, Dep]),
             DepsListAcc
     end.
@@ -220,7 +220,7 @@ cmp({_Pkg, _PkgVsn, Dep, _App} = Dep1, Vsn, HexRegistry, State, DepsListAcc, Cmp
 
 
 cmp_(undefined, _MinVsn, [], DepsListAcc, {Pkg, PkgVsn, Dep, _App}, _CmpFun) ->
-    ?WARN("[~s:~s] Missing registry entry for package ~s. Try to fix with `rebar3 update`",
+    ?WARN("[~ts:~ts] Missing registry entry for package ~ts. Try to fix with `rebar3 update`",
           [Pkg, PkgVsn, Dep]),
     DepsListAcc;
 cmp_(HighestDepVsn, _MinVsn, [], DepsListAcc, {_Pkg, _PkgVsn, Dep, App}, _CmpFun) ->
@@ -241,7 +241,7 @@ cmpl({_Pkg, _PkgVsn, Dep, _App} = Dep1, Vsn, HexRegistry, State, DepsListAcc, Cm
     cmpl_(undefined, Vsn, Vsns, DepsListAcc, Dep1, CmpFun).
 
 cmpl_(undefined, _MaxVsn, [], DepsListAcc, {Pkg, PkgVsn, Dep, _App}, _CmpFun) ->
-    ?WARN("[~s:~s] Missing registry entry for package ~s. Try to fix with `rebar3 update`",
+    ?WARN("[~ts:~ts] Missing registry entry for package ~ts. Try to fix with `rebar3 update`",
           [Pkg, PkgVsn, Dep]),
     DepsListAcc;
 

--- a/src/rebar_prv_xref.erl
+++ b/src/rebar_prv_xref.erl
@@ -71,7 +71,7 @@ short_desc() ->
 
 desc() ->
     io_lib:format(
-      "~s~n"
+      "~ts~n"
       "~n"
       "Valid rebar.config options:~n"
       "  ~p~n"
@@ -204,7 +204,7 @@ display_results(XrefResults, QueryResults) ->
      lists:map(fun display_query_result/1, QueryResults)].
 
 display_query_result({Query, Answer, Value}) ->
-    io_lib:format("Query ~s~n answer ~p~n did not match ~p~n",
+    io_lib:format("Query ~ts~n answer ~p~n did not match ~p~n",
                   [Query, Answer, Value]).
 
 display_xref_results_for_type({Type, XrefResults}) ->
@@ -225,37 +225,37 @@ display_xref_result_fun(Type) ->
                 end,
             case Type of
                 undefined_function_calls ->
-                    io_lib:format("~sWarning: ~s calls undefined function ~s (Xref)\n",
+                    io_lib:format("~tsWarning: ~ts calls undefined function ~ts (Xref)\n",
                                   [Source, SMFA, TMFA]);
                 undefined_functions ->
-                    io_lib:format("~sWarning: ~s is undefined function (Xref)\n",
+                    io_lib:format("~tsWarning: ~ts is undefined function (Xref)\n",
                                   [Source, SMFA]);
                 locals_not_used ->
-                    io_lib:format("~sWarning: ~s is unused local function (Xref)\n",
+                    io_lib:format("~tsWarning: ~ts is unused local function (Xref)\n",
                                   [Source, SMFA]);
                 exports_not_used ->
-                    io_lib:format("~sWarning: ~s is unused export (Xref)\n",
+                    io_lib:format("~tsWarning: ~ts is unused export (Xref)\n",
                                   [Source, SMFA]);
                 deprecated_function_calls ->
-                    io_lib:format("~sWarning: ~s calls deprecated function ~s (Xref)\n",
+                    io_lib:format("~tsWarning: ~ts calls deprecated function ~ts (Xref)\n",
                                   [Source, SMFA, TMFA]);
                 deprecated_functions ->
-                    io_lib:format("~sWarning: ~s is deprecated function (Xref)\n",
+                    io_lib:format("~tsWarning: ~ts is deprecated function (Xref)\n",
                                   [Source, SMFA]);
                 Other ->
-                    io_lib:format("~sWarning: ~s - ~s xref check: ~s (Xref)\n",
+                    io_lib:format("~tsWarning: ~ts - ~ts xref check: ~ts (Xref)\n",
                                   [Source, SMFA, TMFA, Other])
             end
     end.
 
 format_mfa({M, F, A}) ->
-    ?FMT("~s:~s/~w", [M, F, A]).
+    ?FMT("~ts:~ts/~w", [M, F, A]).
 
 format_mfa_source(MFA) ->
     case find_mfa_source(MFA) of
         {module_not_found, function_not_found} -> "";
-        {Source, function_not_found} -> ?FMT("~s: ", [Source]);
-        {Source, Line} -> ?FMT("~s:~w: ", [Source, Line])
+        {Source, function_not_found} -> ?FMT("~ts: ", [Source]);
+        {Source, Line} -> ?FMT("~ts:~w: ", [Source, Line])
     end.
 
 %%

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -182,7 +182,7 @@ all(_, []) ->
 all(Dir, [File|Artifacts]) ->
     case filelib:is_regular(filename:join(Dir, File)) of
         false ->
-            ?DEBUG("Missing artifact ~s", [filename:join(Dir, File)]),
+            ?DEBUG("Missing artifact ~ts", [filename:join(Dir, File)]),
             {false, File};
         true ->
             all(Dir, Artifacts)
@@ -302,9 +302,9 @@ dir(State=#state_t{}, Dir) ->
 
 deps_names(Deps) when is_list(Deps) ->
     lists:map(fun(Dep) when is_tuple(Dep) ->
-                      ec_cnv:to_binary(element(1, Dep));
+                      rebar_utils:to_binary(element(1, Dep));
                  (Dep) when is_atom(Dep) ->
-                      ec_cnv:to_binary(Dep)
+                      rebar_utils:to_binary(Dep)
               end, Deps);
 deps_names(State) ->
     Deps = rebar_state:get(State, deps, []),

--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -129,7 +129,7 @@ default_author_and_email() ->
             %% Ok, try mecurial
             case rebar_utils:sh("hg showconfig ui.username", [return_on_error]) of
                 {ok, NameEmail} ->
-                    case re:run(NameEmail, "^(.*) <(.*)>$", [{capture, [1,2], list}]) of
+                    case re:run(NameEmail, "^(.*) <(.*)>$", [{capture, [1,2], list}, unicode]) of
                         {match, [Name, Email]} ->
                             {Name, Email};
                         _ ->
@@ -169,7 +169,7 @@ maybe_warn_about_name(Vars) ->
         invalid ->
            ?WARN("The 'name' variable is often associated with Erlang "
                  "module names and/or file names. The value submitted "
-                 "(~s) isn't an unquoted Erlang atom. Templates "
+                 "(~ts) isn't an unquoted Erlang atom. Templates "
                  "generated may contain errors.",
                  [Name]);
         valid ->
@@ -189,7 +189,7 @@ validate_atom(Str) ->
 
 %% Run template instructions one at a time.
 execute_template([], _, {Template,_,_}, _, _) ->
-    ?DEBUG("Template ~s applied", [Template]),
+    ?DEBUG("Template ~ts applied", [Template]),
     ok;
 %% We can't execute the description
 execute_template([{description, _} | Terms], Files, Template, Vars, Force) ->
@@ -242,7 +242,7 @@ execute_template([{template, From, To} | Terms], Files, {Template, Type, Cwd}, V
     execute_template(Terms, Files, {Template, Type, Cwd}, Vars, Force);
 %% Unknown
 execute_template([Instruction|Terms], Files, Tpl={Template,_,_}, Vars, Force) ->
-    ?WARN("Unknown template instruction ~p in template ~s",
+    ?WARN("Unknown template instruction ~p in template ~ts",
           [Instruction, Template]),
     execute_template(Terms, Files, Tpl, Vars, Force).
 
@@ -305,7 +305,7 @@ cache_escript_files(State) ->
 find_escript_templates(Files) ->
     [{escript, Name}
      || {Name, _Bin} <- Files,
-        re:run(Name, ?TEMPLATE_RE, [{capture, none}]) == match].
+        re:run(Name, ?TEMPLATE_RE, [{capture, none}, unicode]) == match].
 
 find_localinstall_templates(_State) ->
     Templates = rebar_utils:find_files(code:priv_dir(rebar), ?TEMPLATE_RE),
@@ -374,7 +374,7 @@ prioritize_templates([{Name, Type, File} | Rest], Valid) ->
             prioritize_templates(Rest, Valid);
         {_, file, _} ->
             ?DEBUG("Skipping template ~p, due to presence of a custom "
-                   "template at ~s", [Name, File]),
+                   "template at ~ts", [Name, File]),
             prioritize_templates(Rest, Valid)
     end.
 
@@ -429,10 +429,10 @@ write_file(Output, Data, Force) ->
             ok = filelib:ensure_dir(Output),
             case {Force, FileExists} of
                 {true, true} ->
-                    ?INFO("Writing ~s (forcibly overwriting)",
+                    ?INFO("Writing ~ts (forcibly overwriting)",
                              [Output]);
                 _ ->
-                    ?INFO("Writing ~s", [Output])
+                    ?INFO("Writing ~ts", [Output])
             end,
             case file:write_file(Output, Data) of
                 ok ->
@@ -449,4 +449,4 @@ write_file(Output, Data, Force) ->
 %% Render a binary to a string, using mustache and the specified context
 %%
 render(Bin, Context) ->
-    bbmustache:render(ec_cnv:to_binary(Bin), Context, [{key_type, atom}]).
+    bbmustache:render(rebar_utils:to_binary(Bin), Context, [{key_type, atom}]).

--- a/test/rebar_as_SUITE.erl
+++ b/test/rebar_as_SUITE.erl
@@ -176,7 +176,7 @@ error_on_empty_tasks(Config) ->
 
 warn_match(App, History) ->
     lists:any(
-        fun({_, {rebar_log,log, [warn, "No entry for profile ~s in config.",
+        fun({_, {rebar_log,log, [warn, "No entry for profile ~ts in config.",
             [ArgApp]]}, _}) -> ArgApp =:= App
         ;  (_) ->
             false

--- a/test/rebar_ct_SUITE.erl
+++ b/test/rebar_ct_SUITE.erl
@@ -1611,7 +1611,7 @@ test_suite(Name) ->
                   "some_test(_) -> ok.\n", [Name]).
 
 cmd_sys_config_file(AppName) ->
-    io_lib:format("[{~s, [{key, cmd_value}]}].", [AppName]).
+    io_lib:format("[{~ts, [{key, cmd_value}]}].", [AppName]).
 
 cfg_sys_config_file(AppName) ->
-    io_lib:format("[{~s, [{key, cfg_value}]}].", [AppName]).
+    io_lib:format("[{~ts, [{key, cfg_value}]}].", [AppName]).

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -349,7 +349,7 @@ check_results(AppDir, Expected, ProfileRun) ->
                                      iolist_to_binary(LockVsn))
                 end
         ;  ({release, Name, Vsn, ExpectedDevMode}) ->
-                ct:pal("Release: ~p-~s", [Name, Vsn]),
+                ct:pal("Release: ~p-~ts", [Name, Vsn]),
                 {ok, Cwd} = file:get_cwd(),
                 try
                     file:set_cwd(AppDir),
@@ -377,14 +377,14 @@ check_results(AppDir, Expected, ProfileRun) ->
                     file:set_cwd(Cwd)
                 end
         ;  ({tar, Name, Vsn}) ->
-                ct:pal("Tarball: ~s-~s", [Name, Vsn]),
+                ct:pal("Tarball: ~ts-~ts", [Name, Vsn]),
                 Tarball = filename:join([AppDir, "_build", "rel", Name, Name++"-"++Vsn++".tar.gz"]),
                 ?assertNotEqual([], filelib:is_file(Tarball))
         ;  ({file, Filename}) ->
-                ct:pal("Filename: ~s", [Filename]),
+                ct:pal("Filename: ~ts", [Filename]),
                 ?assert(filelib:is_file(Filename))
         ;  ({dir, Dirname}) ->
-                ct:pal("Directory: ~s", [Dirname]),
+                ct:pal("Directory: ~ts", [Dirname]),
                 ?assert(filelib:is_dir(Dirname))
         end, Expected).
 


### PR DESCRIPTION
This is done through 3 main change groups:

- replacing `~s` by `~ts` in format strings, so that strings that
  contain unicode are properly printed rather than crashing
- adding the `unicode` argument to all function of the `re` module to
  ensure transformations on strings containing unicode data are valid
  instead of crashing (see issue #1302)
- replacing `ec_cnv:to_binary/1` and `ec_cnv:to_list/1` with matching
  functions in `rebar_utils`.

The last point has been done, rather than modifying and updating erlware
commons, because binary and list conversions can be a contentious
subject. For example, if what is being handled is actually bytes from a
given binary stream, then forcing a byte-oriented interpretation of the
data can corrupt it. As such, it does not appear safe to modify erlware
commons' conversion functions since it may not be safe for all its
users.

Instead, rebar3 reimplements a subset of them (only converting
atoms and chardata, ignoring numbers) with the explicit purpose of
handling unicode string data.

Tests were left as unchanged as possible. This may impact the ability to
run rebar3's own suites in a unicode path, but respects a principle of
least change for such a large patch.