### PR TITLE
use debug level for logs about bad package versioning

### DIFF
--- a/src/rebar_prv_update.erl
+++ b/src/rebar_prv_update.erl
@@ -151,8 +151,8 @@ update_deps_list(Pkg, PkgVsn, Deps, HexRegistry, State) ->
                             %% and doubled since spaces seem not to be
                             %% enforced
                             {false, Vsn} ->
-                                ?WARN("[~ts:~ts], Bad dependency version for ~ts: ~ts.",
-                                      [Pkg, PkgVsn, Dep, Vsn]),
+                                ?DEBUG("[~ts:~ts], Bad dependency version for ~ts: ~ts.",
+                                       [Pkg, PkgVsn, Dep, Vsn]),
                                 DepsListAcc;
                             {_, <<"~>", Vsn/binary>>} ->
                                 highest_matching(Dep1, rm_ws(Vsn), HexRegistry,
@@ -210,7 +210,7 @@ highest_matching({Pkg, PkgVsn, Dep, App}, Vsn, HexRegistry, State, DepsListAcc) 
         {ok, HighestDepVsn} ->
             [{App, {pkg, Dep, HighestDepVsn, undefined}} | DepsListAcc];
         none ->
-            ?WARN("[~ts:~ts] Missing registry entry for package ~ts. Try to fix with `rebar3 update`",
+            ?DEBUG("[~ts:~ts] Missing registry entry for package ~ts. Try to fix with `rebar3 update`",
                   [Pkg, PkgVsn, Dep]),
             DepsListAcc
     end.
@@ -221,8 +221,8 @@ cmp({_Pkg, _PkgVsn, Dep, _App} = Dep1, Vsn, HexRegistry, State, DepsListAcc, Cmp
 
 
 cmp_(undefined, _MinVsn, [], DepsListAcc, {Pkg, PkgVsn, Dep, _App}, _CmpFun) ->
-    ?WARN("[~ts:~ts] Missing registry entry for package ~ts. Try to fix with `rebar3 update`",
-          [Pkg, PkgVsn, Dep]),
+    ?DEBUG("[~ts:~ts] Missing registry entry for package ~ts. Try to fix with `rebar3 update`",
+           [Pkg, PkgVsn, Dep]),
     DepsListAcc;
 cmp_(HighestDepVsn, _MinVsn, [], DepsListAcc, {_Pkg, _PkgVsn, Dep, App}, _CmpFun) ->
     [{App, {pkg, Dep, HighestDepVsn, undefined}} | DepsListAcc];
@@ -242,8 +242,8 @@ cmpl({_Pkg, _PkgVsn, Dep, _App} = Dep1, Vsn, HexRegistry, State, DepsListAcc, Cm
     cmpl_(undefined, Vsn, Vsns, DepsListAcc, Dep1, CmpFun).
 
 cmpl_(undefined, _MaxVsn, [], DepsListAcc, {Pkg, PkgVsn, Dep, _App}, _CmpFun) ->
-    ?WARN("[~ts:~ts] Missing registry entry for package ~ts. Try to fix with `rebar3 update`",
-          [Pkg, PkgVsn, Dep]),
+    ?DEBUG("[~ts:~ts] Missing registry entry for package ~ts. Try to fix with `rebar3 update`",
+           [Pkg, PkgVsn, Dep]),
     DepsListAcc;
 
 cmpl_(HighestDepVsn, _MaxVsn, [], DepsListAcc, {_Pkg, _PkgVsn, Dep, App}, _CmpFun) ->


### PR DESCRIPTION
These warnings just confuse users. We should really only bother the user if they try to use one of these packages, not every time they update the package index.