### PR TITLE
Handle Schema-less Proxy URLs in ENV vars

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -854,9 +854,17 @@ set_httpc_options(_, []) ->
     ok;
 
 set_httpc_options(Scheme, Proxy) ->
-    {ok, {_, UserInfo, Host, Port, _, _}} = http_uri:parse(Proxy),
+    URI = normalise_proxy(Scheme, Proxy),
+    {ok, {_, UserInfo, Host, Port, _, _}} = http_uri:parse(URI),
     httpc:set_options([{Scheme, {{Host, Port}, []}}], rebar),
     set_proxy_auth(UserInfo).
+
+normalise_proxy(Scheme, URI) ->
+    case re:run(URI, "://", [unicode]) of
+        nomatch when Scheme =:= https_proxy -> "https://" ++ URI;
+        nomatch when Scheme =:= proxy -> "http://" ++ URI;
+        _ -> URI
+    end.
 
 url_append_path(Url, ExtraPath) ->
      case http_uri:parse(Url) of

--- a/test/rebar_utils_SUITE.erl
+++ b/test/rebar_utils_SUITE.erl
@@ -275,11 +275,13 @@ tup_merge(_Config) ->
        )
     ).
 
-proxy_auth(_Config) ->
-	proxy_auth(_Config, "http_proxy"),
-	proxy_auth(_Config, "https_proxy").
+proxy_auth(Config) ->
+    proxy_auth(Config, "http://", "http_proxy"),
+    proxy_auth(Config, "https://", "https_proxy"),
+    proxy_auth(Config, "", "http_proxy"),
+    proxy_auth(Config, "", "https_proxy").
 
-proxy_auth(_Config, ProxyEnvKey) ->
+proxy_auth(_Config, Schema, ProxyEnvKey) ->
 	Host = "host:",
 	Port = "1234",
 
@@ -291,13 +293,13 @@ proxy_auth(_Config, ProxyEnvKey) ->
 	?assertEqual([], rebar_utils:get_proxy_auth()),
 
 	%% proxy auth with regular username/password
-	os:putenv(ProxyEnvKey, "http://Username:Password@" ++ Host ++ Port),
+	os:putenv(ProxyEnvKey, Schema++"Username:Password@" ++ Host ++ Port),
 	rebar_utils:set_httpc_options(),
 	?assertEqual([{proxy_auth, {"Username", "Password"}}],
 				 rebar_utils:get_proxy_auth()),
 
 	%% proxy auth with username missing and url encoded password
-	os:putenv(ProxyEnvKey, "http://:%3F!abc%23%24@" ++ Host ++ Port),
+	os:putenv(ProxyEnvKey, Schema++":%3F!abc%23%24@" ++ Host ++ Port),
 	rebar_utils:set_httpc_options(),
 	?assertEqual([{proxy_auth, {"", "?!abc#$"}}],
 				 rebar_utils:get_proxy_auth()),


### PR DESCRIPTION
We've had multiple tickets opened because of unclear PROXY settings when
the scheme is missing form the URI. To be helpful, we instead add them
dynamically whenever they're missing.

Example issues:
- https://github.com/erlang/rebar3/issues/1747
- https://github.com/erlang/rebar3/issues/1697