### PR TITLE
Restore default templates in bootstrapped rebar3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -54,6 +54,10 @@
             {bootstrap, []},
 
             {prod, [
+                {escript_incl_extra, [
+                    {"relx/priv/templates/*", "_build/prod/lib/"},
+                    {"rebar/priv/templates/*", "_build/prod/lib/"}
+                ]},
                 {erl_opts, [no_debug_info]},
                 {overrides, [
                     {override, erlware_commons, [


### PR DESCRIPTION
When allowing Dialyzer to work internally, we moved a bunch of
config (such as no_debug_info) to the prod profile, but the escript
included files remained locked onto the default profile.

Because the bootstrapping phase now happened in a prod run, the priv/
dirs were never created for the default profile unless a prior run
existed, which hid the bug from us.

This patch overrides the path on the prod profile so that we don't rely
on accidental leftovers for things to work on a bootstrap phase as a
dev.

Fixes #1781