### PR TITLE
ensure dest exists before copying to it and fix src_dirs symlinking

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -191,6 +191,10 @@ cp_r(Sources, Dest) ->
         {unix, _} ->
             EscSources = [rebar_utils:escape_chars(Src) || Src <- Sources],
             SourceStr = rebar_string:join(EscSources, " "),
+            % ensure destination exists before copying files into it
+            {ok, []} = rebar_utils:sh(?FMT("mkdir -p ~ts",
+                           [rebar_utils:escape_chars(Dest)]),
+                      [{use_stdout, false}, abort_on_error]),
             {ok, []} = rebar_utils:sh(?FMT("cp -Rp ~ts \"~ts\"",
                                            [SourceStr, rebar_utils:escape_double_quotes(Dest)]),
                                       [{use_stdout, false}, abort_on_error]),

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -236,7 +236,10 @@ copy_app_dirs(AppInfo, OldAppDir, AppDir) ->
 symlink_or_copy(OldAppDir, AppDir, Dir) ->
     Source = filename:join([OldAppDir, Dir]),
     Target = filename:join([AppDir, Dir]),
-    rebar_file_utils:symlink_or_copy(Source, Target).
+    case ec_file:is_dir(Source) of
+        true -> rebar_file_utils:symlink_or_copy(Source, Target);
+        false -> ok
+    end.
 
 copy(OldAppDir, AppDir, Dir) ->
     Source = filename:join([OldAppDir, Dir]),

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -225,7 +225,11 @@ copy_app_dirs(AppInfo, OldAppDir, AppDir) ->
             end,
             {SrcDirs, ExtraDirs} = resolve_src_dirs(rebar_app_info:opts(AppInfo)),
             %% link to src_dirs to be adjacent to ebin is needed for R15 use of cover/xref
-            [symlink_or_copy(OldAppDir, AppDir, Dir) || Dir <- ["priv", "include"] ++ SrcDirs],
+            %% priv/ and include/ are symlinked unconditionally to allow hooks
+            %% to write to them _after_ compilation has taken place when the
+            %% initial directory did not, and still work
+            [symlink_or_copy(OldAppDir, AppDir, Dir) || Dir <- ["priv", "include"]],
+            [symlink_or_copy_existing(OldAppDir, AppDir, Dir) || Dir <- SrcDirs],
             %% copy all extra_src_dirs as they build into themselves and linking means they
             %% are shared across profiles
             [copy(OldAppDir, AppDir, Dir) || Dir <- ExtraDirs];
@@ -234,6 +238,11 @@ copy_app_dirs(AppInfo, OldAppDir, AppDir) ->
     end.
 
 symlink_or_copy(OldAppDir, AppDir, Dir) ->
+    Source = filename:join([OldAppDir, Dir]),
+    Target = filename:join([AppDir, Dir]),
+    rebar_file_utils:symlink_or_copy(Source, Target).
+
+symlink_or_copy_existing(OldAppDir, AppDir, Dir) ->
     Source = filename:join([OldAppDir, Dir]),
     Target = filename:join([AppDir, Dir]),
     case ec_file:is_dir(Source) of

--- a/test/rebar_dir_SUITE.erl
+++ b/test/rebar_dir_SUITE.erl
@@ -79,13 +79,10 @@ alt_src_dir_nested(Config) ->
     RebarConfig = [{src_dirs, ["src", "alt/nested"]}],
     AppsDir = ?config(apps, Config),
     Name1 = ?config(app_one, Config),
-    Name2 = ?config(app_two, Config),
     ModDir = filename:join([AppsDir, "apps", Name1, "alt", "nested"]),
-    ModDir2 = filename:join([AppsDir, "apps", Name2, "alt", "nested"]),
     Mod = "-module(altmod). -export([main/0]). main() -> ok.",
 
     ec_file:mkdir_path(ModDir),
-    ec_file:mkdir_path(ModDir2),
     ok = file:write_file(filename:join([ModDir, "altmod.erl"]), Mod),
 
     Ebin = filename:join([AppsDir, "_build", "default", "lib", Name1, "ebin", "altmod.beam"]),


### PR DESCRIPTION
This PR augments what is found at #1763 by @danikp

Original Description
---------
While using src_dirs options it's possible to set first level directories under app folder, but setting something deeper will fail on copying files to _build folder. so following example will work
```
{src_dirs, [
  "src",
  "src2"
]}.
```
and this one not
```
{src_dirs, [
  "src/lib",
  "src/mail",
  "src/test",
  "src/view",
  "src/websocket"
]}.
```
failing with error

> cp: cannot create directory '/some/path/to/project/_build/default/lib/web/src/lib': No such file or directory

that happens cause cp command not creating missing path parts. This PR comes to solve it by trying to create destination folder with all parent folders in path.

-------

Difference with Original
------
The original branch had a test we both worked on, but that had an issue when setting multiple values of `src_dirs` such as `{src_dirs, ["alt/nested", "src"]}` if either of the directories did not exist in one of the umbrella applications. The original PR relaxed the test so this was not a problem anymore, and this branch reinstates that configuration, and instead fixes the problem by adding a check in the compiler.

It appears that a check to know if the source directory existed was already in place for file copying, but not for symlinking. The check is added to the symlink operation.

This branch has been tested both on Linux and on Windows 10.

Question for @tsloughter and @talentdeficit : any reason why the source directory check was not on symlink calls? I'm afraid of accidentally breaking something, but this seems to work fine.