### PR TITLE
add eunit and ct option to set coverdata file name

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -8,8 +8,11 @@
 -export([init/1,
          do/1,
          format_error/1]).
-%% exported for test purposes, consider private
--export([compile/2, prepare_tests/1, translate_paths/2]).
+
+-ifdef(TEST).
+%% exported for test purposes
+-export([compile/2, prepare_tests/1, translate_paths/2, maybe_write_coverdata/1]).
+-endif.
 
 -include("rebar.hrl").
 -include_lib("providers/include/providers.hrl").
@@ -728,7 +731,8 @@ maybe_write_coverdata(State) ->
         true  -> rebar_state:set(State, cover_enabled, true);
         false -> State
     end,
-    rebar_prv_cover:maybe_write_coverdata(State1, ?PROVIDER).
+    Name = proplists:get_value(cover_export_name, RawOpts, ?PROVIDER),
+    rebar_prv_cover:maybe_write_coverdata(State1, Name).
 
 ct_opts(_State) ->
     [{dir, undefined, "dir", string, help(dir)}, %% comma-separated list
@@ -744,6 +748,7 @@ ct_opts(_State) ->
      {logopts, undefined, "logopts", string, help(logopts)}, %% comma-separated list
      {verbosity, undefined, "verbosity", integer, help(verbosity)}, %% Integer
      {cover, $c, "cover", {boolean, false}, help(cover)},
+     {cover_export_name, undefined, "cover_export_name", string, help(cover_export_name)},
      {repeat, undefined, "repeat", integer, help(repeat)}, %% integer
      {duration, undefined, "duration", string, help(duration)}, % format: HHMMSS
      {until, undefined, "until", string, help(until)}, %% format: YYMoMoDD[HHMMSS]
@@ -797,6 +802,8 @@ help(verbosity) ->
     "Verbosity";
 help(cover) ->
     "Generate cover data";
+help(cover_export_name) ->
+    "Base name of the coverdata file to write";
 help(repeat) ->
     "How often to repeat tests";
 help(duration) ->

--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -372,10 +372,10 @@ redirect_cover_output(State, CoverPid) ->
                         [append]),
     group_leader(F, CoverPid).
 
-write_coverdata(State, Task) ->
+write_coverdata(State, Name) ->
     DataDir = cover_dir(State),
     ok = filelib:ensure_dir(filename:join([DataDir, "dummy.log"])),
-    ExportFile = filename:join([DataDir, atom_to_list(Task) ++ ".coverdata"]),
+    ExportFile = filename:join([DataDir, rebar_utils:to_list(Name) ++ ".coverdata"]),
     case cover:export(ExportFile) of
         ok ->
             %% dump accumulated coverdata after writing

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -472,7 +472,8 @@ maybe_write_coverdata(State) ->
         true  -> rebar_state:set(State, cover_enabled, true);
         false -> State
     end,
-    rebar_prv_cover:maybe_write_coverdata(State1, ?PROVIDER).
+    Name = proplists:get_value(cover_export_name, RawOpts, ?PROVIDER),
+    rebar_prv_cover:maybe_write_coverdata(State1, Name).
 
 handle_results(ok) -> ok;
 handle_results(error) ->
@@ -484,6 +485,7 @@ eunit_opts(_State) ->
     [{app, undefined, "app", string, help(app)},
      {application, undefined, "application", string, help(app)},
      {cover, $c, "cover", boolean, help(cover)},
+     {cover_export_name, undefined, "cover_export_name", string, help(cover_export_name)},
      {dir, $d, "dir", string, help(dir)},
      {file, $f, "file", string, help(file)},
      {module, $m, "module", string, help(module)},
@@ -495,6 +497,7 @@ eunit_opts(_State) ->
 
 help(app)       -> "Comma separated list of application test suites to run. Equivalent to `[{application, App}]`.";
 help(cover)     -> "Generate cover data. Defaults to false.";
+help(cover_export_name) -> "Base name of the coverdata file to write";
 help(dir)       -> "Comma separated list of dirs to load tests from. Equivalent to `[{dir, Dir}]`.";
 help(file)      -> "Comma separated list of files to load tests from. Equivalent to `[{file, File}]`.";
 help(module)    -> "Comma separated list of modules to load tests from. Equivalent to `[{module, Module}]`.";

--- a/test/rebar_cover_SUITE.erl
+++ b/test/rebar_cover_SUITE.erl
@@ -7,6 +7,7 @@
          all/0,
          flag_coverdata_written/1,
          config_coverdata_written/1,
+         config_coverdata_overridden_name_written/1,
          basic_extra_src_dirs/1,
          release_extra_src_dirs/1,
          root_extra_src_dirs/1,
@@ -34,6 +35,7 @@ init_per_testcase(_, Config) ->
 
 all() ->
     [flag_coverdata_written, config_coverdata_written,
+     config_coverdata_overridden_name_written,
      basic_extra_src_dirs, release_extra_src_dirs,
      root_extra_src_dirs,
      index_written,
@@ -69,6 +71,21 @@ config_coverdata_written(Config) ->
                                    {ok, [{app, Name}]}),
 
     true = filelib:is_file(filename:join([AppDir, "_build", "test", "cover", "eunit.coverdata"])).
+
+config_coverdata_overridden_name_written(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("cover_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_eunit_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    RebarConfig = [{erl_opts, [{d, some_define}]}, {cover_enabled, true}],
+    rebar_test_utils:run_and_check(Config,
+                                   RebarConfig,
+                                   ["eunit", "--cover_export_name=test_name"],
+                                   {ok, [{app, Name}]}),
+
+    true = filelib:is_file(filename:join([AppDir, "_build", "test", "cover", "test_name.coverdata"])).
 
 basic_extra_src_dirs(Config) ->
     AppDir = ?config(apps, Config),


### PR DESCRIPTION
Adds option for `eunit` and `ct` to set the name of the coverdata file exported when cover is enabled. this will allow for aggregating cover stats of multiple different `ct` or `eunit` runs -- not simply aggregating `ct` and `eunit` runs together.