### PR TITLE
Support ignoring entire modules in xref results

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -141,3 +141,4 @@ Roberto Aloi
 Andrew McRobb
 Drew Varner
 Niklas Johansson
+Bryan Paxton

--- a/src/rebar_prv_xref.erl
+++ b/src/rebar_prv_xref.erl
@@ -160,7 +160,8 @@ get_xref_ignorelist(Mod, XrefCheck) ->
     %% And create a flat {M,F,A} list
     lists:foldl(
       fun({F, A}, Acc) -> [{Mod,F,A} | Acc];
-         ({M, F, A}, Acc) -> [{M,F,A} | Acc]
+         ({M, F, A}, Acc) -> [{M,F,A} | Acc];
+         (M, Acc) when is_atom(M) -> [M | Acc]
       end, [], lists:flatten([IgnoreXref, BehaviourCallbacks])).
 
 keyall(Key, List) ->
@@ -195,7 +196,8 @@ filter_xref_results(XrefCheck, XrefIgnores, XrefResults) ->
                             end, SearchModules),
 
     [Result || Result <- XrefResults,
-               not lists:member(parse_xref_result(Result), Ignores)].
+               not lists:member(element(1, Result), Ignores)
+               andalso not lists:member(parse_xref_result(Result), Ignores)].
 
 display_results(XrefResults, QueryResults) ->
     [lists:map(fun display_xref_results_for_type/1, XrefResults),


### PR DESCRIPTION
Closes #1905 

 This PR is for supporting `module()` in xref ignores config list and via `-xref_ignore()` module attribute. 

 The current specification (prior to this PR) for xref ignores is : 
`[{module(), function(), arity()} | {module(), function()}]`. 

However,  it is often desirable to ignore an entire module for varying reasons. This patch updates the specification to:
`[module() | {module(), function(), arity()} | {module(), function()}]`

TODO: 
- [x] Implementation
- [x] Unit test
