### PR TITLE
Support env. vars in src_dirs/extra_src_dirs

### DIFF
--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -191,13 +191,18 @@ compile(State, Providers, AppInfo) ->
 %% Internal functions
 %% ===================================================================
 
+expand_dir_env({Dir, Opts}, State) ->
+  {expand_dir_env(Dir, State), Opts};
+expand_dir_env(Dir, State) ->
+  rebar_utils:expand_env_variables(Dir, State).
+
 expand_source_dirs_env(App, Prop, State) ->
     case rebar_app_info:get(App, Prop, undef) of
         undef ->
             App;
 
         Dirs ->
-            Dirs1 = [rebar_utils:expand_env_variables(D, State) || D <- Dirs],
+            Dirs1 = [expand_dir_env(D, State) || D <- Dirs],
             rebar_app_info:set(App, Prop, Dirs1)
     end.
 

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -53,6 +53,7 @@
          cleanup_code_path/1,
          args_to_tasks/1,
          expand_env_variable/3,
+         expand_env_variables/2,
          get_arch/0,
          wordsize/0,
          deps_to_binary/1,
@@ -529,6 +530,16 @@ expand_env_variable(InStr, VarName, RawVarValue) ->
             RegEx = io_lib:format("\\\$(~ts(\\W|$)|{~ts})", [VarName, VarName]),
             re:replace(InStr, RegEx, [VarValue, "\\2"], ReOpts)
     end.
+
+%% @doc Expand all the env. variables provided by rebar_env using `expand_env_variable'
+-spec expand_env_variables(string(), rebar_state:t()) -> string().
+expand_env_variables(Input, State) ->
+  lists:foldl(
+    fun({Var, Value}, Input0) ->
+      expand_env_variable(Input0, Var, Value)
+    end,
+    Input,
+    rebar_env:create_env(State)).
 
 %% ====================================================================
 %% Internal functions


### PR DESCRIPTION
In some scenarios (like using protobuf for example) the sources are to be generated during compilation.
It is more convenient to generate them in temporary directory under the $REBAR_BUILD_DIR to appropriately isolate them.
In order to compile those sources, the rebar should support specifying src_dirs/extra_src_dirs with variables.