### PR TITLE
Bump certifi

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -16,7 +16,9 @@ main(_) ->
                ,{getopt, []}
                ,{cf, []}
                ,{erlware_commons, ["ec_dictionary.erl", "ec_vsn.erl"]}
-               ,{certifi, ["certifi_pt.erl"]}],
+               ,{parse_trans, ["parse_trans.erl", "parse_trans_pp.erl",
+                               "parse_trans_codegen.erl"]}
+               ,{certifi, []}],
     Deps = get_deps(),
     [fetch_and_compile(Dep, Deps) || Dep <- BaseDeps],
 

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,8 @@
 
 {deps, [{erlware_commons,     "1.2.0"},
         {ssl_verify_fun,      "1.1.3"},
-        {certifi,             "2.0.0"},
+        {certifi,             "2.3.1"},
+        {parse_trans,         "3.3.0"}, % force otp-21 compat
         {providers,           "1.7.0"},
         {getopt,              "1.0.1"},
         {bbmustache,          "1.5.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,23 +1,25 @@
 {"1.1.0",
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.5.0">>},0},
- {<<"certifi">>,{pkg,<<"certifi">>,<<"2.0.0">>},0},
+ {<<"certifi">>,{pkg,<<"certifi">>,<<"2.3.1">>},0},
  {<<"cf">>,{pkg,<<"cf">>,<<"0.2.2">>},0},
  {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.4.2">>},0},
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"1.2.0">>},0},
  {<<"eunit_formatters">>,{pkg,<<"eunit_formatters">>,<<"0.5.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},0},
+ {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.7.0">>},0},
  {<<"relx">>,{pkg,<<"relx">>,<<"3.26.0">>},0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.3">>},0}]}.
 [
 {pkg_hash,[
  {<<"bbmustache">>, <<"8CFDE0602E90A4057E161BF5288ADE854B4E511E2E8924966A8438730E958381">>},
- {<<"certifi">>, <<"A0C0E475107135F76B8C1D5BC7EFB33CD3815CB3CF3DEA7AEFDD174DABEAD064">>},
+ {<<"certifi">>, <<"D0F424232390BF47D82DA8478022301C561CF6445B5B5FB6A84D49A9E76D2639">>},
  {<<"cf">>, <<"7F2913FFF90ABCABD0F489896CFEB0B0674F6C8DF6C10B17A83175448029896C">>},
  {<<"cth_readable">>, <<"0F57B4EB7DA7F5438F422312245F9143A1B3118C11B6BAE5C3D1391C9EE88322">>},
  {<<"erlware_commons">>, <<"2BAB99CF88941145767A502F1209886F1F0D31695EEF21978A30F15E645721E0">>},
  {<<"eunit_formatters">>, <<"6A9133943D36A465D804C1C5B6E6839030434B8879C5600D7DDB5B3BAD4CCB59">>},
  {<<"getopt">>, <<"C73A9FA687B217F2FF79F68A3B637711BB1936E712B521D8CE466B29CBF7808A">>},
+ {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>},
  {<<"providers">>, <<"BBF730563914328EC2511D205E6477A94831DB7297DE313B3872A2B26C562EAB">>},
  {<<"relx">>, <<"DD645ECAA1AB1647DB80D3E9BCAE0B39ED0A536EF37245F6A74B114C6D0F4E87">>},
  {<<"ssl_verify_fun">>, <<"6C49665D4326E26CD4A5B7BD54AA442B33DADFB7C5D59A0D0CD0BF5534BBFBD7">>}]}


### PR DESCRIPTION
Includes an update to parse_trans on an OTP-21 friendly version