### PR TITLE
Fix pkg name during update by using pkg_name understood by hex

### DIFF
--- a/src/rebar_prv_upgrade.erl
+++ b/src/rebar_prv_upgrade.erl
@@ -132,11 +132,13 @@ update_pkg_deps([], _, _) ->
 update_pkg_deps([{Name, _, _} | Rest], AppInfos, State) ->
     case rebar_app_utils:find(Name, AppInfos) of
         {ok, AppInfo} ->
-            case element(1, rebar_app_info:source(AppInfo)) of
+            Source = rebar_app_info:source(AppInfo),
+            case element(1, Source) of
                 pkg ->
                     Resources = rebar_state:resources(State),
                     #{repos := RepoConfigs} = rebar_resource_v2:find_resource_state(pkg, Resources),
-                    [update_package(Name, RepoConfig, State) || RepoConfig <- RepoConfigs];
+                    PkgName = element(2, Source),
+                    [update_package(PkgName, RepoConfig, State) || RepoConfig <- RepoConfigs];
                 _ ->
                     skip
             end;


### PR DESCRIPTION
Before this fix warnings were displayed during package upgrade when `rebar3` and `hex` package names were different. For example "mixer" / "inaka_mixer". Such deps are specified like:
```
{deps, [
        {mixer, "1.0.1", {pkg, inaka_mixer}}
 ]}.
```
On branch master `rebar3 upgrade` gives:
```
===> Verifying dependencies...
===> Failed to update package from repo hexpm
===> Failed to fetch updates for package mixer from repo hexpm
```
Note the package name ("mixer") in the warning message.

After the fix there is no warning. 
