### PR TITLE
Use double quotes in git shell command on Windows

### DIFF
--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -36,8 +36,8 @@ lock_(AppDir, {git, Url}) ->
     {ok, VsnString} =
         case os:type() of
             {win32, _} ->
-                rebar_utils:sh("git --git-dir='" ++ Dir ++ "/.git' "
-                               "--work-tree='" ++ Dir ++ "' rev-parse --verify HEAD",
+                rebar_utils:sh("git --git-dir=\"" ++ Dir ++ "/.git\" "
+                               "--work-tree=\"" ++ Dir ++ "\" rev-parse --verify HEAD",
                     [{use_stdout, false}, {debug_abort_on_error, AbortMsg}]);
             _ ->
                 rebar_utils:sh("git --git-dir='" ++ Dir ++ "/.git' rev-parse --verify HEAD",


### PR DESCRIPTION
Partially reverts commit f52a115ea9d66c812f68200383d769ac300a2828

Fixes #2003. (The single quotes cause the path to be mis-parsed in the windows command prompt, git cannot find the repo, and therefore rebar reports that "Locking of git dependency failed".)

Needs tests to prevent a future regression. (Sorry, this is outside my expertise / time available.)