### PR TITLE
Set unicode option for standard_io at entry point

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -116,6 +116,7 @@ run(RawArgs) ->
 -spec run_aux(rebar_state:t(), [string()]) ->
     {ok, rebar_state:t()} | {error, term()}.
 run_aux(State, RawArgs) ->
+    io:setopts([{encoding, unicode}]),
     %% Profile override; can only support one profile
     State1 = case os:getenv("REBAR_PROFILE") of
                  false ->

--- a/src/rebar_prv_deps_tree.erl
+++ b/src/rebar_prv_deps_tree.erl
@@ -52,14 +52,12 @@ print_deps_tree(SrcDeps, Verbose, State) ->
     ProjectAppNames = [{rebar_app_info:name(App)
                        ,rebar_utils:vcs_vsn(rebar_app_info:original_vsn(App), rebar_app_info:dir(App), Resources)
                        ,project} || App <- rebar_state:project_apps(State)],
-    io:setopts([{encoding, unicode}]),
     case dict:find(root, D) of
         {ok, Children} ->
             print_children("", lists:keysort(1, Children++ProjectAppNames), D, Verbose);
         error ->
             print_children("", lists:keysort(1, ProjectAppNames), D, Verbose)
-    end,
-    io:setopts([{encoding, latin1}]).
+    end.
 
 print_children(_, [], _, _) ->
     ok;


### PR DESCRIPTION
This PR sets unicode option for standard_io at the very entry point of rebar3.

The issue was:
Using eunit test cases weith titles with unicode characters

```
long_test_() ->
    [{"タイトル", fun() -> timer:sleep(100) end}].
```

(`タイトル` is "title" in Japanese Katakana), output is in escaped format like

```
Top 10 slowest tests (0.134 seconds, 13.3% of total time):
  foo_tests:long_test_/0: \x{30BF}\x{30A4}\x{30C8}\x{30EB}
 ```

Rebar3 3.4.4 works nice, but 3.4.5 does not.

The direct cause is `~ts` pattern in [1] (it IS right.)

Fixing direction:
Set unicode option for starndard_io.
Before this PR,  tree command uses it but others don't.

It's possible to set option in eunit runner. This PR chooses to use it
at entry point because of rebar3 now should supoort unicode as in [2].


[1] https://github.com/seancribbs/eunit_formatters/commit/7df78bbf0edbec516b78923a61cfd50ec78e5e4f
[2] https://github.com/erlang/rebar3/pull/1660