### PR TITLE
Fix relative src_dir specifications to avoid double .app.src file detection

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -258,8 +258,11 @@ extra_src_dirs(Opts, Default) ->
 
 %% @private agnostic version of src_dirs and extra_src_dirs.
 src_dirs(Type, Opts, Default) ->
-    lists:usort([case D0 of {D,_} -> D; _ -> D0 end ||
-                    D0 <- raw_src_dirs(Type,Opts,Default)]).
+    lists:usort([
+        case D0 of
+            {D,_} -> normalize_relative_path(D);
+            _ -> normalize_relative_path(D0)
+        end || D0 <- raw_src_dirs(Type,Opts,Default)]).
 
 %% @private extracts the un-formatted src_dirs or extra_src_dirs
 %% options as configured.
@@ -270,6 +273,10 @@ raw_src_dirs(Type, Opts, Default) ->
         []   -> Default;
         Dirs -> Dirs
     end.
+
+%% @private normalizes relative paths so that ./a/b/c/ => a/b/c
+normalize_relative_path(Path) ->
+    make_normalized_path(filename:split(Path), []).
 
 %% @doc returns all the source directories (`src_dirs' and
 %% `extra_src_dirs').

--- a/test/rebar_dir_SUITE.erl
+++ b/test/rebar_dir_SUITE.erl
@@ -68,7 +68,7 @@ default_all_src_dirs(Config) ->
     ["src", "test"] = rebar_dir:all_src_dirs(rebar_state:opts(State), ["src"], ["test"]).
 
 src_dirs(Config) ->
-    RebarConfig = [{erl_opts, [{src_dirs, ["foo", "bar", "baz"]}]}],
+    RebarConfig = [{erl_opts, [{src_dirs, ["foo", "./bar", "bar", "bar/", "./bar/", "baz"]}]}],
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
 
     ["bar", "baz", "foo"] = rebar_dir:src_dirs(rebar_state:opts(State)).


### PR DESCRIPTION
When fetching src_dir values, some relative paths can be inserted. When
deduplicating the paths on the fetch, this fact means that logically
duplicate (but literally different) directories can be returned at once.

By normalizing the names, duplication bugs can be resolved.

Fixes #1622