### PR TITLE
Clear all dialyzer errors

### DIFF
--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -8,6 +8,7 @@
   {registered, []},
   {applications, [kernel,
                   stdlib,
+                  hipe,
                   sasl,
                   compiler,
                   crypto,

--- a/src/rebar_string.erl
+++ b/src/rebar_string.erl
@@ -11,7 +11,7 @@
 %% used. Instead we just adopt join/2 locally and hope it works
 %% for most unicode use cases anyway.
 join([], Sep) when is_list(Sep) ->
-        [];
+    [];
 join([H|T], Sep) ->
     H ++ lists:append([Sep ++ X || X <- T]).
 

--- a/test/rebar_dir_SUITE.erl
+++ b/test/rebar_dir_SUITE.erl
@@ -5,6 +5,7 @@
 -export([default_src_dirs/1, default_extra_src_dirs/1, default_all_src_dirs/1]).
 -export([src_dirs/1, src_dirs_with_opts/1, extra_src_dirs/1, all_src_dirs/1]).
 -export([src_dir_opts/1, recursive/1]).
+-export([top_src_dirs/1]).
 -export([profile_src_dirs/1, profile_extra_src_dirs/1, profile_all_src_dirs/1]).
 -export([profile_src_dir_opts/1]).
 -export([retarget_path/1, alt_base_dir_abs/1, alt_base_dir_rel/1]).
@@ -18,7 +19,7 @@
 all() -> [default_src_dirs, default_extra_src_dirs, default_all_src_dirs,
           src_dirs, extra_src_dirs, all_src_dirs, src_dir_opts, recursive,
           profile_src_dirs, profile_extra_src_dirs, profile_all_src_dirs,
-          profile_src_dir_opts,
+          profile_src_dir_opts, top_src_dirs,
           retarget_path, alt_base_dir_abs, alt_base_dir_rel, global_cache_dir,
           default_global_cache_dir, overwrite_default_global_cache_dir].
 
@@ -122,6 +123,15 @@ recursive(Config) ->
     true = rebar_dir:recursive(rebar_state:opts(State2), "bar"),
 
     ok.
+
+top_src_dirs(Config) ->
+    %% We can get the same result out of specifying src_dirs from the config root,
+    %% not just the erl_opts
+    RebarConfig = [{src_dirs, ["foo", "./bar", "bar", "bar/", "./bar/", "baz",
+                               "./", ".", "../", "..", "./../", "../.", ".././../"]}],
+    {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
+
+    [".", "..", "../..", "bar", "baz", "foo"] = rebar_dir:src_dirs(rebar_state:opts(State)).
 
 profile_src_dirs(Config) ->
     RebarConfig = [


### PR DESCRIPTION
- this is done by adding a HiPE dependency, which makes calls to erl_types work in analysis 
- also in this: adding a test for directories, and fixing some indent