### PR TITLE
fix sys config merging

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -75,8 +75,9 @@ consult_config(State, Filename) ->
     JoinedConfig = lists:flatmap(
         fun (SubConfig) when is_list(SubConfig) ->
             case lists:suffix(".config", SubConfig) of
-                false -> consult_config(State, SubConfig ++ ".config");
-                true -> consult_config(State, SubConfig)
+                %% since consult_config returns a list in a list we take the head here
+                false -> hd(consult_config(State, SubConfig ++ ".config"));
+                true -> hd(consult_config(State, SubConfig))
             end;
             (Entry) -> [Entry]
       end, Config),

--- a/test/rebar_ct_SUITE.erl
+++ b/test/rebar_ct_SUITE.erl
@@ -1132,11 +1132,18 @@ cmd_sys_config(Config) ->
     CfgFile = filename:join([AppDir, "config", "cfg_sys.config"]),
     ok = filelib:ensure_dir(CfgFile),
     ok = file:write_file(CfgFile, cfg_sys_config_file(AppName)),
+
+    OtherCfgFile = filename:join([AppDir, "config", "other.config"]),
+    ok = filelib:ensure_dir(OtherCfgFile),
+    ok = file:write_file(OtherCfgFile, other_sys_config_file(AppName)),
+
     RebarConfig = [{ct_opts, [{sys_config, CfgFile}]}],
     {ok, State1} = rebar_test_utils:run_and_check(Config, RebarConfig, ["as", "test", "lock"], return),
 
     {ok, _} = rebar_prv_common_test:prepare_tests(State1),
     ?assertEqual({ok, cfg_value}, application:get_env(AppName, key)),
+
+    ?assertEqual({ok, other_cfg_value}, application:get_env(AppName, other_key)),
 
     Providers = rebar_state:providers(State1),
     Namespace = rebar_state:namespace(State1),
@@ -1614,4 +1621,7 @@ cmd_sys_config_file(AppName) ->
     io_lib:format("[{~ts, [{key, cmd_value}]}].", [AppName]).
 
 cfg_sys_config_file(AppName) ->
-    io_lib:format("[{~ts, [{key, cfg_value}]}].", [AppName]).
+    io_lib:format("[{~ts, [{key, cfg_value}]}, \"config/other\"].", [AppName]).
+
+other_sys_config_file(AppName) ->
+    io_lib:format("[{~ts, [{other_key, other_cfg_value}]}].", [AppName]).


### PR DESCRIPTION
Resolving the referenced config files resulted in a list in a list, `[{app, [...]}, [{app, [...]}]]`, and because of this it would not set those config values in `reread_config` which uses a list comphrension `[... || {Application, Items} <- Config, ...]`.

Since `consult_config` always returns a list of length 1 we can safely take the head of the returned list to fix this issue.