### PR TITLE
Prevent hard crash on duplicate plugin paths

### DIFF
--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -136,6 +136,7 @@ process_command(State, Command) ->
 do([], State) ->
     {ok, State};
 do([ProviderName | Rest], State) ->
+    ?DEBUG("Provider: ~p", [ProviderName]),
     %% Special providers like 'as', 'do' or some hooks may be passed
     %% as a tuple {Namespace, Name}, otherwise not. Handle them
     %% on a per-need basis.

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -766,7 +766,7 @@ remove_from_code_path(Paths) ->
                                   [begin code:purge(M), code:delete(M) end || M <- Modules]
                           end,
                           code:del_path(Path)
-                  end, Paths).
+                  end, lists:usort(Paths)).
 
 %% @doc Revert to only having the beams necessary for running rebar3 and
 %% plugins in the path


### PR DESCRIPTION
When a global plugin is used both locally and within the project, there
are cases when the rebar3 program will hard crash (killed in do_boot).
This has been traced to plugin-handling in compilation, where the same
code path may be purged twice in a row without further reloading for the
compile operation.

This of course yields the result where the code handling on the VM kills
all processes holding references to the module in memory, in this case
the rebar3 process itself.

By deduplicating the paths first, we ensure at most one purge before
reloading plugins and paths, and this prevents a hard crash.