### PR TITLE
Fix ordering of overlays and overlay vars in Relx

### DIFF
--- a/src/rebar_opts.erl
+++ b/src/rebar_opts.erl
@@ -132,7 +132,11 @@ merge_opt(mib_first_files, Value, Value) ->
 merge_opt(mib_first_files, NewValue, OldValue) ->
     OldValue ++ NewValue;
 merge_opt(relx, NewValue, OldValue) ->
-    rebar_utils:tup_umerge(OldValue, NewValue);
+    Partition = fun(C) -> is_tuple(C) andalso element(1, C) =:= overlay end,
+    {NewOverlays, NewOther} = lists:partition(Partition, NewValue),
+    {OldOverlays, OldOther} = lists:partition(Partition, OldValue),
+    rebar_utils:tup_umerge(NewOverlays, OldOverlays)
+    ++ rebar_utils:tup_umerge(OldOther, NewOther);
 merge_opt(Key, NewValue, OldValue)
     when Key == erl_opts; Key == eunit_compile_opts; Key == ct_compile_opts ->
     merge_erl_opts(lists:reverse(OldValue), NewValue);


### PR DESCRIPTION
Specifically, this impacts profiles. It appears that relx as a whole
requires its configuration to be merged in one tuple order (New takes
precedence over Old), whereas the overlays require the opposite (Old
takes precedence over New) since the operation order on disk is
important to work well.

This patch reorders overlay values such that the overlay of a profile
takes place *after* the basic overlay, ensuring that the profile actions
take place after the basic ones; this allows profiles to properly
overwrite files as expected (see #1609)

This is done while adequately maintaining the order of operations that
were required as part of #1563

Overlay vars of profiles are also checked to be working fine, along with
a test.

This fixes #1247 and #1609