### PR TITLE
Fix misleading config in app template

### DIFF
--- a/priv/templates/app_rebar.config
+++ b/priv/templates/app_rebar.config
@@ -2,6 +2,6 @@
 {deps, []}.
 
 {shell, [
-  % {config, [{config, "config/sys.config"}]},
+  % {config, "config/sys.config"},
     {apps, [{{name}}]}
 ]}.


### PR DESCRIPTION
Uncommenting the sys.config shell setting in app template rebar.config
works now as expected.