### PR TITLE
start at least one async thread in async thread poll

### DIFF
--- a/priv/templates/escript_rebar.config
+++ b/priv/templates/escript_rebar.config
@@ -5,7 +5,7 @@
  [{{name}}]}.
 {escript_main_app, {{name}}}.
 {escript_name, {{name}}}.
-{escript_emu_args, "%%! +sbtu +A0\n"}.
+{escript_emu_args, "%%! +sbtu +A1\n"}.
 
 %% Profiles
 {profiles, [{test,

--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,7 @@
              ]}.
 
 {escript_name, rebar3}.
-{escript_emu_args, "%%! +sbtu +A0\n"}.
+{escript_emu_args, "%%! +sbtu +A1\n"}.
 %% escript_incl_extra is for internal rebar-private use only.
 %% Do not use outside rebar. Config interface is not stable.
 {escript_incl_extra, [{"relx/priv/templates/*", "_build/default/lib/"},
@@ -78,4 +78,3 @@
                     {add, relx, [{erl_opts, [no_debug_info]}]}]}
             ]}
            ]}.
-

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -54,7 +54,7 @@
 %% ====================================================================
 
 %% @doc For running with:
-%% erl +sbtu +A0 -noinput -mode minimal -boot start_clean -s rebar3 main -extra "$@"
+%% erl +sbtu +A1 -noinput -mode minimal -boot start_clean -s rebar3 main -extra "$@"
 -spec main() -> no_return().
 main() ->
     List = init:get_plain_arguments(),

--- a/src/rebar_prv_local_install.erl
+++ b/src/rebar_prv_local_install.erl
@@ -64,7 +64,7 @@ format_error(Reason) ->
 bin_contents(OutputDir) ->
     <<"#!/usr/bin/env sh
 
-erl -pz ", (rebar_utils:to_binary(OutputDir))/binary,"/*/ebin +sbtu +A0 -noshell -boot start_clean -s rebar3 main $REBAR3_ERL_ARGS -extra \"$@\"
+erl -pz ", (rebar_utils:to_binary(OutputDir))/binary,"/*/ebin +sbtu +A1 -noshell -boot start_clean -s rebar3 main $REBAR3_ERL_ARGS -extra \"$@\"
 ">>.
 
 extract_escript(State, ScriptPath) ->


### PR DESCRIPTION
#### Description

fixes an issue when shell is terminated with an error "Bus error: 10",
on attempt to run rebar shell with verbose logging

Error example:

```
$ ./rebar3 help ct
Run Common Tests.
Usage: rebar3 ct [--dir <dir>] [--suite <suite>] [--group <group>]
                 [--case <testcase>] [--label <label>]
                 [--config <config>] [--spec <spec>]
                 [--join_specs <join_specs>]
                 [--allow_user_terms <allow_user_terms>]
                 [--logdir <logdir>] [--logopts <logopts>]
                 [--verbosity <verbosity>] [-c [<cover>]]
                 [--cover_export_name <cover_export_name>]
                 [--repeat <repeat>] [--duration <duration>]
                 [--until <until>] [--force_stop <force_stop>]
                 [--basic_html <basic_html>] [--stylesheet <stylesheet>]
                 [--decrypt_key <decrypt_key>]
                 [--decrypt_file <decrypt_file>]
                 [--abort_if_missing_suites [<abort_if_missing_suites>]]
                 [--multiply_timetraps <multiply_timetraps>]
                 [--scale_timetraps <scale_timetraps>]
                 [--create_priv_dir <create_priv_dir>]
                 [--include <incluBus error: 10
$ exit

Process shell exited abnormally with code 138
```

Used this script to reproduce:

```
-module(io_test).

-export([main/0]).

main() ->
    [io:format(standard_error, "~s~n", [lists:duplicate(100, I)])
     || I <- lists:seq(30, 120)],
    erlang:halt(0).
```

The following command crashes shell:
`erl -pz +sbtu +A0 -noshell -boot start_clean -s io_test main`
Whilst the one below does not (note `+A1` flag):
`erl -pz +sbtu +A1 -noshell -boot start_clean -s io_test main`

#### Report

```
-----------------
Rebar3 report
 version 3.5.2+build.4067.ref59a99a70
 generated at 2018-05-08T20:11:15+00:00
=================
Please submit this along with your issue at https://github.com/erlang/rebar3/issues (and feel free to edit out private information, if any)
-----------------
Task: help
Entered as:
  help ct
-----------------
Operating System: x86_64-apple-darwin17.3.0
ERTS: Erlang/OTP 20 [erts-9.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:0] [hipe] [kernel-poll:false]
Root Directory: /Users/gstarinkin/otp/20.1
Library directory: /Users/gstarinkin/otp/20.1/lib
-----------------
Loaded Applications:
bbmustache: 1.3.0
certifi: 2.0.0
cf: 0.2.2
common_test: 1.15.2
compiler: 7.1.2
crypto: 4.1
cth_readable: 1.4.0
dialyzer: 3.2.2
edoc: 0.9.1
erlware_commons: 1.1.0
eunit: 2.3.4
eunit_formatters: 0.5.0
getopt: 1.0.1
hipe: 3.16.1
inets: 6.4.2
kernel: 5.4
providers: 1.7.0
public_key: 1.5
relx: 3.24.4
sasl: 3.1
snmp: 5.2.7
ssl_verify_fun: 1.1.3
stdlib: 3.4.2
syntax_tools: 2.1.3
tools: 2.11

-----------------
Escript path: /Users/gstarinkin/src/rebar3/rebar3
Providers:
  app_discovery as clean compile compile cover ct deps dialyzer do edoc escriptize eunit get-deps help install install_deps list lock new path pkgs release relup report shell state tar tree unlock update upgrade upgrade upgrade version xref 
```
