### PR TITLE
[WIP/Proposal] Split up debug info into diagnostic mode.

### DIFF
--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -6,6 +6,7 @@
 
 -define(CONSOLE(Str, Args), io:format(Str++"~n", Args)).
 
+-define(DIAGNOSTIC(Str, Args), rebar_log:log(diagnostic, Str, Args)).
 -define(DEBUG(Str, Args), rebar_log:log(debug, Str, Args)).
 -define(INFO(Str, Args), rebar_log:log(info, Str, Args)).
 -define(WARN(Str, Args), rebar_log:log(warn, Str, Args)).

--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -37,8 +37,12 @@ needed_files(Graph, FoundFiles, _, AppInfo) ->
     EbinDir = rebar_app_info:ebin_dir(AppInfo),
     RebarOpts = rebar_app_info:opts(AppInfo),
     ErlOpts = rebar_opts:erl_opts(RebarOpts),
-    ?DEBUG("erlopts ~p", [ErlOpts]),
-    ?DEBUG("files to compile ~p", [FoundFiles]),
+    ?DEBUG("compiler options: ~p", [ErlOpts]),
+    ?DEBUG("files to compile:~n~s", [
+            [io_lib:format("~ts~n", [
+              rebar_dir:make_relative_path(File, rebar_dir:get_cwd())
+             ]) || File <- FoundFiles]
+    ]),
 
     %% Make sure that the ebin dir is on the path
     ok = rebar_file_utils:ensure_dir(EbinDir),

--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -92,7 +92,8 @@ process_command(State, Command) ->
     Namespace = rebar_state:namespace(State),
     TargetProviders = providers:get_target_providers(Command, Providers, Namespace),
     CommandProvider = providers:get_provider(Command, Providers, Namespace),
-    ?DEBUG("Expanded command sequence to be run: ~p", [TargetProviders]),
+    ?DEBUG("Expanded command sequence to be run: ~w",
+           [[friendly_provider(P) || P <- TargetProviders]]),
     case CommandProvider of
         not_found when Command =/= do ->
             case Namespace of
@@ -136,7 +137,7 @@ process_command(State, Command) ->
 do([], State) ->
     {ok, State};
 do([ProviderName | Rest], State) ->
-    ?DEBUG("Provider: ~p", [ProviderName]),
+    ?DEBUG("Running provider: ~p", [friendly_provider(ProviderName)]),
     %% Special providers like 'as', 'do' or some hooks may be passed
     %% as a tuple {Namespace, Name}, otherwise not. Handle them
     %% on a per-need basis.
@@ -176,3 +177,8 @@ format_error({bad_provider_namespace, {Namespace, Name}}) ->
     io_lib:format("Undefined command ~ts in namespace ~ts", [Name, Namespace]);
 format_error({bad_provider_namespace, Name}) ->
     io_lib:format("Undefined command ~ts", [Name]).
+
+%% @private help display a friendlier sequence of provider names by
+%% omitting the default namespace if it's not there
+friendly_provider({default, P}) -> P;
+friendly_provider(P) -> P.

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -243,7 +243,7 @@ find_deps(AppNames, AllApps) ->
 %% Should look at the app files to find direct dependencies
 find_deps_of_deps([], _, Acc) -> Acc;
 find_deps_of_deps([Name|Names], Apps, Acc) ->
-    ?DEBUG("processing ~p", [Name]),
+    ?DEBUG("processing ~s", [Name]),
     {ok, App} = rebar_app_utils:find(Name, Apps),
     DepNames = proplists:get_value(applications, rebar_app_info:app_details(App), []),
     BinDepNames = [rebar_utils:to_binary(Dep) || Dep <- DepNames,
@@ -252,7 +252,15 @@ find_deps_of_deps([Name|Names], Apps, Acc) ->
                    DepDir =:= {error, bad_name} orelse % those are all local
                    not lists:prefix(code:root_dir(), DepDir)]
                 -- ([Name|Names]++Acc), % avoid already seen deps
-    ?DEBUG("new deps of ~p found to be ~p", [Name, BinDepNames]),
+    case BinDepNames of
+        [] ->
+            ok;
+        _ ->
+            ?DEBUG("new deps of ~s found: ~s", [
+                Name,
+                [io_lib:format("~ts ", [Dep]) || Dep <- BinDepNames]
+            ])
+    end,
     find_deps_of_deps(BinDepNames ++ Names, Apps, BinDepNames ++ Acc).
 
 def(Rm, State, Key, Default) ->

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -177,8 +177,8 @@ sh_send(Command0, String, Options0) ->
 %% Val = string() | false
 %%
 sh(Command0, Options0) ->
-    ?DEBUG("sh info:\n\tcwd: ~p\n\tcmd: ~ts\n", [rebar_dir:get_cwd(), Command0]),
-    ?DEBUG("\topts: ~p\n", [Options0]),
+    ?DEBUG("shell command:\n\tcwd: ~p\n\tcmd: ~ts~n", [rebar_dir:get_cwd(), Command0]),
+    ?DIAGNOSTIC("shell opts: ~p\n", [Options0]),
 
     DefaultOptions = [{use_stdout, false}, debug_and_abort_on_error],
     Options = [expand_sh_flag(V)
@@ -190,12 +190,14 @@ sh(Command0, Options0) ->
     Command = lists:flatten(patch_on_windows(Command0, proplists:get_value(env, Options0, []))),
     PortSettings = proplists:get_all_values(port_settings, Options) ++
         [exit_status, {line, 16384}, use_stdio, stderr_to_stdout, hide, eof],
-    ?DEBUG("Port Cmd: ~ts\nPort Opts: ~p\n", [Command, PortSettings]),
+    ?DIAGNOSTIC("port command: ~ts\nPort Opts: ~p\n", [Command, PortSettings]),
     Port = open_port({spawn, Command}, PortSettings),
 
     try
         case sh_loop(Port, OutputHandler, []) of
-            {ok, _Output} = Ok ->
+            {ok, Output} = Ok ->
+                ?DEBUG("shell command status: ok~n", []),
+                ?DIAGNOSTIC("shell command output: ~ts~n", [rebar_log:truncate(Output)]),
                 Ok;
             {error, {_Rc, _Output}=Err} ->
                 ErrorHandler(Command, Err)
@@ -203,6 +205,7 @@ sh(Command0, Options0) ->
     after
         port_close(Port)
     end.
+
 
 find_files(Dir, Regex) ->
     find_files(Dir, Regex, true).


### PR DESCRIPTION
Diagnostic mode is intended to separate the two use cases of DEBUG=1
mode of rebar3:

1. The user trying to understand what is going on
2. A maintainer trying to dig into what leads to a given behaviour

The scope for both should be different, if only because the user's
interactions with the system should only be done through:

- rebar.config
- the files on disk
- the CLI commands
- a superficial understanding of how the tool works

The first three points tell us that we should provide user debug
output first and foremost on these topics, since those are the
interaction points users will have with the tool.

Anything that _requires_ more than superficial understanding of how the
tool works in the output is meaningless, or actively harming
understanding. This kind of output should only point towards gently
nudging the user towards understanding how the tool operates without
digging in the code (i.e. outputting the implicit commands yours depends
on)

For a maintainer, this is different. What we want is raw information
that we can rattach and reinterpret in the context of more specific
knowledge of the internals, with support from the source code if
necessary.

This is a proof of concept that keeps the former in DEBUG=1, and places
the advanced stuff in DIAGNOSTIC=1, to invent a term, kind of based on
my blog post at https://ferd.ca/operable-software.html
So far only a few things in rebar3 core and escriptize have been covered.