### PR TITLE
Env for providers

### DIFF
--- a/src/rebar_env.erl
+++ b/src/rebar_env.erl
@@ -49,7 +49,6 @@ create_env(State, Opts) ->
      {"ERLC",                    filename:join([code:root_dir(), "bin", "erlc"])},
      {"ERLANG_ARCH"  ,           rebar_api:wordsize()},
      {"ERLANG_TARGET",           rebar_api:get_arch()}
-
     ].
 
 %% ====================================================================

--- a/src/rebar_env.erl
+++ b/src/rebar_env.erl
@@ -1,0 +1,66 @@
+-module(rebar_env).
+
+-export([create_env/2]).
+
+-include("rebar.hrl").
+
+%% @doc The following environment variables are exported when running
+%% a hook (absolute paths):
+%%
+%% REBAR_DEPS_DIR          = rebar_dir:deps_dir/1
+%% REBAR_BUILD_DIR         = rebar_dir:base_dir/1
+%% REBAR_ROOT_DIR          = rebar_dir:root_dir/1
+%% REBAR_CHECKOUTS_DIR     = rebar_dir:checkouts_dir/1
+%% REBAR_PLUGINS_DIR       = rebar_dir:plugins_dir/1
+%% REBAR_GLOBAL_CONFIG_DIR = rebar_dir:global_config_dir/1
+%% REBAR_GLOBAL_CACHE_DIR  = rebar_dir:global_cache_dir/1
+%% REBAR_TEMPLATE_DIR      = rebar_dir:template_dir/1
+%% REBAR_APP_DIRS          = rebar_dir:lib_dirs/1
+%% REBAR_SRC_DIRS          = rebar_dir:src_dirs/1
+%%
+%% autoconf compatible variables
+%% (see: http://www.gnu.org/software/autoconf/manual/autoconf.html#Erlang-Libraries):
+%% ERLANG_ERTS_VER              = erlang:system_info(version)
+%% ERLANG_ROOT_DIR              = code:root_dir/0
+%% ERLANG_LIB_DIR_erl_interface = code:lib_dir(erl_interface)
+%% ERLANG_LIB_VER_erl_interface = version part of path returned by code:lib_dir(erl_interface)
+%% ERL                          = ERLANG_ROOT_DIR/bin/erl
+%% ERLC                         = ERLANG_ROOT_DIR/bin/erl
+%%
+-spec create_env(rebar_state:t(), rebar_dict()) -> proplists:proplist().
+create_env(State, Opts) ->
+    BaseDir = rebar_dir:base_dir(State),
+    [
+     {"REBAR_DEPS_DIR",          filename:absname(rebar_dir:deps_dir(State))},
+     {"REBAR_BUILD_DIR",         filename:absname(rebar_dir:base_dir(State))},
+     {"REBAR_ROOT_DIR",          filename:absname(rebar_dir:root_dir(State))},
+     {"REBAR_CHECKOUTS_DIR",     filename:absname(rebar_dir:checkouts_dir(State))},
+     {"REBAR_PLUGINS_DIR",       filename:absname(rebar_dir:plugins_dir(State))},
+     {"REBAR_GLOBAL_CONFIG_DIR", filename:absname(rebar_dir:global_config_dir(State))},
+     {"REBAR_GLOBAL_CACHE_DIR",  filename:absname(rebar_dir:global_cache_dir(Opts))},
+     {"REBAR_TEMPLATE_DIR",      filename:absname(rebar_dir:template_dir(State))},
+     {"REBAR_APP_DIRS",          join_dirs(BaseDir, rebar_dir:lib_dirs(State))},
+     {"REBAR_SRC_DIRS",          join_dirs(BaseDir, rebar_dir:all_src_dirs(Opts))},
+     {"ERLANG_ERTS_VER",         erlang:system_info(version)},
+     {"ERLANG_ROOT_DIR",         code:root_dir()},
+     {"ERLANG_LIB_DIR_erl_interface", code:lib_dir(erl_interface)},
+     {"ERLANG_LIB_VER_erl_interface", re_version(code:lib_dir(erl_interface))},
+     {"ERL",                     filename:join([code:root_dir(), "bin", "erl"])},
+     {"ERLC",                    filename:join([code:root_dir(), "bin", "erlc"])},
+     {"ERLANG_ARCH"  ,           rebar_api:wordsize()},
+     {"ERLANG_TARGET",           rebar_api:get_arch()}
+
+    ].
+
+%% ====================================================================
+%% Internal functions
+%% ====================================================================
+
+join_dirs(BaseDir, Dirs) ->
+    rebar_string:join([filename:join(BaseDir, Dir) || Dir <- Dirs], ":").
+
+re_version(Path) ->
+    case re:run(Path, "^.*-(?<VER>[^/-]*)$", [{capture,[1],list}, unicode]) of
+        nomatch -> "";
+        {match, [Ver]} -> Ver
+    end.

--- a/src/rebar_env.erl
+++ b/src/rebar_env.erl
@@ -1,6 +1,7 @@
 -module(rebar_env).
 
--export([create_env/2]).
+-export([create_env/1,
+         create_env/2]).
 
 -include("rebar.hrl").
 
@@ -27,6 +28,12 @@
 %% ERL                          = ERLANG_ROOT_DIR/bin/erl
 %% ERLC                         = ERLANG_ROOT_DIR/bin/erl
 %%
+
+-spec create_env(rebar_state:t()) -> proplists:proplist().
+create_env(State) ->
+    Opts = rebar_state:opts(State),
+    create_env(State, Opts).
+
 -spec create_env(rebar_state:t(), rebar_dict()) -> proplists:proplist().
 create_env(State, Opts) ->
     BaseDir = rebar_dir:base_dir(State),

--- a/src/rebar_hooks.erl
+++ b/src/rebar_hooks.erl
@@ -61,29 +61,6 @@ format_error({bad_provider, Type, Command, {Name, Namespace}}) ->
 format_error({bad_provider, Type, Command, Name}) ->
     io_lib:format("Unable to run ~ts hooks for '~p', command '~p' not found.", [Type, Command, Name]).
 
-%% @doc The following environment variables are exported when running
-%% a hook (absolute paths):
-%%
-%% REBAR_DEPS_DIR          = rebar_dir:deps_dir/1
-%% REBAR_BUILD_DIR         = rebar_dir:base_dir/1
-%% REBAR_ROOT_DIR          = rebar_dir:root_dir/1
-%% REBAR_CHECKOUTS_DIR     = rebar_dir:checkouts_dir/1
-%% REBAR_PLUGINS_DIR       = rebar_dir:plugins_dir/1
-%% REBAR_GLOBAL_CONFIG_DIR = rebar_dir:global_config_dir/1
-%% REBAR_GLOBAL_CACHE_DIR  = rebar_dir:global_cache_dir/1
-%% REBAR_TEMPLATE_DIR      = rebar_dir:template_dir/1
-%% REBAR_APP_DIRS          = rebar_dir:lib_dirs/1
-%% REBAR_SRC_DIRS          = rebar_dir:src_dirs/1
-%%
-%% autoconf compatible variables
-%% (see: http://www.gnu.org/software/autoconf/manual/autoconf.html#Erlang-Libraries):
-%% ERLANG_ERTS_VER              = erlang:system_info(version)
-%% ERLANG_ROOT_DIR              = code:root_dir/0
-%% ERLANG_LIB_DIR_erl_interface = code:lib_dir(erl_interface)
-%% ERLANG_LIB_VER_erl_interface = version part of path returned by code:lib_dir(erl_interface)
-%% ERL                          = ERLANG_ROOT_DIR/bin/erl
-%% ERLC                         = ERLANG_ROOT_DIR/bin/erl
-%%
 run_hooks(Dir, pre, Command, Opts, State) ->
     run_hooks(Dir, pre_hooks, Command, Opts, State);
 run_hooks(Dir, post, Command, Opts, State) ->
@@ -94,7 +71,7 @@ run_hooks(Dir, Type, Command, Opts, State) ->
             ?DEBUG("run_hooks(~p, ~p, ~p) -> no hooks defined\n", [Dir, Type, Command]),
             ok;
         Hooks ->
-            Env = create_env(State, Opts),
+            Env = rebar_env:create_env(State, Opts),
             lists:foreach(fun({_, C, _}=Hook) when C =:= Command ->
                                   apply_hook(Dir, Env, Hook);
                              ({C, _}=Hook) when C =:= Command ->
@@ -114,36 +91,3 @@ apply_hook(Dir, Env, {Arch, Command, Hook}) ->
 apply_hook(Dir, Env, {Command, Hook}) ->
     Msg = lists:flatten(io_lib:format("Hook for ~p failed!~n", [Command])),
     rebar_utils:sh(Hook, [use_stdout, {cd, Dir}, {env, Env}, {abort_on_error, Msg}]).
-
-create_env(State, Opts) ->
-    BaseDir = rebar_dir:base_dir(State),
-    [
-     {"REBAR_DEPS_DIR",          filename:absname(rebar_dir:deps_dir(State))},
-     {"REBAR_BUILD_DIR",         filename:absname(rebar_dir:base_dir(State))},
-     {"REBAR_ROOT_DIR",          filename:absname(rebar_dir:root_dir(State))},
-     {"REBAR_CHECKOUTS_DIR",     filename:absname(rebar_dir:checkouts_dir(State))},
-     {"REBAR_PLUGINS_DIR",       filename:absname(rebar_dir:plugins_dir(State))},
-     {"REBAR_GLOBAL_CONFIG_DIR", filename:absname(rebar_dir:global_config_dir(State))},
-     {"REBAR_GLOBAL_CACHE_DIR",  filename:absname(rebar_dir:global_cache_dir(Opts))},
-     {"REBAR_TEMPLATE_DIR",      filename:absname(rebar_dir:template_dir(State))},
-     {"REBAR_APP_DIRS",          join_dirs(BaseDir, rebar_dir:lib_dirs(State))},
-     {"REBAR_SRC_DIRS",          join_dirs(BaseDir, rebar_dir:all_src_dirs(Opts))},
-     {"ERLANG_ERTS_VER",         erlang:system_info(version)},
-     {"ERLANG_ROOT_DIR",         code:root_dir()},
-     {"ERLANG_LIB_DIR_erl_interface", code:lib_dir(erl_interface)},
-     {"ERLANG_LIB_VER_erl_interface", re_version(code:lib_dir(erl_interface))},
-     {"ERL",                     filename:join([code:root_dir(), "bin", "erl"])},
-     {"ERLC",                    filename:join([code:root_dir(), "bin", "erlc"])},
-     {"ERLANG_ARCH"  ,           rebar_api:wordsize()},
-     {"ERLANG_TARGET",           rebar_api:get_arch()}
-
-    ].
-
-join_dirs(BaseDir, Dirs) ->
-    rebar_string:join([filename:join(BaseDir, Dir) || Dir <- Dirs], ":").
-
-re_version(Path) ->
-    case re:run(Path, "^.*-(?<VER>[^/-]*)$", [{capture,[1],list}, unicode]) of
-        nomatch -> "";
-        {match, [Ver]} -> Ver
-    end.


### PR DESCRIPTION
This adds and exports the necessary parts to use env variables like REBAR_DEPS_DIR inside provider hooks. It addresses this issue in port_compiler: https://github.com/blt/port_compiler/issues/30

There will be a separate pull request in that repo as well.

This branch is based off of https://github.com/erlang/rebar3/pull/1698 and should not be merged before that one. But in order to use env variables in port_specs of deps, you actually have to run the port_hooks for the deps. So this depends on the mentioned pull request.
