### PR TITLE
Support of unicode command line parameters

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -62,7 +62,8 @@ main() ->
 
 %% @doc escript Entry point
 -spec main(list()) -> no_return().
-main(Args) ->
+main(Args0) ->    
+    Args = [binary_to_list(unicode:characters_to_binary(Arg,  unicode, utf8)) || Arg <- Args0 ],
     try run(Args) of
         {ok, _State} ->
             erlang:halt(0);


### PR DESCRIPTION
Convert сommand line parameters to utf-8 as iolist_to_binary doesn't support unicode lists