### PR TITLE
Add user_default module and have some shell commands

### DIFF
--- a/src/user_default.erl
+++ b/src/user_default.erl
@@ -1,0 +1,30 @@
+-module(user_default).
+-export([compile/0
+        ,c/0
+        ,deps/0
+        ,path/0
+        ,tree/0
+        ,update/0
+        ,version/0
+        ,v/0]).
+
+
+compile() -> r3:compile().
+c()       -> r3:compile().
+
+
+deps() -> r3:deps().
+
+
+path() -> r3:path().
+
+
+tree() -> r3:tree().
+
+
+update() -> r3:update().
+
+
+version() -> r3:version().
+v()       -> r3:version().
+


### PR DESCRIPTION
rebar3 shell will have new commands for example compile(), version(), tree() etc.

```erlang
pouriya@codefather /p/rebar3 $ ./rebar3 shell
===> Verifying dependencies...
===> Compiling rebar
Erlang/OTP 20 [erts-9.3] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe] [kernel-poll:false]
Eshell V9.3  (abort with ^G)
1> v().
rebar 0.0.0+build.2.ref26f12dc on Erlang/OTP 20 Erts 9.3
ok
2> version().
rebar 0.0.0+build.2.ref26f12dc on Erlang/OTP 20 Erts 9.3
ok
3> path().
/p/rebar3/_build/default/lib/ssl_verify_fun/ebin /p/rebar3/_build/default/lib/relx/ebin /p/rebar3/_build/default/lib/providers/ebin /p/rebar3/_build/default/lib/getopt/ebin /p/rebar3/_build/default/lib/eunit_formatters/ebin /p/rebar3/_build/default/lib/erlware_commons/ebin /p/rebar3/_build/default/lib/cth_readable/ebin /p/rebar3/_build/default/lib/cf/ebin /p/rebar3/_build/default/lib/certifi/ebin /p/rebar3/_build/default/lib/bbmustache/ebin /p/rebar3/_build/default/lib/rebar/ebinok
4> tree().
Verifying dependencies...
└─ rebar─0.0.0+build.2.ref26f12dc (project app)
   ├─ bbmustache─1.5.0 (hex package)
   ├─ certifi─2.0.0 (hex package)
   ├─ cf─0.2.2 (hex package)
   ├─ cth_readable─1.4.2 (hex package)
   ├─ erlware_commons─1.2.0 (hex package)
   ├─ eunit_formatters─0.5.0 (hex package)
   ├─ getopt─1.0.1 (hex package)
   ├─ providers─1.7.0 (hex package)
   ├─ relx─3.26.0 (hex package)
   └─ ssl_verify_fun─1.1.3 (hex package)
ok
5> c().
Verifying dependencies...
Compiling rebar
ok
6> compile().
Verifying dependencies...
Compiling rebar
ok
```