### PR TITLE
Avoid guessing on utf8 decoding of app files

### DIFF
--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -127,7 +127,7 @@ preprocess(State, AppInfo, AppSrcFile) ->
             EbinDir = rebar_app_info:ebin_dir(AppInfo),
             filelib:ensure_dir(filename:join(EbinDir, "dummy.beam")),
             AppFile = rebar_app_utils:app_src_to_app(OutDir, AppSrcFile),
-            ok = rebar_file_utils:write_file_if_contents_differ(AppFile, Spec),
+            ok = rebar_file_utils:write_file_if_contents_differ(AppFile, Spec, utf8),
 
             AppFile;
         {error, Reason} ->


### PR DESCRIPTION
Rather than trying one method and then the other, allow the caller to
specify the encoding of the expected file. All other schemes are risky
and won't work well.

Rollback the function's default interface to the binary format in case
any plugin used it for non-unicode content, preserving backwards compat.

Fixes https://github.com/erlang/rebar3/issues/1644