### PR TITLE
move packages to top level of of hexpm cache dir

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -194,7 +194,7 @@ init_config() ->
                     ?DEBUG("Load global config file ~ts", [GlobalConfigFile]),
                     try state_from_global_config(Config1, GlobalConfigFile)
                     catch
-                        _:_ ->
+                        _:_->
                             ?WARN("Global config ~ts exists but can not be read. Ignoring global config values.", [GlobalConfigFile]),
                             rebar_state:new(Config1)
                     end;

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -97,8 +97,8 @@ download(TmpDir, Pkg, State) ->
       State :: rebar_state:t(),
       UpdateETag :: boolean(),
       Res :: download_result().
-download(TmpDir, Pkg={pkg, Name, Vsn, _Hash, _}, State, UpdateETag) ->
-    {ok, PackageDir} = rebar_packages:package_dir(State),
+download(TmpDir, Pkg={pkg, Name, Vsn, _Hash, Repo}, State, UpdateETag) ->
+    {ok, PackageDir} = rebar_packages:package_dir(Repo, State),
     Package = binary_to_list(<<Name/binary, "-", Vsn/binary, ".tar">>),
     ETagFile = binary_to_list(<<Name/binary, "-", Vsn/binary, ".etag">>),
     CachePath = filename:join(PackageDir, Package),

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -374,12 +374,9 @@ make_relative_to_root(State, Path) when is_list(Path) ->
 
 fetch_app(AppInfo, AppDir, State) ->
     ?INFO("Fetching ~ts (~p)", [rebar_app_info:name(AppInfo),
-                               format_source(rebar_app_info:source(AppInfo))]),
+                                rebar_resource:format_source(rebar_app_info:source(AppInfo))]),
     Source = rebar_app_info:source(AppInfo),
     true = rebar_fetch:download_source(AppDir, Source, State).
-
-format_source({pkg, Name, Vsn, _Hash, _}) -> {pkg, Name, Vsn};
-format_source(Source) -> Source.
 
 %% This is called after the dep has been downloaded and unpacked, if it hadn't been already.
 %% So this is the first time for newly downloaded apps that its .app/.app.src data can
@@ -398,7 +395,8 @@ maybe_upgrade(AppInfo, AppDir, Upgrade, State) ->
         true ->
             case rebar_fetch:needs_update(AppDir, Source, State) of
                 true ->
-                    ?INFO("Upgrading ~ts (~p)", [rebar_app_info:name(AppInfo), rebar_app_info:source(AppInfo)]),
+                    ?INFO("Upgrading ~ts (~p)", [rebar_app_info:name(AppInfo),
+                                                 rebar_resource:format_source(rebar_app_info:source(AppInfo))]),
                     true = rebar_fetch:download_source(AppDir, Source, State);
                 false ->
                     case Upgrade of

--- a/src/rebar_resource.erl
+++ b/src/rebar_resource.erl
@@ -4,7 +4,8 @@
 
 -export([new/3,
          find_resource_module/2,
-         find_resource_state/2]).
+         find_resource_state/2,
+         format_source/1]).
 
 -export_type([resource/0
              ,source/0
@@ -62,3 +63,6 @@ find_resource_state(Type, Resources) ->
         #resource{state=State} ->
             State
     end.
+
+format_source({pkg, Name, Vsn, _Hash, _}) -> {pkg, Name, Vsn};
+format_source(Source) -> Source.

--- a/test/rebar_pkg_SUITE.erl
+++ b/test/rebar_pkg_SUITE.erl
@@ -33,10 +33,6 @@ init_per_testcase(pkgs_provider=Name, Config) ->
     CacheDir = filename:join([CacheRoot, "hex", "com", "test", "packages"]),
     filelib:ensure_dir(filename:join([CacheDir, "registry"])),
     ok = ets:tab2file(Tid, filename:join([CacheDir, "registry"])),
-    %% meck:new(rebar_packages, [passthrough]),
-    %% meck:expect(rebar_packages, registry_dir, fun(_) -> {ok, CacheDir} end),
-    %% meck:expect(rebar_packages, package_dir, fun(_) -> {ok, CacheDir} end),
-    %% rebar_prv_update:hex_to_index(rebar_state:new()),
     Config;
 init_per_testcase(good_uncached=Name, Config0) ->
     Config = [{good_cache, false},
@@ -278,7 +274,7 @@ mock_config(Name, Config) ->
     meck:expect(rebar_dir, global_cache_dir, fun(_) -> CacheRoot end),
 
     meck:expect(rebar_packages, registry_dir, fun(_) -> {ok, CacheDir} end),
-    meck:expect(rebar_packages, package_dir, fun(_) -> {ok, CacheDir} end),
+    meck:expect(rebar_packages, package_dir, fun(_, _) -> {ok, CacheDir} end),
 
     meck:new(rebar_prv_update, [passthrough]),
     meck:expect(rebar_prv_update, do, fun(State) -> {ok, State} end),

--- a/test/rebar_pkg_alias_SUITE.erl
+++ b/test/rebar_pkg_alias_SUITE.erl
@@ -215,7 +215,7 @@ mock_config(Name, Config) ->
 
     meck:new(rebar_packages, [passthrough, no_link]),
     meck:expect(rebar_packages, registry_dir, fun(_) -> {ok, CacheDir} end),
-    meck:expect(rebar_packages, package_dir, fun(_) -> {ok, CacheDir} end),
+    meck:expect(rebar_packages, package_dir, fun(_, _) -> {ok, CacheDir} end),
 
     %% TODO: is something else wrong that we need this for transitive_alias to pass
     meck:expect(rebar_packages, update_package, fun(_, _, _) -> ok end),


### PR DESCRIPTION
Also removes the printing of the source from upgrading info message.