### PR TITLE
otp-21 eperm fix: bump of erlware_commons and relx

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,13 +1,13 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 
-{deps, [{erlware_commons,     "1.1.0"},
+{deps, [{erlware_commons,     "1.2.0"},
         {ssl_verify_fun,      "1.1.3"},
         {certifi,             "2.0.0"},
         {providers,           "1.7.0"},
         {getopt,              "1.0.1"},
         {bbmustache,          "1.5.0"},
-        {relx,                "3.25.0"},
+        {relx,                "3.26.0"},
         {cf,                  "0.2.2"},
         {cth_readable,        "1.4.2"},
         {eunit_formatters,    "0.5.0"}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,11 +3,11 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.0.0">>},0},
  {<<"cf">>,{pkg,<<"cf">>,<<"0.2.2">>},0},
  {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.4.2">>},0},
- {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"1.1.0">>},0},
+ {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"1.2.0">>},0},
  {<<"eunit_formatters">>,{pkg,<<"eunit_formatters">>,<<"0.5.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.7.0">>},0},
- {<<"relx">>,{pkg,<<"relx">>,<<"3.25.0">>},0},
+ {<<"relx">>,{pkg,<<"relx">>,<<"3.26.0">>},0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.3">>},0}]}.
 [
 {pkg_hash,[
@@ -15,10 +15,10 @@
  {<<"certifi">>, <<"A0C0E475107135F76B8C1D5BC7EFB33CD3815CB3CF3DEA7AEFDD174DABEAD064">>},
  {<<"cf">>, <<"7F2913FFF90ABCABD0F489896CFEB0B0674F6C8DF6C10B17A83175448029896C">>},
  {<<"cth_readable">>, <<"0F57B4EB7DA7F5438F422312245F9143A1B3118C11B6BAE5C3D1391C9EE88322">>},
- {<<"erlware_commons">>, <<"F69F3D96044C2A9E735CCD76F469FEC5FC851797E5FE23115698B4EDC072191B">>},
+ {<<"erlware_commons">>, <<"2BAB99CF88941145767A502F1209886F1F0D31695EEF21978A30F15E645721E0">>},
  {<<"eunit_formatters">>, <<"6A9133943D36A465D804C1C5B6E6839030434B8879C5600D7DDB5B3BAD4CCB59">>},
  {<<"getopt">>, <<"C73A9FA687B217F2FF79F68A3B637711BB1936E712B521D8CE466B29CBF7808A">>},
  {<<"providers">>, <<"BBF730563914328EC2511D205E6477A94831DB7297DE313B3872A2B26C562EAB">>},
- {<<"relx">>, <<"460A336514DC209F0FA243A6F2D4ECB33B3652A1588CAF9FCE3C1FA170FACAEC">>},
+ {<<"relx">>, <<"DD645ECAA1AB1647DB80D3E9BCAE0B39ED0A536EF37245F6A74B114C6D0F4E87">>},
  {<<"ssl_verify_fun">>, <<"6C49665D4326E26CD4A5B7BD54AA442B33DADFB7C5D59A0D0CD0BF5534BBFBD7">>}]}
 ].


### PR DESCRIPTION
Opening this for an easy place to point users to get a branch they can try that pulls in an updated erlware_commons and relx before having to merge and release those.

And a place for feedback/comments on the solution, assuming it works for people.

Related PRs to relx and erlware_commons:

https://github.com/erlware/relx/pull/661

https://github.com/erlware/erlware_commons/pull/135