### PR TITLE
Fix unlock state carry, which broke `do` sequences with `unlock` in them.

### DIFF
--- a/src/rebar_prv_unlock.erl
+++ b/src/rebar_prv_unlock.erl
@@ -49,8 +49,8 @@ do(State) ->
         {ok, _} ->
             Locks = rebar_config:consult_lock_file(LockFile),
             case handle_unlocks(State, Locks, LockFile) of
-                ok ->
-                    {ok, State};
+                {ok, NewLocks} ->
+                    {ok, rebar_state:set(State, {locks, default}, NewLocks)};
                 {error, Reason} ->
                     ?PRV_ERROR({file,Reason})
             end
@@ -69,11 +69,14 @@ handle_unlocks(State, Locks, LockFile) ->
     Names = parse_names(rebar_utils:to_binary(proplists:get_value(package, Args, <<"">>))),
     case [Lock || Lock = {Name, _, _} <- Locks, not lists:member(Name, Names)] of
         [] ->
-            file:delete(LockFile);
+            file:delete(LockFile),
+            {ok, []};
         _ when Names =:= [] -> % implicitly all locks
-            file:delete(LockFile);
+            file:delete(LockFile),
+            {ok, []};
         NewLocks ->
-            rebar_config:write_lock_file(LockFile, NewLocks)
+            rebar_config:write_lock_file(LockFile, NewLocks),
+            {ok, NewLocks}
     end.
 
 parse_names(Bin) ->

--- a/test/rebar_unlock_SUITE.erl
+++ b/test/rebar_unlock_SUITE.erl
@@ -42,8 +42,10 @@ unlock(Config) ->
     Locks = read_locks(Config),
     rebar_test_utils:run_and_check(Config, [], ["unlock", "fakeapp"], {ok, []}),
     Locks = read_locks(Config),
-    rebar_test_utils:run_and_check(Config, [], ["unlock", "uuid"], {ok, []}),
+    {ok, State} = rebar_test_utils:run_and_check(Config, [], ["unlock", "uuid"], return),
     ?assertEqual(Locks -- ["uuid"], read_locks(Config)),
+    ?assert(false =:= lists:keyfind(<<"uuid">>, 1, rebar_state:get(State, {locks, default}))),
+    ?assert(false =/= lists:keyfind(<<"itc">>, 1, rebar_state:get(State, {locks, default}))),
     rebar_test_utils:run_and_check(Config, [], ["unlock", "gproc,itc"], {ok, []}),
     ?assertEqual(Locks -- ["uuid","gproc","itc"], read_locks(Config)),
     rebar_test_utils:run_and_check(Config, [], ["unlock", string:join(Locks,",")], {ok, []}),
@@ -52,8 +54,9 @@ unlock(Config) ->
 
 unlock_all(Config) ->
     [_|_] = read_locks(Config),
-    rebar_test_utils:run_and_check(Config, [], ["unlock"], {ok, []}),
+    {ok, State} = rebar_test_utils:run_and_check(Config, [], ["unlock"], return),
     ?assertEqual({error, enoent}, read_locks(Config)),
+    ?assertEqual([], rebar_state:get(State, {locks, default})),
     ok.
 
 read_locks(Config) ->


### PR DESCRIPTION
Fixes bugs in behaviour where `rebar3 do unlock, other_cmd` was not equivalent of `rebar3 unlock && rebar3 other_cmd` because the `unlock` provider forgot to update the internal state before returning.