### PR TITLE
Fix shell hook expansion on windows

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -156,7 +156,7 @@ sh_send(Command0, String, Options0) ->
     Options = [expand_sh_flag(V)
                || V <- proplists:compact(Options0 ++ DefaultOptions)],
 
-    Command = lists:flatten(patch_on_windows(Command0, proplists:get_value(env, Options, []))),
+    Command = lists:flatten(patch_on_windows(Command0, proplists:get_value(env, Options0, []))),
     PortSettings = proplists:get_all_values(port_settings, Options) ++
         [exit_status, {line, 16384}, use_stdio, stderr_to_stdout, hide],
     Port = open_port({spawn, Command}, PortSettings),
@@ -187,7 +187,7 @@ sh(Command0, Options0) ->
     ErrorHandler = proplists:get_value(error_handler, Options),
     OutputHandler = proplists:get_value(output_handler, Options),
 
-    Command = lists:flatten(patch_on_windows(Command0, proplists:get_value(env, Options, []))),
+    Command = lists:flatten(patch_on_windows(Command0, proplists:get_value(env, Options0, []))),
     PortSettings = proplists:get_all_values(port_settings, Options) ++
         [exit_status, {line, 16384}, use_stdio, stderr_to_stdout, hide, eof],
     ?DEBUG("Port Cmd: ~ts\nPort Opts: ~p\n", [Command, PortSettings]),

--- a/test/rebar_hooks_SUITE.erl
+++ b/test/rebar_hooks_SUITE.erl
@@ -84,7 +84,7 @@ run_hooks_once(Config) ->
 
     Name = rebar_test_utils:create_random_name("app1_"),
     Vsn = rebar_test_utils:create_random_vsn(),
-    RebarConfig = [{pre_hooks, [{compile, "mkdir  $REBAR_ROOT_DIR/blah"}]}],
+    RebarConfig = [{pre_hooks, [{compile, "mkdir  \"$REBAR_ROOT_DIR/blah\""}]}],
     rebar_test_utils:create_config(AppDir, RebarConfig),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
     rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], {ok, [{app, Name, valid}]}).
@@ -96,7 +96,7 @@ run_hooks_once_profiles(Config) ->
 
     Name = rebar_test_utils:create_random_name("app1_"),
     Vsn = rebar_test_utils:create_random_vsn(),
-    RebarConfig = [{profiles, [{hooks, [{pre_hooks, [{compile, "mkdir $REBAR_ROOT_DIR/blah"}]}]}]}],
+    RebarConfig = [{profiles, [{hooks, [{pre_hooks, [{compile, "mkdir \"$REBAR_ROOT_DIR/blah\""}]}]}]}],
     rebar_test_utils:create_config(AppDir, RebarConfig),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
     rebar_test_utils:run_and_check(Config, RebarConfig, ["as", "hooks", "compile"], {ok, [{app, Name, valid}]}).
@@ -236,7 +236,7 @@ root_hooks(Config) ->
     rebar_test_utils:create_app(SubAppsDir, Name, Vsn, [kernel, stdlib]),
     rebar_test_utils:create_config(SubAppsDir, [{provider_hooks, [{post, [{compile, clean}]}]}]),
 
-    RConfFile = rebar_test_utils:create_config(AppDir, [{pre_hooks, [{compile, "mkdir $REBAR_ROOT_DIR/blah"}]}]),
+    RConfFile = rebar_test_utils:create_config(AppDir, [{pre_hooks, [{compile, "mkdir \"$REBAR_ROOT_DIR/blah\""}]}]),
     {ok, RConf} = file:consult(RConfFile),
 
     %% Build with deps.


### PR DESCRIPTION
Dollar Variable expansion (`$VAR`) was inadvertently disabled for
windows variables, although %VARIABLES% already worked. This reduced the
portability of hooks in general.

This was disabled more than four years ago, I'm in fact not quite sure it had ever
worked as intended since `expand_sh_flag/1` wrapped the env value in a way that
`proplists:get_env/3` _always_ returned `[]`. This is re-expanding them. This might
actually be a bit risky to enable at this point.

Additionally, tests would fail on windows due to bad quoting of paths:
the path C:/a/b/c would fail when passed to the command
`cmd /q /c C:/a/b/c` because it would interpret /a /b and /c as 3
options. Using quotes makes the tests pass. This one fix should at least
be safe on its own, but I'm curious as to how it ever passed without
the var expansion.