### PR TITLE
Re-disable debug_info on prod profile

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -54,6 +54,7 @@
             {bootstrap, []},
 
             {prod, [
+                {erl_opts, [no_debug_info]},
                 {overrides, [
                     {override, erlware_commons, [
                         {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},


### PR DESCRIPTION
Had mistakenly only disabled it for deps.