### PR TITLE
fix `rebar3 shell` when relx section of rebar.config contains release…

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -322,6 +322,9 @@ find_apps_relx(State) ->
         {_, _, Apps} ->
             ?DEBUG("Found shell apps from relx.", []),
             Apps;
+        {_, _, Apps, _} ->
+            ?DEBUG("Found shell apps from relx.", []),
+            Apps;
         false ->
             no_value
     end.


### PR DESCRIPTION
…s with independent configurations