### PR TITLE
Allow silencing skip warnings when fetching deps

### DIFF
--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -419,8 +419,13 @@ warn_skip_deps(AppInfo, State) ->
     Args = [rebar_app_info:name(AppInfo),
             rebar_app_info:source(AppInfo)],
     case rebar_state:get(State, deps_error_on_conflict, false) of
-        false -> ?WARN(Msg, Args);
-        true -> ?ERROR(Msg, Args), ?FAIL
+        false ->
+            case rebar_state:get(State, deps_warning_on_conflict, true) of
+                true  -> ?WARN(Msg, Args);
+                false -> ok
+            end;
+        true ->
+            ?ERROR(Msg, Args), ?FAIL
     end.
 
 not_needs_compile(App) ->


### PR DESCRIPTION
When fetching deps, if this is a clean repo there will be extensive
messages warning that dependencies which have already been fetched are
being skipped. For large projects being built and tested in a clean
environment this significantly increases the noise level of the build.

This modification adds an additional rebar option
(deps_warning_on_conflict) that will allow disabling these warning
messages. If deps_error_on_conflict is set, an error will still be
thrown. This will not change default behaviour of rebar.

There is a similar outstanding issue:
https://github.com/erlang/rebar3/issues/1105
However this seems to be a push for not outputting warnings when the dep
version is the same, rather than disabling warnings altogether.