### PR TITLE
Various fixes related to .app files

### DIFF
--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -3,7 +3,7 @@
 
 {application, rebar,
  [{description, "Rebar: Erlang Build Tool"},
-  {vsn, "3.4.4"},
+  {vsn, "git"},
   {modules, []},
   {registered, []},
   {applications, [kernel,

--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -117,8 +117,11 @@ preprocess(State, AppInfo, AppSrcFile) ->
             %% without a 'registered' value.
             A3 = ensure_registered(A2),
 
+            %% some tools complain if a description is not present.
+            A4 = ensure_description(A3),
+
             %% Build the final spec as a string
-            Spec = io_lib:format("~p.\n", [{application, AppName, A3}]),
+            Spec = io_lib:format("~p.\n", [{application, AppName, A4}]),
 
             %% Setup file .app filename and write new contents
             EbinDir = rebar_app_info:ebin_dir(AppInfo),
@@ -192,6 +195,15 @@ ensure_registered(AppData) ->
             [{registered, []} | AppData];
         {registered, _} ->
             %% We could further check whether the value is a list of atoms.
+            AppData
+    end.
+
+ensure_description(AppData) ->
+    case lists:keyfind(description, 1, AppData) of
+        false ->
+            %% Required for releases to work.
+            [{description, ""} | AppData];
+        {description, _} ->
             AppData
     end.
 

--- a/test/rebar_pkg_alias_SUITE.erl
+++ b/test/rebar_pkg_alias_SUITE.erl
@@ -166,6 +166,8 @@ mock_config(Name, Config) ->
     {ChkFake, Etag} = create_lib(Name, Config, "fakelib"),
     {ChkTop, _} = create_lib(Name, Config, "topdep"),
     {ChkTrans, _} = create_lib(Name, Config, "transitive_app", "transitive"),
+    ct:pal("{~p, _}",[ChkTop]),
+    ct:pal("{~p, _}",[ChkTrans]),
     Priv = ?config(priv_dir, Config),
     TmpDir = filename:join([Priv, "tmp", atom_to_list(Name)]),
     %% Add an alias for goodpkg -> fakelib by hand
@@ -173,6 +175,7 @@ mock_config(Name, Config) ->
     CacheRoot = filename:join([Priv, "cache", atom_to_list(Name)]),
     CacheDir = filename:join([CacheRoot, "hex", "com", "test", "packages"]),
     rebar_test_utils:create_app(AppDir, "fakelib", "1.0.0", [kernel, stdlib]),
+    ct:pal("{~p, ~p}",[ChkFake, Etag]),
     {ChkFake, Etag} = rebar_test_utils:package_app(AppDir, CacheDir, "goodpkg-1.0.0"),
 
     Tid = ets:new(registry_table, [public]),


### PR DESCRIPTION
-  Add a description in compiled app file if undefined. Same default value as used in relx and other environments, but as reported in #979 some tools don't like having no description available.
- The parsing functions in app_details were used inconsistently, and the returned values were bad in some clauses; things only worked because they are never used within rebar3. This ensures the return types are consistent on all clauses.
- bundling in quickfixes (rollback to git versionning -- I bad messed up a commit) and test patch to find nondeterministic data.