### PR TITLE
sort-as: force an order on multiple profiles

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -49,7 +49,7 @@ profile_dir(Opts, Profiles) ->
         %%  of profiles to match order passed to `as`
         ["default"|Rest] -> {rebar_opts:get(Opts, base_dir, ?DEFAULT_BASE_DIR), Rest}
     end,
-    ProfilesDir = rebar_string:join(lists:sort(ProfilesStrings), "+"),
+    ProfilesDir = rebar_string:join(ProfilesStrings, "+"),
     filename:join(BaseDir, ProfilesDir).
 
 %% @doc returns the directory where dependencies should be placed

--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -49,7 +49,7 @@ profile_dir(Opts, Profiles) ->
         %%  of profiles to match order passed to `as`
         ["default"|Rest] -> {rebar_opts:get(Opts, base_dir, ?DEFAULT_BASE_DIR), Rest}
     end,
-    ProfilesDir = rebar_string:join(ProfilesStrings, "+"),
+    ProfilesDir = rebar_string:join(lists:sort(ProfilesStrings), "+"),
     filename:join(BaseDir, ProfilesDir).
 
 %% @doc returns the directory where dependencies should be placed

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -43,6 +43,10 @@
          allow_provider_overrides/1, allow_provider_overrides/2
         ]).
 
+-ifdef(TEST).
+-export([deduplicate/1]).
+-endif.
+
 -include("rebar.hrl").
 -include_lib("providers/include/providers.hrl").
 

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -257,12 +257,15 @@ apply_profiles(State, Profile) when not is_list(Profile) ->
 apply_profiles(State, [default]) ->
     State;
 apply_profiles(State=#state_t{default = Defaults, current_profiles=CurrentProfiles}, Profiles) ->
+    IsTesting = lists:member(test, CurrentProfiles),
     AppliedProfiles = case Profiles of
                           %% Head of list global profile is special, only for use by rebar3
                           %% It does not clash if a user does `rebar3 as global...` but when
                           %% it is the head we must make sure not to prepend `default`
                           [global | _] ->
                               Profiles;
+                          [test] when IsTesting ->
+                              deduplicate(CurrentProfiles);
                           _ ->
                               deduplicate(CurrentProfiles ++ Profiles)
                       end,

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -87,8 +87,8 @@ new(Config) when is_list(Config) ->
                         opts = Opts }.
 
 -spec new(t() | atom(), list()) -> t().
-new(Profile, Config) when is_atom(Profile),
-                          is_list(Config) ->
+new(Profile, Config) when is_atom(Profile)
+                        , is_list(Config) ->
     BaseState = base_state(),
     Opts = base_opts(Config),
     BaseState#state_t { dir = rebar_dir:get_cwd(),
@@ -283,12 +283,11 @@ apply_profiles(State=#state_t{default = Defaults, current_profiles=CurrentProfil
                     end, Defaults, AppliedProfiles),
     State#state_t{current_profiles = AppliedProfiles, opts=NewOpts}.
 
-%% @doc A stable deduplicator.
 deduplicate(Profiles) ->
-    do_deduplicate(Profiles, []).
+    do_deduplicate(lists:reverse(Profiles), []).
 
 do_deduplicate([], Acc) ->
-    lists:reverse(Acc);
+    Acc;
 do_deduplicate([Head | Rest], Acc) ->
     case lists:member(Head, Acc) of
         true -> do_deduplicate(Rest, Acc);

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -43,10 +43,6 @@
          allow_provider_overrides/1, allow_provider_overrides/2
         ]).
 
--ifdef(TEST).
--export([deduplicate/1]).
--endif.
-
 -include("rebar.hrl").
 -include_lib("providers/include/providers.hrl").
 

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -257,14 +257,14 @@ apply_profiles(State, Profile) when not is_list(Profile) ->
 apply_profiles(State, [default]) ->
     State;
 apply_profiles(State=#state_t{default = Defaults, current_profiles=CurrentProfiles}, Profiles) ->
-    IsTesting = lists:member(test, CurrentProfiles),
+    ProvidedProfiles = lists:prefix([default|Profiles], CurrentProfiles),
     AppliedProfiles = case Profiles of
                           %% Head of list global profile is special, only for use by rebar3
                           %% It does not clash if a user does `rebar3 as global...` but when
                           %% it is the head we must make sure not to prepend `default`
                           [global | _] ->
                               Profiles;
-                          [test] when IsTesting ->
+                          _ when ProvidedProfiles ->
                               deduplicate(CurrentProfiles);
                           _ ->
                               deduplicate(CurrentProfiles ++ Profiles)

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -87,8 +87,8 @@ new(Config) when is_list(Config) ->
                         opts = Opts }.
 
 -spec new(t() | atom(), list()) -> t().
