### PR TITLE
Corrects a fix to src_dir values

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -197,8 +197,10 @@ make_normalized_path([], NormalizedPath) ->
     filename:join(lists:reverse(NormalizedPath));
 make_normalized_path([H|T], NormalizedPath) ->
     case H of
+        "." when NormalizedPath == [], T == [] -> make_normalized_path(T, ["."]);
         "."  -> make_normalized_path(T, NormalizedPath);
-        ".." -> make_normalized_path(T, tl(NormalizedPath));
+        ".." when NormalizedPath == [] -> make_normalized_path(T, [".."]);
+        ".." when hd(NormalizedPath) =/= ".." -> make_normalized_path(T, tl(NormalizedPath));
         _    -> make_normalized_path(T, [H|NormalizedPath])
     end.
 

--- a/test/rebar_dir_SUITE.erl
+++ b/test/rebar_dir_SUITE.erl
@@ -68,10 +68,11 @@ default_all_src_dirs(Config) ->
     ["src", "test"] = rebar_dir:all_src_dirs(rebar_state:opts(State), ["src"], ["test"]).
 
 src_dirs(Config) ->
-    RebarConfig = [{erl_opts, [{src_dirs, ["foo", "./bar", "bar", "bar/", "./bar/", "baz"]}]}],
+    RebarConfig = [{erl_opts, [{src_dirs, ["foo", "./bar", "bar", "bar/", "./bar/", "baz",
+                                           "./", ".", "../", "..", "./../", "../.", ".././../"]}]}],
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
 
-    ["bar", "baz", "foo"] = rebar_dir:src_dirs(rebar_state:opts(State)).
+    [".", "..", "../..", "bar", "baz", "foo"] = rebar_dir:src_dirs(rebar_state:opts(State)).
 
 src_dirs_with_opts(Config) ->
     RebarConfig = [{erl_opts, [{src_dirs, ["foo", "bar", "baz"]},


### PR DESCRIPTION
The previous patch at #7c959cc fixed the usage of duplicate values
for directories through relative paths, but mistakenly went overboard
and dropped the `./` path, which is still fairly common. Similarly for
`../`.

The code is modified to special-case such values and keep the code
working.

Fixes https://github.com/erlang/rebar3/issues/1632 because paths like `./../` would yield a crash or an empty
string and now if a relative path is all that can be obtained, this is what
will be kept. Some fun edge cases like `./.././.././` cannot be made fully
normal in some cases and gets reduced to `../..`.