### PR TITLE
revert ebin_modules to include all beams minus extra_src

### DIFF
--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -164,16 +164,31 @@ validate_name(AppName, File) ->
 
 ebin_modules(AppInfo, Dir) ->
     Beams = lists:sort(rebar_utils:beams(filename:join(Dir, "ebin"))),
-    SrcDirs = rebar_dir:src_dirs(rebar_app_info:opts(AppInfo), ["src"]),
-    FindSourceRules = [{".beam", ".erl",
-                        [{"ebin", filename:join(SrcDir, "**")} || SrcDir <- SrcDirs]}],
-    Filtered = lists:filter(fun(Beam) ->
-                                rebar_utils:find_source(filename:basename(Beam),
-                                                        filename:dirname(Beam),
-                                                        FindSourceRules)
-                                        =/= {error, not_found}
-                            end, Beams),
+    ExtraDirs = extra_dirs(AppInfo),
+    F = fun(Beam) -> not in_extra_dir(AppInfo, Beam, ExtraDirs) end,
+    Filtered = lists:filter(F, Beams),
     [rebar_utils:beam_to_mod(N) || N <- Filtered].
+
+extra_dirs(State) ->
+    Extras = rebar_dir:extra_src_dirs(rebar_app_info:opts(State)),
+    SrcDirs = rebar_dir:src_dirs(rebar_app_info:opts(State), ["src"]),
+    %% remove any dirs that are defined in `src_dirs` from `extra_src_dirs`
+    Extras -- SrcDirs.
+
+in_extra_dir(AppInfo, Beam, Dirs) ->
+    lists:any(fun(Dir) -> lists:prefix(filename:join([rebar_app_info:out_dir(AppInfo), Dir]),
+                                       beam_src(Beam)) end,
+              Dirs).
+
+beam_src(Beam) ->
+    case beam_lib:chunks(Beam, [compile_info]) of
+        {ok, {_mod, Chunks}} ->
+            CompileInfo = proplists:get_value(compile_info, Chunks, []),
+            proplists:get_value(source, CompileInfo, []);
+        {error, beam_lib, Reason} ->
+            ?WARN("Couldn't read debug info from ~p for reason: ~p", [Beam, Reason]),
+            []
+    end.
 
 ensure_registered(AppData) ->
     case lists:keyfind(registered, 1, AppData) of


### PR DESCRIPTION
This change broke inclusion of modules that are built straight to beam files and have no `.erl` file in the src dirs for them.

I don't think the removal of beams that are built from extra src dirs is required though... I kept it there since I'm just reverting to the old functionality, but extra src dir beams aren't built to the ebin dir, so not sure why that is there. Unless we should be building extra src dir files to ebin instead of doing the annoying copying of source files.