### PR TITLE
add report in the effects_code_generation, as it is the short form for both report_errors and report_warnings

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -363,6 +363,7 @@ effects_code_generation(Option) ->
         report_errors -> false;
         return_errors-> false;
         return_warnings-> false;
+        report -> false;
         warnings_as_errors -> false;
         binary -> false;
         verbose -> false;


### PR DESCRIPTION
This is a modification of function of effects_code_generation of rebar_erlc_compiler.