### PR TITLE
Fix performance regression in compiler around behaviours

### DIFF
--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -317,7 +317,7 @@ expand_file_names(Files, Dirs) ->
                   true ->
                       [Incl];
                   false ->
-                      rebar_utils:find_files_in_dirs(Dirs, Incl, true)
+                      rebar_utils:find_files_in_dirs(Dirs, [$^, Incl, $$], true)
               end
       end, Files).
 


### PR DESCRIPTION
When the commit at https://github.com/erlang/rebar3/commit/8c4a74a3ed9ddd9841e6596ca86b81f3d43906c0
introduced a recursive search for build elements, it accidentally did so
using a function that accepts a regex for its match.

In doing so, if a behaviour or include had a name such as
`common_prefix` and that multiple other modules used the name
`common_prefix_<rest_of_name>`, all the other files would be seen as
dependencies to be checked in a directed graph.

This resulted in continuous re-checking of files that kept depending on
each others and blew the compile time up exponentially.

By using a delimitation on the regex (`^<modulename>$`), the build comes
back down to finding only the right files and becomes fast again.

Fixes #1997 