### PR TITLE
Fix various Dialyzer warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ deploy:
     secret_access_key:
       secure: "BUv2KQABv0Q4e8DAVNBRTc/lXHWt27yCN46Fdgo1IrcSSIiP+hq2yXzQcXLbPwkEu6pxUZQtL3mvKbt6l7uw3wFrcRfFAi1PGTITAW8MTmxtwcZIBcHSk3XOzDbkK+fYYcaddszmt7hDzzEFPtmYXiNgnaMIVeynhQLgcCcIRRQ="
     skip_cleanup: true
-    local-dir: _build/default/bin
+    local-dir: _build/prod/bin
     bucket: "rebar3-nightly"
     acl: public_read
     on:

--- a/rebar.config
+++ b/rebar.config
@@ -34,7 +34,10 @@
             warnings_as_errors]}.
 
 %% Use OTP 18+ when dialyzing rebar3
-{dialyzer, [{warnings, [unknown]}]}.
+{dialyzer, [
+    {warnings, [unknown]},
+    {exclude_mods, [rebar_prv_alias]}
+]}.
 
 %% Profiles
 {profiles, [{test, [

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -301,7 +301,7 @@ app_file(#app_info_t{app_file=AppFile}) ->
     AppFile.
 
 %% @doc sets the .app file for an app.
--spec app_file(t(), file:filename_all()) -> t().
+-spec app_file(t(), file:filename_all() | undefined) -> t().
 app_file(AppInfo=#app_info_t{}, AppFile) ->
     AppInfo#app_info_t{app_file=AppFile}.
 

--- a/src/rebar_hg_resource.erl
+++ b/src/rebar_hg_resource.erl
@@ -137,7 +137,7 @@ get_branch_ref(Dir, Branch) ->
         rebar_utils:sh("hg -R \"" ++ rebar_utils:escape_double_quotes(Dir) ++
                        "\" log --template \"{node}\n\" --rev " ++ rebar_utils:escape_chars(Branch),
                        [{use_stdout, false}, {debug_abort_on_error, AbortMsg}]),
-    rebar_string:strip(BranchRefString, both, "\n").
+    rebar_string:trim(BranchRefString, both, "\n").
 
 
 maybe_warn_local_url(Url) ->

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -267,9 +267,7 @@ rm_newline(String) ->
     [C || C <- String, C =/= $\n].
 
 write_windows_script(Target) ->
-    CmdPath = if is_binary(Target) -> <<Target/binary, ".cmd">>;
-                 is_list(Target) -> Target ++ ".cmd"
-              end,
+    CmdPath = Target ++ ".cmd",
     CmdScript=
         "@echo off\r\n"
         "setlocal\r\n"

--- a/src/rebar_prv_unlock.erl
+++ b/src/rebar_prv_unlock.erl
@@ -48,12 +48,8 @@ do(State) ->
             ?PRV_ERROR({file,Reason});
         {ok, _} ->
             Locks = rebar_config:consult_lock_file(LockFile),
-            case handle_unlocks(State, Locks, LockFile) of
-                {ok, NewLocks} ->
-                    {ok, rebar_state:set(State, {locks, default}, NewLocks)};
-                {error, Reason} ->
-                    ?PRV_ERROR({file,Reason})
-            end
+            {ok, NewLocks} = handle_unlocks(State, Locks, LockFile),
+            {ok, rebar_state:set(State, {locks, default}, NewLocks)}
     end.
 
 -spec format_error(any()) -> iolist().


### PR DESCRIPTION
Some still remain from erl_type calls from Dialyzer, but most of them
are handled.

Decided to just ignore rebar_alias since playing with the type specs of
abstract code format is just a nightmare and hard to do cross-versions I
guess.