### PR TITLE
Fix load order for custom project builders

### DIFF
--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -201,7 +201,7 @@ build_app(AppInfo, State) ->
             case lists:keyfind(Type, 1, ProjectBuilders) of
                 {_, Module} ->
                     %% load plugins since thats where project builders would be
-                    rebar_paths:set_paths([plugins, deps], State),
+                    rebar_paths:set_paths([deps, plugins], State),
                     Res = Module:build(AppInfo),
                     rebar_paths:set_paths([deps], State),
                     case Res of


### PR DESCRIPTION
Due to building dependencies with potential artifacts such as parse
transforms or macros, project builder plugins should be included in the
path, but _after_ deps are loaded.

Doing otherwise means that if any of the dependencies is required at
compile time, those of a plugin might get used first.

Fixes #1962 // awaiting confirmation by @hommeabeil 