### PR TITLE
No plus sign in path

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -49,7 +49,7 @@ profile_dir(Opts, Profiles) ->
         %%  of profiles to match order passed to `as`
         ["default"|Rest] -> {rebar_opts:get(Opts, base_dir, ?DEFAULT_BASE_DIR), Rest}
     end,
-    ProfilesDir = string:join(ProfilesStrings, "+"),
+    ProfilesDir = string:join(ProfilesStrings, "_"),
     filename:join(BaseDir, ProfilesDir).
 
 %% @doc returns the directory where dependencies should be placed

--- a/test/rebar_as_SUITE.erl
+++ b/test/rebar_as_SUITE.erl
@@ -121,7 +121,7 @@ as_dir_name(Config) ->
                                    ["as", "foo,bar,baz", "compile"],
                                    {ok, [{app, Name}]}),
 
-    true = filelib:is_dir(filename:join([AppDir, "_build", "foo+bar+baz"])).
+    true = filelib:is_dir(filename:join([AppDir, "_build", "foo_bar_baz"])).
 
 
 as_with_task_args(Config) ->

--- a/test/rebar_profiles_SUITE.erl
+++ b/test/rebar_profiles_SUITE.erl
@@ -369,7 +369,7 @@ deduplicated_paths(Config) ->
                                    ["as", "a,b,c,d,e,a,e,b", "compile"],
                                    {ok, [{app, Name}]}),
 
-    Path = filename:join([AppDir, "_build", "c+d+a+e+b", "lib", Name, "ebin"]),
+    Path = filename:join([AppDir, "_build", "c_d_a_e_b", "lib", Name, "ebin"]),
     ?assert(filelib:is_dir(Path)).
 
 test_profile_applied_at_completion(Config) ->


### PR DESCRIPTION
When rebar3 encounters multiple profile strings, such as "ci" and "test",
it concatenates them with a "+", yielding "ci+test". I've encountered issues
where CircleCI and IntelliJ attempt to serve the raw path and fail,
interpeting the "+" as a URL-encoded space. For simplicity, this PR
uses "_" instead of "+" to concatenate mutliple profile strings.