### PR TITLE
Fix provider hook handling for escriptize

### DIFF
--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -80,11 +80,16 @@ do(State) ->
                     ?PRV_ERROR({bad_name, Name})
             end
     end,
-    AppInfo1 = rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, AppInfo0, State),
-    ?INFO("Building escript...", []),
-    Res = escriptize(State, AppInfo1),
-    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, AppInfo1, State),
-    Res.
+    case AppInfo0 of
+        {error, _} = Err ->
+            Err;
+        _ ->
+            AppInfo1 = rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, AppInfo0, State),
+            ?INFO("Building escript...", []),
+            Res = escriptize(State, AppInfo1),
+            rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, AppInfo1, State),
+            Res
+    end.
 
 escriptize(State0, App) ->
     AppName = rebar_app_info:name(App),

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -63,13 +63,11 @@ desc() ->
 do(State) ->
     Providers = rebar_state:providers(State),
     Cwd = rebar_state:dir(State),
-    rebar_hooks:run_project_and_app_hooks(Cwd, pre, ?PROVIDER, Providers, State),
-    ?INFO("Building escript...", []),
-    Res = case rebar_state:get(State, escript_main_app, undefined) of
+    AppInfo0 = case rebar_state:get(State, escript_main_app, undefined) of
         undefined ->
             case rebar_state:project_apps(State) of
-                [App] ->
-                    escriptize(State, App);
+                [AppInfo] ->
+                    AppInfo;
                 _ ->
                     ?PRV_ERROR(no_main_app)
             end;
@@ -77,12 +75,15 @@ do(State) ->
             AllApps = rebar_state:all_deps(State)++rebar_state:project_apps(State),
             case rebar_app_utils:find(rebar_utils:to_binary(Name), AllApps) of
                 {ok, AppInfo} ->
-                    escriptize(State, AppInfo);
+                    AppInfo;
                 _ ->
                     ?PRV_ERROR({bad_name, Name})
             end
     end,
-    rebar_hooks:run_project_and_app_hooks(Cwd, post, ?PROVIDER, Providers, State),
+    AppInfo1 = rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, AppInfo0, State),
+    ?INFO("Building escript...", []),
+    Res = escriptize(State, AppInfo1),
+    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, AppInfo1, State),
     Res.
 
 escriptize(State0, App) ->


### PR DESCRIPTION
Previously all escriptize hooks from all apps in the project were
executed, which could lead to issue in case of dependencies on artifacts
which are created by these hooks.

Now the behaviour is similar to the handling of other non-global hooks.