### PR TITLE
Fix total coverage

### DIFF
--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -248,7 +248,7 @@ calculate_total(Stats) ->
         Stats
     )).
 
-percentage({0, 0}) -> "0%";
+percentage({_, 0}) -> "100%";
 percentage({Cov, Not}) -> integer_to_list(trunc((Cov / (Cov + Not)) * 100)) ++ "%".
 
 write_index(State, Coverage) ->


### PR DESCRIPTION
Hey,

Given module __a__ with 1 line, and module __b__ with 99 lines 

#### Currently

```bash
  |------------------------|------------|
  |                module  |  coverage  |
  |------------------------|------------|
  |                     a  |        0%  |
  |                     b  |      100%  |
  |------------------------|------------|
  |                 total  |       50%  |
  |------------------------|------------|
```

#### Expected

```bash
  |------------------------|------------|
  |                module  |  coverage  |
  |------------------------|------------|
  |                     a  |        0%  |
  |                     b  |      100%  |
  |------------------------|------------|
  |                 total  |       99%  |
  |------------------------|------------|