### PR TITLE
Reload logger config in shell

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -385,7 +385,7 @@ reread_config(AppsToStart, State) ->
                     lists:member(App, Running),
                     lists:member(App, AppsToStart),
                     not lists:member(App, BlackList)],
-            _ = rebar_utils:reread_config(ConfigList),
+            _ = rebar_utils:reread_config(ConfigList, [update_logger]),
             ok
     end.
 


### PR DESCRIPTION
This requires some fancy dynamic work since the logger is started as
part of the kernel and we lost the sys.config from users when working
from there.

We start conservatively by making it an optional thing, turning it on
only where we know it to be safe.

The changes are applied _after_ having loaded the rest of configs so if
an inoffensive error happens, the shell works (with a bad error message)
rather than plain exploding.

Fixes #1868 