### PR TITLE
Make rebar3 work with dialyzer internally

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -49,7 +49,7 @@ main(_) ->
     code:add_pathsa(DepsPaths),
 
     rebar3:run(["clean", "-a"]),
-    rebar3:run(["escriptize"]),
+    rebar3:run(["as", "prod", "escriptize"]),
 
     %% Done with compile, can turn back on error logger
     error_logger:tty(true).

--- a/rebar.config
+++ b/rebar.config
@@ -31,7 +31,6 @@
 {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
             {platform_define, "^(19|2)", rand_only},
             {platform_define, "^2", unicode_str},
-            no_debug_info,
             warnings_as_errors]}.
 
 %% Use OTP 18+ when dialyzing rebar3
@@ -50,35 +49,27 @@
 
             {bootstrap, []},
 
-            {dialyze, [{overrides, [{add, erlware_commons, [{erl_opts, [debug_info]}]},
-                                    {add, ssl_verify_fun, [{erl_opts, [debug_info]}]},
-                                    {add, certifi, [{erl_opts, [debug_info]}]},
-                                    {add, providers, [{erl_opts, [debug_info]}]},
-                                    {add, getopt, [{erl_opts, [debug_info]}]},
-                                    {add, bbmustache, [{erl_opts, [debug_info]}]},
-                                    {add, relx, [{erl_opts, [debug_info]}]},
-                                    {add, cf, [{erl_opts, [debug_info]}]},
-                                    {add, cth_readable, [{erl_opts, [debug_info]}]},
-                                    {add, eunit_formatters, [{erl_opts, [debug_info]}]}]},
-                       {erl_opts, [debug_info]}]}
+            {prod, [
+                {overrides, [
+                    {override, erlware_commons, [
+                        {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
+                                    {platform_define, "^R1[4|5]", deprecated_crypto},
+                                    {platform_define, "^((1[8|9])|2)", rand_module},
+                                    {platform_define, "^2", unicode_str},
+                                    no_debug_info,
+                                    warnings_as_errors]},
+                        {deps, []}, {plugins, []}]},
+                    {add, ssl_verify_hostname, [{erl_opts, [no_debug_info]}]},
+                    {add, certifi, [{erl_opts, [no_debug_info]}]},
+                    {add, cf, [{erl_opts, [no_debug_info]}]},
+                    {add, cth_readable, [{erl_opts, [no_debug_info]}]},
+                    {add, eunit_formatters, [{erl_opts, [no_debug_info]}]},
+                    {override, bbmustache, [
+                        {erl_opts, [no_debug_info, {platform_define, "^[0-9]+", namespaced_types}]},
+                        {deps, []}, {plugins, []}]},
+                    {add, getopt, [{erl_opts, [no_debug_info]}]},
+                    {add, providers, [{erl_opts, [no_debug_info]}]},
+                    {add, relx, [{erl_opts, [no_debug_info]}]}]}
+            ]}
            ]}.
 
-%% Overrides
-{overrides, [{override, erlware_commons, [{erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
-                                                      {platform_define, "^R1[4|5]", deprecated_crypto},
-                                                      {platform_define, "^((1[8|9])|2)", rand_module},
-                                                      {platform_define, "^2", unicode_str},
-                                                      no_debug_info,
-                                                      warnings_as_errors]},
-                                          {deps, []}, {plugins, []}]},
-             {add, ssl_verify_hostname, [{erl_opts, [no_debug_info]}]},
-             {add, certifi, [{erl_opts, [no_debug_info]}]},
-             {add, cf, [{erl_opts, [no_debug_info]}]},
-             {add, cth_readable, [{erl_opts, [no_debug_info]}]},
-             {add, eunit_formatters, [{erl_opts, [no_debug_info]}]},
-             {override, bbmustache, [{erl_opts, [no_debug_info,
-                                                 {platform_define, "^[0-9]+", namespaced_types}]},
-                                     {deps, []}, {plugins, []}]},
-             {add, getopt, [{erl_opts, [no_debug_info]}]},
-             {add, providers, [{erl_opts, [no_debug_info]}]},
-             {add, relx, [{erl_opts, [no_debug_info]}]}]}.


### PR DESCRIPTION
We got funny interactions since PR #1656:

- the last `debug_info`-related option seen in a list of options after
  profile merge is kept, allowing later profiles from overtaking earlier
  ones
- if you go `rebar3 as a,b,c compile`, the options from profile A come
  before B, which come before C, so C's options win
- overrides are applied in order of profile as well, giving a priority
  to a later profile than an earlier one
- The values in overrides are prepended rather than suffixed to the
  existing list
- this means if we have to overrides adding options, such as `default`
  adding `no_debug_info', and `dialyze` adding `debug_info`, the
  results are `[debug_info]` as `dialyze` is applied first, and then
  `[no_debug_info, debug_info]` as `default` overrides are applied
- the final result is `no_debug_info` always winning when erl_opts are
  overriden specifically.

only `debug_info` options are going to suffer this, and in the context of
overrides. Other `erl_opts` should be fine. I'm not sure how that can be
fixed at all.

In the meanwhile, we can add support back while leaving the default to
not having debug information. This is done by:

- moving all `no_debug_info` options to the `prod` profile
- forcing `prod` to be called by `./bootstrap` so that most people keep
  getting no debug info
- anyone calling `rebar3 clean -a`  and then rebuilding with `rebar3
  escriptize` (i.e. rebar3 devs) get debug info going

This is up for review and discussion. Context at https://github.com/erlang/rebar3/issues/1749