### PR TITLE
Fix precedence rules of erl_opts for test profile

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -389,7 +389,11 @@ state_from_global_config(Config, GlobalConfigFile) ->
     rebar_state:providers(rebar_state:new(GlobalConfig3, Config), GlobalPlugins).
 
 test_state(State) ->
-    ErlOpts = rebar_state:get(State, erl_opts, []),
+    %% Fetch the test profile's erl_opts only
+    Opts = rebar_state:opts(State),
+    Profiles = rebar_opts:get(Opts, profiles, []),
+    ProfileOpts = proplists:get_value(test, Profiles, []),
+    ErlOpts = proplists:get_value(erl_opts, ProfileOpts, []),
     TestOpts = safe_define_test_macro(ErlOpts),
     [{extra_src_dirs, ["test"]}, {erl_opts, TestOpts}].
 


### PR DESCRIPTION
When adding the 'TEST' macro to the test profile, we mistakenly sourced
the erl_opts values from the base profile rather than the test profile
itself.

This means that in cases where the base profile set an option such as
'no_debug_info' and a profile overrode it with 'debug_info', the default
options would get injected within the test profile, and broke the
precedence rules, yielding incompatible values.

This patch fixes things by adding the macro to the values sourced from
the test profile itself, fixing the issue.

Fixes #1715