### PR TITLE
Fix path coverage loading artifacts

### DIFF
--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -320,7 +320,7 @@ cover_compile(State, apps) ->
     AppDirs = app_dirs(Apps),
     cover_compile(State, lists:filter(fun(D) -> ec_file:is_dir(D) end, AppDirs));
 cover_compile(State, Dirs) ->
-    rebar_utils:update_code(rebar_state:code_paths(State, all_deps), [soft_purge]),
+    rebar_paths:set_paths([deps], State),
     %% start the cover server if necessary
     {ok, CoverPid} = start_cover(),
     %% redirect cover output
@@ -343,7 +343,6 @@ cover_compile(State, Dirs) ->
                 ?WARN("Directory ~p error ~p", [Dir, Reason])
         end
     end, Dirs),
-    rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
     ok.
 
 is_ignored(Dir, File, ExclMods) ->


### PR DESCRIPTION
The old path handling routine would force loading a bunch of
applications, but it did not necessarily unload them aside from specific
calls that the other test handlers used to need to do, but no longer
needed under the updated path management of 3.7.0.

The leftover calls in the cover compilation bits caused some apps to be
loaded and to remain loaded before tests started.

Fixes #1958 