### PR TITLE
add option to compiler provider to only build dependencies

### DIFF
--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -266,6 +266,14 @@ check_results(AppDir, Expected, ProfileRun) ->
                         ok
                 end
         ; ({dep_not_exist, Name}) ->
+                ct:pal("Dep Not Exist Name: ~p", [Name]),
+                case lists:keyfind(Name, 1, DepsNames) of
+                    false ->
+                        ok;
+                    {Name, _App} ->
+                        error({app_found, Name})
+                end
+        ; ({app_not_exist, Name}) ->
                 ct:pal("App Not Exist Name: ~p", [Name]),
                 case lists:keyfind(Name, 1, DepsNames) of
                     false ->


### PR DESCRIPTION
The ability to fetch and build only the dependencies is important for docker layer caching. 

With this change an optimal dockerfile for building a release would change to be like:

```
COPY rebar.config rebar.lock /usr/src/app
RUN rebar3 compile --deps_only

COPY . /usr/src/app
RUN rebar3 as prod tar
```