### PR TITLE
warn if the matched package is retired, skip prerelease

### DIFF
--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -27,9 +27,9 @@
 -define(REMOTE_PACKAGE_DIR, "tarballs").
 -define(LOCK_FILE, "rebar.lock").
 -define(DEFAULT_COMPILER_SOURCE_FORMAT, relative).
--define(PACKAGE_INDEX_VERSION, 4).
--define(PACKAGE_TABLE, package_index_v4).
--define(INDEX_FILE, "packages-v4.idx").
+-define(PACKAGE_INDEX_VERSION, 5).
+-define(PACKAGE_TABLE, package_index).
+-define(INDEX_FILE, "packages.idx").
 -define(HEX_AUTH_FILE, "hex.config").
 -define(PUBLIC_HEX_REPO, <<"hexpm">>).
 

--- a/test/mock_pkg_resource.erl
+++ b/test/mock_pkg_resource.erl
@@ -171,7 +171,7 @@ to_index(AllDeps, Dict, Repos) ->
                              DKB <- [ec_cnv:to_binary(DK)],
                              DVB <- [ec_cnv:to_binary(DV)]],
               Repo = rebar_test_utils:random_element(Repos),
-              ets:insert(?PACKAGE_TABLE, #package{key={N, V, Repo},
+              ets:insert(?PACKAGE_TABLE, #package{key={N, ec_semver:parse(V), Repo},
                                                   dependencies=parse_deps(DepsList),
                                                   retired=false,
                                                   checksum = <<"checksum">>})
@@ -179,11 +179,11 @@ to_index(AllDeps, Dict, Repos) ->
 
     lists:foreach(fun({{Name, Vsn}, _}) ->
                           case lists:any(fun(R) ->
-                                                 ets:member(?PACKAGE_TABLE, {ec_cnv:to_binary(Name), Vsn, R})
+                                                 ets:member(?PACKAGE_TABLE, {ec_cnv:to_binary(Name), ec_semver:parse(Vsn), R})
                                          end, Repos) of
                               false ->
                                   Repo = rebar_test_utils:random_element(Repos),
-                                  ets:insert(?PACKAGE_TABLE, #package{key={ec_cnv:to_binary(Name), Vsn, Repo},
+                                  ets:insert(?PACKAGE_TABLE, #package{key={ec_cnv:to_binary(Name), ec_semver:parse(Vsn), Repo},
                                                                       dependencies=[],
                                                                       retired=false,
                                                                       checksum = <<"checksum">>});

--- a/test/rebar_pkg_SUITE.erl
+++ b/test/rebar_pkg_SUITE.erl
@@ -226,13 +226,13 @@ find_highest_matching(_Config) ->
     State = rebar_state:new(),
     {ok, Vsn} = rebar_packages:find_highest_matching_(
                   <<"goodpkg">>, <<"1.0.0">>, #{name => <<"hexpm">>}, ?PACKAGE_TABLE, State),
-    ?assertEqual(<<"1.0.1">>, Vsn),
+    ?assertEqual({{1,0,1},{[],[]}}, Vsn),
     {ok, Vsn1} = rebar_packages:find_highest_matching(
                    <<"goodpkg">>, <<"1.0">>, #{name => <<"hexpm">>}, ?PACKAGE_TABLE, State),
-    ?assertEqual(<<"1.1.1">>, Vsn1),
+    ?assertEqual({{1,1,1},{[],[]}}, Vsn1),
     {ok, Vsn2} = rebar_packages:find_highest_matching(
                    <<"goodpkg">>, <<"2.0">>, #{name => <<"hexpm">>}, ?PACKAGE_TABLE, State),
-    ?assertEqual(<<"2.0.0">>, Vsn2),
+    ?assertEqual({{2,0,0},{[],[]}}, Vsn2),
 
     %% regression test. ~> constraints higher than the available packages would result
     %% in returning the first package version instead of 'none'.
@@ -265,7 +265,7 @@ mock_config(Name, Config) ->
     lists:foreach(fun({{N, Vsn}, [Deps, Checksum, _]}) ->
                           case ets:member(?PACKAGE_TABLE, {ec_cnv:to_binary(N), Vsn, <<"hexpm">>}) of
                               false ->
-                                  ets:insert(?PACKAGE_TABLE, #package{key={ec_cnv:to_binary(N), Vsn, <<"hexpm">>},
+                                  ets:insert(?PACKAGE_TABLE, #package{key={ec_cnv:to_binary(N), ec_semver:parse(Vsn), <<"hexpm">>},
                                                                       dependencies=Deps,
                                                                       retired=false,
                                                                       checksum=Checksum});

--- a/test/rebar_pkg_alias_SUITE.erl
+++ b/test/rebar_pkg_alias_SUITE.erl
@@ -229,7 +229,7 @@ mock_config(Name, Config) ->
     lists:foreach(fun({{N, Vsn}, [Deps, Checksum, _]}) ->
                           case ets:member(?PACKAGE_TABLE, {ec_cnv:to_binary(N), Vsn, <<"hexpm">>}) of
                               false ->
-                                  ets:insert(?PACKAGE_TABLE, #package{key={ec_cnv:to_binary(N), Vsn, <<"hexpm">>},
+                                  ets:insert(?PACKAGE_TABLE, #package{key={ec_cnv:to_binary(N), ec_semver:parse(Vsn), <<"hexpm">>},
                                                                       dependencies=[{DAppName, {pkg, DN, DV, undefined}} || {DN, DV, _, DAppName} <- Deps],
                                                                       retired=false,
                                                                       checksum=Checksum});


### PR DESCRIPTION
retired packages are now used the same as any other but a warning will be printed when it is resolved.

prerelease versions are skipped unless explicitly given as the version in the constraint or lock file.