### PR TITLE
(#1833) Include one more level in verify_config_format

### DIFF
--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -239,10 +239,24 @@ consult_file_(File) ->
 -spec verify_config_format([{_,_}]) -> true.
 verify_config_format([]) ->
     true;
+verify_config_format([{_Key, Value} | T] ) when is_list(Value) ->
+    verify_config_format(T) andalso verify_config_format_sub(Value);
 verify_config_format([{_Key, _Value} | T]) ->
     verify_config_format(T);
 verify_config_format([Term | _]) ->
     throw(?PRV_ERROR({bad_config_format, Term})).
+
+%% @private checks that sub lists (in the top level key value pairs)
+%% do not contain empty, or size 1 tuples
+-spec verify_config_format_sub([tuple()]) -> true.
+verify_config_format_sub([]) ->
+    true;
+verify_config_format_sub([{_}=Term | _]) ->
+    throw(?PRV_ERROR({bad_config_format, Term}));
+verify_config_format_sub([{}=Term | _]) ->
+    throw(?PRV_ERROR({bad_config_format, Term}));
+verify_config_format_sub([_Term | T]) ->
+    verify_config_format_sub(T).
 
 %% @doc takes an existing configuration and the content of a lockfile
 %% and merges the locks into the config.

--- a/systest/all_SUITE_data/faulty_config/rebar.config
+++ b/systest/all_SUITE_data/faulty_config/rebar.config
@@ -1,0 +1,20 @@
+{erl_opts, [debug_info]}.
+{deps, []}.
+
+{relx, [{release, { haha2, "0.1.0" },
+         [haha2,
+          sasl]},
+
+        {sys_config, "./config/sys.config"},
+        {vm_args, "./config/vm.args"},
+
+        {dev_mode, true},
+        {include_erts, false},
+
+        {extended_start_script, true}]
+}.
+
+{profiles, [ {}, {prod, [{relx, [{dev_mode, false},
+                            {include_erts, true}]}]
+            }]
+}.


### PR DESCRIPTION
top level tuples in the 'rebar.config' file are
already verified to be a tuple of size two.
If something else is specified, rebar3 will exit
with an error message. But in the next level,
users can enter empty tuples, and tuples of
size one and rebar3 will crash later on.

This commit fixes strange 'rebar.config'
definitions in the next level. Perhaps it should
verify even deeper levels?