### PR TITLE
Reorder rebar3 tree output on umbrella apps

### DIFF
--- a/src/rebar_prv_deps_tree.erl
+++ b/src/rebar_prv_deps_tree.erl
@@ -52,7 +52,8 @@ print_deps_tree(SrcDeps, Verbose, State) ->
                        ,project} || App <- rebar_state:project_apps(State)],
     case dict:find(root, D) of
         {ok, Children} ->
-            print_children("", lists:keysort(1, Children++ProjectAppNames), D, Verbose);
+            print_children("", lists:keysort(1, ProjectAppNames), D, Verbose),
+            print_children("   ", lists:keysort(1, Children), D, Verbose);
         error ->
             print_children("", lists:keysort(1, ProjectAppNames), D, Verbose)
     end.


### PR DESCRIPTION
This change makes it so umbrella projects get ordered in a way more
in-line with what we do with non-umbrellas.

For example, a non-umbrella app (rebar3 itself) gives output like:

    └─ rebar─3.8.0+build.4270.refaece1d7 (project app)
       ├─ bbmustache─1.6.0 (hex package)
       ├─ certifi─2.3.1 (hex package)
       ├─ cf─0.2.2 (hex package)
       ├─ cth_readable─1.4.2 (hex package)
       ├─ erlware_commons─1.3.1 (hex package)
       ├─ eunit_formatters─0.5.0 (hex package)
       ├─ getopt─1.0.1 (hex package)
       ├─ hex_core─0.4.0 (hex package)
       ├─ parse_trans─3.3.0 (hex package)
       ├─ providers─1.7.0 (hex package)
       ├─ relx─3.28.0 (hex package)
       └─ ssl_verify_fun─1.1.3 (hex package)

The current (prior to this patch) output for an umbrella project looks
like this:

    ├─ bootstrap─0.0.2 (git repo)
    ├─ dirmon─0.1.0 (project app)
    ├─ fake─0.1.0 (project app)
    ├─ file_monitor─0.1 (git repo)
    ├─ peeranha─0.1.0 (git repo)
    │  ├─ gproc─0.5 (git repo)
    │  ├─ interclock─0.1.2 (git repo)
    │  │  ├─ bitcask─1.7.0 (git repo)
    │  │  │  └─ lager─2.1.1 (hex package)
    │  │  │     └─ goldrush─0.1.6 (hex package)
    │  │  └─ itc─1.0.0 (git repo)
    │  └─ merklet─1.0.0 (git repo)
    ├─ recon─2.2.2 (git repo)
    └─ uuid─1.5.0 (git repo)
       └─ quickrand─1.5.0 (git repo)

Which kind of looks odd because the layout represents the dependencies
of deps as declared by the rebar3 config files, but mix up the project
apps as dependencies. This turns out to break expectations, and some
external tools (such as Blackduck's dep detection -- see
https://github.com/blackducksoftware/hub-detect/blob/d8a0f2281a056aec04e3f8aecd22bbbe9a2a6f3e/hub-detect/src/main/groovy/com/blackducksoftware/integration/hub/detect/detector/hex/Rebar3TreeParser.java)
which were developed with regular apps in mind, but not umbrellas.

This PR changes things by reordering all project apps at the root level
and putting them first, and then indenting all deps below them. The same
app now looks like:

    ├─ dirmon─0.1.0 (project app)
    └─ fake─0.1.0 (project app)
       ├─ bootstrap─0.0.2 (git repo)
       ├─ file_monitor─0.1 (git repo)
       ├─ peeranha─0.1.0 (git repo)
       │  ├─ gproc─0.5 (git repo)
       │  ├─ interclock─0.1.2 (git repo)
       │  │  ├─ bitcask─1.7.0 (git repo)
       │  │  │  └─ lager─2.1.1 (hex package)
       │  │  │     └─ goldrush─0.1.6 (hex package)
       │  │  └─ itc─1.0.0 (git repo)
       │  └─ merklet─1.0.0 (git repo)
       ├─ recon─2.2.2 (git repo)
       └─ uuid─1.5.0 (git repo)
          └─ quickrand─1.5.0 (git repo)

Now the project apps are back at the top, and all the dependencies
follow at one level of indentation below.

There is no recorded change for single-app projects.