### PR TITLE
problems when building in folders with exclamation mark

### DIFF
--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -35,7 +35,7 @@ lock_(AppDir, {git, Url}) ->
                 rebar_utils:sh("git --git-dir=\"" ++ Dir ++ "/.git\" --work-tree=\"" ++ Dir ++ "\" rev-parse --verify HEAD",
                     [{use_stdout, false}, {debug_abort_on_error, AbortMsg}]);
             _ ->
-                rebar_utils:sh("git --git-dir=\"" ++ Dir ++ "/.git\" rev-parse --verify HEAD",
+                rebar_utils:sh("git --git-dir=" ++ Dir ++ "/.git rev-parse --verify HEAD",
                     [{use_stdout, false}, {debug_abort_on_error, AbortMsg}])
         end,
     Ref = rebar_string:trim(VsnString, both, "\n"),


### PR DESCRIPTION
When try to build from, let say `/Users/maxim/depot/\!/joe` directory:

```
===> Port Cmd: git --git-dir="/Users/maxim/depot/\!/joe/_build/default/lib/goldrush/.git" rev-parse --verify HEAD
Port Opts: [exit_status,{line,16384},use_stdio,stderr_to_stdout,hide,eof]

===> sh(git --git-dir="/Users/maxim/depot/\!/joe/_build/default/lib/goldrush/.git" rev-parse --verify HEAD)
failed with return code 128 and the following output:
fatal: Not a git repository: '/Users/maxim/depot/\!/joe/_build/default/lib/goldrush/.git'

===> Locking of git dependency failed in /Users/maxim/depot/!/joe/_build/default/lib/goldrush
```

Reproducing:

```
bash-3.2$ git --git-dir="/Users/maxim/depot/\!/joe/_build/default/deps/goldrush/.git/" rev-parse --verify HEAD
fatal: Not a git repository: '/Users/maxim/depot/\!/joe/_build/default/deps/goldrush/.git/'
```

However without quotes works:

```
bash-3.2$ git --git-dir=/Users/maxim/depot/\!/joe/_build/default/deps/goldrush/.git rev-parse --verify HEAD
9e92405985827fabd2508b92bdc8b28b9e17b668
```

NOTE: This fix is just for demonstrating the problem. Do not merge.
