### PR TITLE
fix resolving versions from vcs

### DIFF
--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -124,14 +124,14 @@ new(AppName) ->
                  {ok, t()}.
 new(AppName, Vsn) ->
     {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
-                     original_vsn=rebar_utils:to_binary(Vsn)}}.
+                     original_vsn=Vsn}}.
 
 %% @doc build a complete version of the app info with all fields set.
 -spec new(atom() | binary() | string(), binary() | string(), file:name()) ->
                  {ok, t()}.
 new(AppName, Vsn, Dir) ->
     {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
-                     original_vsn=rebar_utils:to_binary(Vsn),
+                     original_vsn=Vsn,
                      dir=rebar_utils:to_list(Dir),
                      out_dir=rebar_utils:to_list(Dir),
                      ebin_dir=filename:join(rebar_utils:to_list(Dir), "ebin")}}.
@@ -141,7 +141,7 @@ new(AppName, Vsn, Dir) ->
                  {ok, t()}.
 new(AppName, Vsn, Dir, Deps) ->
     {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
-                     original_vsn=rebar_utils:to_binary(Vsn),
+                     original_vsn=Vsn,
                      dir=rebar_utils:to_list(Dir),
                      out_dir=rebar_utils:to_list(Dir),
                      ebin_dir=filename:join(rebar_utils:to_list(Dir), "ebin"),
@@ -153,7 +153,7 @@ new(AppName, Vsn, Dir, Deps) ->
 new(Parent, AppName, Vsn, Dir, Deps) ->
     {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
                      parent=Parent,
-                     original_vsn=rebar_utils:to_binary(Vsn),
+                     original_vsn=Vsn,
                      dir=rebar_utils:to_list(Dir),
                      out_dir=rebar_utils:to_list(Dir),
                      ebin_dir=filename:join(rebar_utils:to_list(Dir), "ebin"),
@@ -390,7 +390,7 @@ original_vsn(#app_info_t{original_vsn=Vsn}) ->
 %% asking for a semver)
 -spec original_vsn(t(), binary() | string()) -> t().
 original_vsn(AppInfo=#app_info_t{}, Vsn) ->
-    AppInfo#app_info_t{original_vsn=rebar_utils:to_binary(Vsn)}.
+    AppInfo#app_info_t{original_vsn=Vsn}.
 
 %% @doc returns the list of applications the app depends on.
 -spec applications(t()) -> list().

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -60,7 +60,7 @@ lock(AppInfo, _) ->
       Res :: boolean().
 needs_update(AppInfo, _) ->
     {pkg, _Name, Vsn, _Hash, _} = rebar_app_info:source(AppInfo),
-    case rebar_app_info:original_vsn(AppInfo) =:= rebar_utils:to_binary(Vsn) of
+    case rebar_utils:to_binary(rebar_app_info:original_vsn(AppInfo)) =:= rebar_utils:to_binary(Vsn) of
         true ->
             false;
         false ->

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -43,7 +43,7 @@
 
          project_builders/1, add_project_builder/3,
 
-         create_resources/2,
+         create_resources/2, set_resources/2,
          resources/1, resources/2, add_resource/2,
          providers/1, providers/2, add_provider/2,
          allow_provider_overrides/1, allow_provider_overrides/2
@@ -367,6 +367,10 @@ namespace(State=#state_t{}, Namespace) ->
 -spec resources(t()) -> [{rebar_resource_v2:type(), module()}].
 resources(#state_t{resources=Resources}) ->
     Resources.
+
+-spec set_resources(t(), [{rebar_resource_v2:type(), module()}]) -> t().
+set_resources(State, Resources) ->
+    State#state_t{resources=Resources}.
 
 -spec resources(t(), [{rebar_resource_v2:type(), module()}]) -> t().
 resources(State, NewResources) ->

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -715,6 +715,15 @@ escript_foldl(Fun, Acc, File) ->
             Error
     end.
 
+%% TODO: this is just for rebar3_hex and maybe other plugins
+%% but eventually it should be dropped
+vcs_vsn(OriginalVsn, Dir, Resources) when is_list(Dir) ,
+                                          is_list(Resources) ->
+    ?WARN("Using deprecated rebar_utils:vcs_vsn/3. Please upgrade your plugins.", []),
+    FakeState = rebar_state:new(),
+    {ok, AppInfo} = rebar_app_info:new(fake, OriginalVsn, Dir),
+    vcs_vsn(AppInfo, OriginalVsn,
+            rebar_state:set_resources(FakeState, Resources));
 vcs_vsn(AppInfo, Vcs, State) ->
     case vcs_vsn_cmd(AppInfo, Vcs, State) of
         {plain, VsnString} ->
@@ -728,7 +737,7 @@ vcs_vsn(AppInfo, Vcs, State) ->
     end.
 
 %% Temp work around for repos like relx that use "semver"
-vcs_vsn_cmd(_AppInfo, Vsn, _) when is_binary(Vsn) ->
+vcs_vsn_cmd(_, Vsn, _) when is_binary(Vsn) ->
     {plain, Vsn};
 vcs_vsn_cmd(AppInfo, VCS, State) when VCS =:= semver ; VCS =:= "semver" ->
     vcs_vsn_cmd(AppInfo, git, State);


### PR DESCRIPTION
app_info was turning any vsn into a binary which the vcs_vsn function interprets as being an actual version and not something like <<"git">>. original_vsn shouldn't be converted as it is then not longer "original".