### PR TITLE
Include version in plugin list

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -142,3 +142,4 @@ Andrew McRobb
 Drew Varner
 Niklas Johansson
 Bryan Paxton
+Justin Wood

--- a/src/rebar_prv_plugins.erl
+++ b/src/rebar_prv_plugins.erl
@@ -66,8 +66,8 @@ display_plugins(Apps, Plugins) ->
                                     is_tuple(Plugin) -> rebar_utils:to_binary(element(1, Plugin))
                                  end,
                           case rebar_app_utils:find(Name, Apps) of
-                              {ok, _App} ->
-                                  ?CONSOLE("~ts", [Name]);
+                              {ok, App} ->
+                                  ?CONSOLE("~ts (~s)", [Name, rebar_app_info:original_vsn(App)]);
                               error ->
                                   ?DEBUG("Unable to find plugin ~ts", [Name])
                           end


### PR DESCRIPTION
Fixes #1417 

Running `rebar3 plugin list` now outputs the following

```
$ rebar3 plugins list
--- Global plugins ---
rebar3_hex (4.1.0)
```