### PR TITLE
templates/gitignore ignore emacs temp files

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -140,3 +140,4 @@ Heinz N. Gies
 Roberto Aloi
 Andrew McRobb
 Drew Varner
+Niklas Johansson

--- a/priv/templates/gitignore
+++ b/priv/templates/gitignore
@@ -16,3 +16,4 @@ _build
 .idea
 *.iml
 rebar3.crashdump
+*~


### PR DESCRIPTION
emacs creates temp files that ends with tilde (~).
These temp files should never be commited.
It is therefore safe to ignore them.

Signed-off-by: Niklas Johansson <raphexion@gmail.com>