### PR TITLE
rebar_package: do not return first package version for constraint with no match

### DIFF
--- a/test/rebar_pkg_SUITE.erl
+++ b/test/rebar_pkg_SUITE.erl
@@ -226,7 +226,12 @@ find_highest_matching(_Config) ->
     ?assertEqual(<<"1.1.1">>, Vsn1),
     {ok, Vsn2} = rebar_packages:find_highest_matching(
                    <<"test">>, <<"1.0.0">>, <<"goodpkg">>, <<"2.0">>, package_index, State),
-    ?assertEqual(<<"2.0.0">>, Vsn2).
+    ?assertEqual(<<"2.0.0">>, Vsn2),
+
+    %% regression test. ~> constraints higher than the available packages would result
+    %% in returning the first package version instead of 'none'.
+    ?assertEqual(none, rebar_packages:find_highest_matching(<<"test">>, <<"1.0.0">>, <<"goodpkg">>,
+                                                            <<"~> 5.0">>, package_index, State)).
 
 
 %%%%%%%%%%%%%%%
@@ -266,6 +271,9 @@ mock_config(Name, Config) ->
     meck:expect(rebar_packages, registry_dir, fun(_) -> {ok, CacheDir} end),
     meck:expect(rebar_packages, package_dir, fun(_) -> {ok, CacheDir} end),
     rebar_prv_update:hex_to_index(rebar_state:new()),
+
+    meck:new(rebar_prv_update, [passthrough]),
+    meck:expect(rebar_prv_update, do, fun(State) -> {ok, State} end),
 
     %% Cache fetches are mocked -- we assume the server and clients are
     %% correctly used.


### PR DESCRIPTION
Rebar3 would solve a version constraint to the first version available if it there was no version that matches the constraint because of the `foldl` we used starting at `HeadVsn`.