### PR TITLE
Support setting shell hot code loading blacklists

### DIFF
--- a/src/rebar_agent.erl
+++ b/src/rebar_agent.erl
@@ -167,11 +167,14 @@ maybe_show_warning(State) ->
 %% that makes sense.
 -spec refresh_paths(rebar_state:t()) -> ok.
 refresh_paths(RState) ->
+    
     RefreshPaths = application:get_env(rebar, refresh_paths, [all_deps, test]),
     ToRefresh = parse_refresh_paths(RefreshPaths, RState, []),
     %% Modules from apps we can't reload without breaking functionality
+    ShellOpts = rebar_state:get(RState, shell, []),
+    ShellBlacklist = proplists:get_value(app_reload_blacklist, ShellOpts, []),
     Blacklist = lists:usort(
-        application:get_env(rebar, refresh_paths_blacklist, [])
+        application:get_env(rebar, refresh_paths_blacklist, ShellBlacklist)
         ++ [rebar, erlware_commons, providers, cf, cth_readable]),
     %% Similar to rebar_utils:update_code/1, but also forces a reload
     %% of used modules. Also forces to reload all of ebin/ instead


### PR DESCRIPTION
by default, all apps except internal rebar3 ones can be blacklisted.
Some months ago, someone added support for configurable lists within
rebar3 itself using the .app env.

This PR re-exports that functionality from the rebar.config file, so
that one can set something like:

    {shell, [
      {app_reload_blacklist, [cowboy, ranch]}
    ]}.

Which will allow to prevent applications that often crash when being
reloaded from doing so. For example, cowboy and ranch processes can be
stuck in an accept call for multiple reloads in dev, which ends up
causing large failures.