-new(Profile, Config) when is_atom(Profile)
-                        , is_list(Config) ->
+new(Profile, Config) when is_atom(Profile),
+                          is_list(Config) ->
     BaseState = base_state(),
     Opts = base_opts(Config),
     BaseState#state_t { dir = rebar_dir:get_cwd(),
@@ -283,11 +283,12 @@ apply_profiles(State=#state_t{default = Defaults, current_profiles=CurrentProfil
                     end, Defaults, AppliedProfiles),
     State#state_t{current_profiles = AppliedProfiles, opts=NewOpts}.
 
+%% @doc A stable deduplicator.
 deduplicate(Profiles) ->
-    do_deduplicate(lists:reverse(Profiles), []).
+    do_deduplicate(Profiles, []).
 
 do_deduplicate([], Acc) ->
-    Acc;
+    lists:reverse(Acc);
 do_deduplicate([Head | Rest], Acc) ->
     case lists:member(Head, Acc) of
         true -> do_deduplicate(Rest, Acc);

--- a/test/rebar_profiles_SUITE.erl
+++ b/test/rebar_profiles_SUITE.erl
@@ -211,7 +211,7 @@ implicit_profile_deduplicate_deps(Config) ->
     rebar_test_utils:run_and_check(Config, RebarConfig,
                                    ["as", "test,bar", "eunit"], {ok, [{app, Name}
                                                                  ,{dep, "a", "1.0.0"}
-                                                                 ,{dep, "b", "2.0.0"}]}).
+                                                                 ,{dep, "b", "1.0.0"}]}).
 
 all_deps_code_paths(Config) ->
     AppDir = ?config(apps, Config),

--- a/test/rebar_profiles_SUITE.erl
+++ b/test/rebar_profiles_SUITE.erl
@@ -28,8 +28,7 @@
          test_profile_erl_opts_order_4/1,
          test_profile_erl_opts_order_5/1,
          test_erl_opts_debug_info/1,
-         first_files_exception/1,
-         deduplication_stability/1]).
+         first_files_exception/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -53,8 +52,7 @@ all() ->
      test_profile_erl_opts_order_4,
      test_profile_erl_opts_order_5,
      test_erl_opts_debug_info,
-     first_files_exception,
-     deduplication_stability].
+     first_files_exception].
 
 init_per_suite(Config) ->
     application:start(meck),
@@ -135,7 +133,7 @@ profile_merge_umbrella_keys(Config) ->
                    {profiles,
                     [{ct,
                       [{vals, [{a,1},{b,2}]}]}]}],
-
+    
     SubRebarConfig = [{vals, []},
                        {profiles, [{ct, [{vals, [{c,1}]}]}]}],
 
@@ -546,17 +544,6 @@ first_files_exception(_Config) ->
     %% there is no specific reason not to dedupe "a" here aside from "this is how it is"
     ?assertEqual(["c","a","b","a","e"], rebar_state:get(State1, erl_first_files)),
     ?assertEqual(["c","a","b","a","e"], rebar_state:get(State1, mib_first_files)),
-    ok.
-
-deduplication_stability(_Config) ->
-    ?assertEqual([default,all_deps_test], rebar_state:deduplicate([default,all_deps_test])),
-    ?assertEqual([default,profile1,profile2], rebar_state:deduplicate([default,profile1,profile2])),
-    ?assertEqual([default,bar,foo], rebar_state:deduplicate([default,bar,foo,bar])), %% master wants [default,foo,bar]
-    ?assertEqual([default,test,bar], rebar_state:deduplicate([default,test,bar])),
-    ?assertEqual([default,test,bar], rebar_state:deduplicate([default,test,bar,test])),
-    ?assertEqual([default,profile1], rebar_state:deduplicate([default,profile1,profile1,profile1])),
-    ?assertEqual([default,a,b,c,d,e], rebar_state:deduplicate([default,a,b,c,d,e,a,e,b])),
-    ?assertEqual([default,test], rebar_state:deduplicate([default,test])),
     ok.
 
 get_compiled_profile_erl_opts(Profiles, Config) ->


### PR DESCRIPTION
Ensures that directories inside _build/ have a fixed nomenclature: makes it impossible for `rebar3 as a,b` to create sometimes `_build/a+b` and other times `_build/b+a`.

I got caught by it when developing offline. Plugins were pulled to a+b but then rebar3 would decide to use `b+a` and would fail to load plugins.

Next step would be to symlink plugins instead of re-fetching them when using a new `as` combination. That would probably be an issue provided that plugins are (generally?) un-version'ed.