### PR TITLE
Issue #1704: Fix alias provider argument passing

### DIFF
--- a/src/rebar_prv_alias.erl
+++ b/src/rebar_prv_alias.erl
@@ -70,33 +70,56 @@ example(Alias) ->
     "rebar3 " ++ atom_to_list(Alias).
 
 desc(Cmds) ->
-    "Equivalent to running: rebar3 do " ++
-    rebar_string:join(lists:map(fun({Cmd, Args}) ->
-                                        atom_to_list(Cmd) ++ " " ++ Args;
-                                   (Cmd) ->
-                                        atom_to_list(Cmd)
-                                end, Cmds), ",").
+    "Equivalent to running: rebar3 do "
+        ++ rebar_string:join(lists:map(fun to_desc/1, Cmds), ",").
+
+to_desc({Cmd, Args}) ->
+    atom_to_list(Cmd) ++ " " ++ Args;
+to_desc(Cmd) ->
+    atom_to_list(Cmd).
 
 module(Name) ->
-    {attribute,1,module,Name}.
+    {attribute, 1, module, Name}.
 
 exports() ->
-    {attribute,1,export,[{do,1}]}.
+    {attribute, 1, export, [{do, 1}]}.
 
 do_func(Cmds) ->
-    {function,1,do,1,
-     [{clause,1,
-       [{var,1,'State'}],
+    {function, 1, do, 1,
+     [{clause, 1,
+       [{var, 1, 'State'}],
        [],
-       [{call,1,
-         {remote,1,{atom,1,rebar_prv_do},{atom,1,do_tasks}},
-         [to_args(Cmds),{var,1,'State'}]}]}]}.
+       [{call, 1,
+         {remote, 1, {atom, 1, rebar_prv_do}, {atom, 1, do_tasks}},
+         [make_args(Cmds), {var, 1, 'State'}]}]}]}.
 
+make_args(Cmds) ->
+    make_list(
+      lists:map(fun make_tuple/1,
+                lists:map(fun make_arg/1, Cmds))).
 
-to_args([]) ->
-    {nil,1};
-to_args([{Cmd, Args} | Rest]) ->
-    {cons,1,{tuple,1,[{string,1,atom_to_list(Cmd)},{string,1,Args}]}, to_args(Rest)};
-to_args([Cmd | Rest]) ->
-    {cons,1,{tuple,1,[{string,1,atom_to_list(Cmd)},{nil,1}]}, to_args(Rest)}.
+make_arg({Cmd, Args}) ->
+    {make_string(Cmd), make_list([make_string(A) || A <- split_args(Args)])};
+make_arg(Cmd) ->
+    {make_string(Cmd), make_list([])}.
 
+make_tuple(Tuple) ->
+    {tuple, 1, tuple_to_list(Tuple)}.
+
+make_list(List) ->
+    lists:foldr(
+      fun(Elem, Acc) -> {cons, 1, Elem, Acc} end,
+      {nil, 1},
+      List).
+
+make_string(Atom) when is_atom(Atom) ->
+    make_string(atom_to_list(Atom));
+make_string(String) when is_list(String) ->
+    {string, 1, String}.
+
+%% In case someone used the long option format, the option needs to get
+%% separated from its value.
+split_args(Args) ->
+    rebar_string:lexemes(
+      lists:map(fun($=) -> 32; (C) -> C end, Args),
+      " ").


### PR DESCRIPTION
The way arguments are passed by the alias provider is not compatible
with all rebar providers/commands. Especially the release (relx)
provider does not like getting its arguments as a plain string. It
expects its arguments in a pre-parsed format as returned by
getopt:parse/2.

Other commands, e.g. eunit, seem to be fine with both ways of argument
passing. Therefore, this fix changes the alias provider argument passing
to the getopt format in general.

Basically, this is a port of this tsloughter/rebar_alias#1 PR.