### PR TITLE
Call next resource when first matching module is not available in com…

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -682,8 +682,12 @@ vcs_vsn_cmd({cmd, _Cmd}=Custom, _, _) ->
     Custom;
 vcs_vsn_cmd(VCS, Dir, Resources) when is_atom(VCS) ->
     case find_resource_module(VCS, Resources) of
-        {ok, Module} ->
-            Module:make_vsn(Dir);
+        {ok, Module, Resources1} ->
+            try
+                Module:make_vsn(Dir)
+            catch _:undef ->
+                vcs_vsn_cmd(VCS, Dir, Resources1)
+            end;
         {error, _} ->
             unknown
     end;
@@ -712,10 +716,10 @@ find_resource_module(Type, Resources) ->
                 non_existing ->
                     {error, unknown};
                 _ ->
-                    {ok, Type}
+                    {ok, Type, Resources}
             end;
         {Type, Module} ->
-            {ok, Module}
+            {ok, Module, lists:keydelete(Type, 1, Resources)}
     end.
 
 %% @doc ident to the level specified


### PR DESCRIPTION
…pile phase

As rebar3 unloads all available plugin modules before compile phase
plugin  modules implementing resource behaviour are not in memory when
rebar_prv_compile:compile/3 calls MyResourceModule:make_vsn/3.