### PR TITLE
Fix bad clause when validating support of hg resources

### DIFF
--- a/src/rebar_hg_resource.erl
+++ b/src/rebar_hg_resource.erl
@@ -200,7 +200,7 @@ check_type_support() ->
     case get({is_supported, ?MODULE}) of
         true ->
             ok;
-        false ->
+        _ ->
             case rebar_utils:sh("hg --version", [{return_on_error, true},
                                                  {use_stdout, false}]) of
                 {error, _} ->
@@ -210,4 +210,3 @@ check_type_support() ->
                     ok
             end
     end.
-


### PR DESCRIPTION
I got a case clause when I tried to fetch a hg dep.

===> rebar_fetch exception error {case_clause,undefined} [{rebar_hg_resource,
                                                                  check_type_support,
                                                                  0,
                                                                  [{file,
                                                                    "/opt/rebar3-3.8.0/src/rebar_hg_resource.erl"},
                                                                   {line,
                                                                    200}]},
.....
===> Failed to fetch and copy dep: {hg,"****"}