### PR TITLE
fixed handling of proxy username and password when fetching registry

### DIFF
--- a/src/rebar_prv_update.erl
+++ b/src/rebar_prv_update.erl
@@ -51,7 +51,7 @@ do(State) ->
                 CDN = rebar_state:get(State, rebar_packages_cdn, ?DEFAULT_CDN),
                 case rebar_utils:url_append_path(CDN, ?REMOTE_REGISTRY_FILE) of
                     {ok, Url} ->
-                        HttpOptions = rebar_utils:get_proxy_auth(),
+                        HttpOptions = [{relaxed, true} | rebar_utils:get_proxy_auth()],
                         ?DEBUG("Fetching registry from ~p", [Url]),
                         case httpc:request(get, {Url, [{"User-Agent", rebar_utils:user_agent()}]},
                                            HttpOptions, [{stream, TmpFile}, {sync, true}],

--- a/src/rebar_prv_update.erl
+++ b/src/rebar_prv_update.erl
@@ -51,9 +51,10 @@ do(State) ->
                 CDN = rebar_state:get(State, rebar_packages_cdn, ?DEFAULT_CDN),
                 case rebar_utils:url_append_path(CDN, ?REMOTE_REGISTRY_FILE) of
                     {ok, Url} ->
+                        HttpOptions = rebar_utils:get_proxy_auth(),
                         ?DEBUG("Fetching registry from ~p", [Url]),
                         case httpc:request(get, {Url, [{"User-Agent", rebar_utils:user_agent()}]},
-                                           [], [{stream, TmpFile}, {sync, true}],
+                                           HttpOptions, [{stream, TmpFile}, {sync, true}],
                                            rebar) of
                             {ok, saved_to_file} ->
                                 {ok, Data} = file:read_file(TmpFile),


### PR DESCRIPTION
I am not sure about option {relaxed, true}. 
In my case, it also works without it.
Should I add it? Like in this place:
https://github.com/erlang/rebar3/blob/3.4.4/src/rebar_pkg_resource.erl#L110