### PR TITLE
Fix plugins list display to include project plugins

### DIFF
--- a/src/rebar_prv_plugins.erl
+++ b/src/rebar_prv_plugins.erl
@@ -42,10 +42,11 @@ do(State) ->
     RebarOpts = rebar_state:opts(State),
     SrcDirs = rebar_dir:src_dirs(RebarOpts, ["src"]),
     Plugins = rebar_state:get(State, plugins, []),
+    ProjectPlugins = rebar_state:get(State, project_plugins, []),
     PluginsDirs = filelib:wildcard(filename:join(rebar_dir:plugins_dir(State), "*")),
     CheckoutsDirs = filelib:wildcard(filename:join(rebar_dir:checkouts_dir(State), "*")),
     Apps = rebar_app_discover:find_apps(CheckoutsDirs++PluginsDirs, SrcDirs, all, State),
-    display_plugins("Local plugins", Apps, Plugins),
+    display_plugins("Local plugins", Apps, Plugins ++ ProjectPlugins),
     {ok, State}.
 
 -spec format_error(any()) -> iolist().


### PR DESCRIPTION
I believe project plugins should also be listed when displaying plugins by: `rebar3 plugins list`