### PR TITLE
Add --generator option for eunit

### DIFF
--- a/priv/shell-completion/bash/rebar3
+++ b/priv/shell-completion/bash/rebar3
@@ -93,8 +93,8 @@ _rebar3()
     elif [[ ${prev} == escriptize ]] ; then
         :
     elif [[ ${prev} == eunit ]] ; then
-        sopts="-c -e -v -d -f -m -s"
-        lopts="--app --application --cover --dir --error_on_warning --file --module --suite --verbose"
+        sopts="-c -e -v -d -f -m -s -g"
+        lopts="--app --application --cover --dir --error_on_warning --file --module --suite --generator --verbose"
     elif [[ ${prev} == help ]] ; then
         :
     elif [[ ${prev} == new ]] ; then

--- a/priv/shell-completion/fish/rebar3.fish
+++ b/priv/shell-completion/fish/rebar3.fish
@@ -136,6 +136,7 @@ complete -f -c 'rebar3' -n '__fish_rebar3_using_command eunut' -s e -l error_on_
 complete -f -c 'rebar3' -n '__fish_rebar3_using_command eunit' -s f -l file -d "Comma separated list of files to load tests from. Equivalent to `[{file, File}]`"
 complete -f -c 'rebar3' -n '__fish_rebar3_using_command eunit' -s m -l module -d "Comma separated list of modules to load tests from. Equivalent to `[{module, Module}]`"
 complete -f -c 'rebar3' -n '__fish_rebar3_using_command eunit' -s s -l suite -d "Comma separated list of modules to load tests from. Equivalent to `[{module, Module}]`"
+complete -f -c 'rebar3' -n '__fish_rebar3_using_command eunit' -s g -l generator -d "Comma separated list of generators (the format is `module:function`) to load tests from. Equivalent to `[{generator, Module, Function}]`"
 complete -f -c 'rebar3' -n '__fish_rebar3_using_command eunit' -s v -l verbose -d "Verbose output"
 
 complete -f -c 'rebar3' -n '__fish_rebar3_using_command eunit' -l suite -d "Lists of test suites to run"

--- a/priv/shell-completion/zsh/_rebar3
+++ b/priv/shell-completion/zsh/_rebar3
@@ -95,6 +95,7 @@ _rebar3 () {
                         '(-f --file)'{-f,--file}'[Comma separated list of files to load tests from]:files' \
                         '(-m --module)'{-m,--module}'[Comma separated list of modules to load tests from]:modules' \
                         '(-s --suite)'{-s,--suite}'[Comma separated list of modules to load tests from]:modules' \
+                        '(-g --generator)'{-g,--generator}'[Comma separated list of generators (the format is `module:function`) to load tests from.]:{generator, Module, Function}' \
                         '(-v --verbose)'{-v,--verbose}'[Verbose output]' \
                     && ret=0
                 ;;

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -105,6 +105,8 @@ format_error({eunit_test_errors, Errors}) ->
                                lists:map(fun(Error) -> "~n  " ++ Error end, Errors)), []);
 format_error({badconfig, {Msg, {Value, Key}}}) ->
     io_lib:format(Msg, [Value, Key]);
+format_error({generator, Value}) ->
+    io_lib:format("Generator ~p has an invalid format", [Value]);
 format_error({error, Error}) ->
     format_error({error_running_tests, Error}).
 
@@ -154,7 +156,7 @@ normalize(generator, Value) ->
             lists:map(fun(F) -> {generator, Module, list_to_atom(F)} end,
                       string:tokens(Functions, [$;]));
         _ ->
-            ?PRV_ERROR({generator, {"Generator `~p` is invalid format", {Value}}})
+            ?PRV_ERROR({generator, Value})
     end;
 normalize(Key, Value) when Key == dir; Key == file -> {Key, Value};
 normalize(Key, Value) -> {Key, list_to_atom(Value)}.

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -158,7 +158,7 @@ normalize(generator, Value) ->
             lists:map(fun(F) -> {generator, Module, list_to_atom(F)} end,
                       string:tokens(Functions, [$;]));
         _ ->
-            throw(lists:concat(["Generator `", Value, "' is invalid format."]))
+            ?PRV_ERROR({generator, {"Generator `~p` is invalid format", {Value}}})
     end;
 normalize(Key, Value) when Key == dir; Key == file -> {Key, Value};
 normalize(Key, Value) -> {Key, list_to_atom(Value)}.

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -40,18 +40,14 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    try
-        Tests = prepare_tests(State),
-        %% inject `eunit_first_files`, `eunit_compile_opts` and any
-        %% directories required by tests into the applications
-        NewState = inject_eunit_state(State, Tests),
-        case compile(NewState) of
-            %% successfully compiled apps
-            {ok, S} -> do(S, Tests);
-            Error   -> Error
-        end
-    catch
-        throw:Reason -> {error, Reason}
+    Tests = prepare_tests(State),
+    %% inject `eunit_first_files`, `eunit_compile_opts` and any
+    %% directories required by tests into the applications
+    NewState = inject_eunit_state(State, Tests),
+    case compile(NewState) of
+        %% successfully compiled apps
+        {ok, S} -> do(S, Tests);
+        Error   -> Error
     end.
 
 do(State, Tests) ->


### PR DESCRIPTION
This PR adds `--generator` option for rebar3 eunit.
The option is useful when we add new eunits.

Here is an example
`./rebar3 eunit --generator some_app:util_functions_test_`