### PR TITLE
Remove trailing forward slash before recrusive cp on darwin in rebar shell utils

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -203,7 +203,6 @@ cp_r(Sources, Dest) ->
                 {false, _} ->
                     SourceStr
             end,
-            EscSources = [rebar_utils:escape_chars(Src) || Src <- Sources],
             % ensure destination exists before copying files into it
             {ok, []} = rebar_utils:sh(?FMT("mkdir -p ~ts",
                            [rebar_utils:escape_chars(Dest)]),


### PR DESCRIPTION
 This PR fixes systests on darwin where previously the recursive `cp` would fail due to everything being copied after the last forward slash. Specifically, everything in  `systest/all_SUITE_data/` would be
copied but not `all_suite_data` dir itself which the tests expected.