### PR TITLE
fix for mix projects that don't have app.src files

### DIFF
--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -343,9 +343,12 @@ app_file(AppInfo=#app_info_t{}, AppFile) ->
 app_details(AppInfo=#app_info_t{app_details=[]}) ->
     case app_file(AppInfo) of
         undefined ->
-            case rebar_config:consult_app_file(app_file_src(AppInfo)) of
+            try rebar_config:consult_app_file(app_file_src(AppInfo)) of
                 [] -> [];
                 [{application, _Name, AppDetails}] -> AppDetails
+            catch
+                _:_ ->
+                    []
             end;
         AppFile ->
             try rebar_file_utils:try_consult(AppFile) of

--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -224,7 +224,8 @@ dep_to_app(Parent, DepsDir, Name, Vsn, Source, IsLock, State) ->
                       {ok, AppInfo0} =
                           case rebar_app_info:discover(Dir) of
                               {ok, App} ->
-                                  {ok, rebar_app_info:is_available(rebar_app_info:parent(App, Parent),
+                                  App1 = rebar_app_info:name(App, Name),
+                                  {ok, rebar_app_info:is_available(rebar_app_info:parent(App1, Parent),
                                                                    true)};
                               not_found ->
                                   rebar_app_info:new(Parent, Name, Vsn, Dir, [])


### PR DESCRIPTION
Marked as WIP because I'm not exactly happy with it. I'd like to understand why the `app_utils` part needed to change. The `app_info` part I understand, the new `rebar_paths` wants to find a `.app.src` file to get details and that shit doesn't exist in mix projects.

Though may want to change how it is handling a case like that, catching the exception worked to at least get mix projects to build but isn't the cleanest solution I'm sure.