### PR TITLE
Fix repeated bootstrap runs

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -168,8 +168,9 @@ compile_file(File, Opts) ->
 bootstrap_rebar3() ->
     filelib:ensure_dir("_build/default/lib/rebar/ebin/dummy.beam"),
     code:add_path("_build/default/lib/rebar/ebin/"),
-    ok = symlink_or_copy(filename:absname("src"),
-                         filename:absname("_build/default/lib/rebar/src")),
+    Res = symlink_or_copy(filename:absname("src"),
+                          filename:absname("_build/default/lib/rebar/src")),
+    true = Res == ok orelse Res == exists,
     Sources = ["src/rebar_resource.erl" | filelib:wildcard("src/*.erl")],
     [compile_file(X, [{outdir, "_build/default/lib/rebar/ebin/"}
                      ,return | additional_defines()]) || X <- Sources],


### PR DESCRIPTION
Updating the bootstrap script in #1689 made it so symlinks that already
exist return `exist` rather than ok, in line with the regular code.
However the bootstrap module wouldn't handle this case.

This fixes the problem by ensuring that `exists` is as valid as `ok`.

Fixes #1691 