### PR TITLE
format hex packages in a nice/human way

### DIFF
--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -283,7 +283,7 @@ update_seen_dep(AppInfo, _Profile, _Level, Deps, Apps, State, Upgrade, Seen, Loc
                     %% meaning there is no conflict, so don't warn about it.
                     skip;
                 _ ->
-                    warn_skip_deps(Name, Source, State)
+                    warn_skip_deps(AppInfo, State)
             end;
         true ->
             ok
@@ -395,8 +395,7 @@ make_relative_to_root(State, Path) when is_list(Path) ->
     rebar_dir:make_relative_path(Path, Root).
 
 fetch_app(AppInfo, State) ->
-    ?INFO("Fetching ~ts (~p)", [rebar_app_info:name(AppInfo),
-                                rebar_resource_v2:format_source(rebar_app_info:source(AppInfo))]),
+    ?INFO("Fetching ~ts", [rebar_resource_v2:format_source(AppInfo)]),
     rebar_fetch:download_source(AppInfo, State).
 
 maybe_upgrade(AppInfo, _AppDir, Upgrade, State) ->
@@ -404,8 +403,7 @@ maybe_upgrade(AppInfo, _AppDir, Upgrade, State) ->
         true ->
             case rebar_fetch:needs_update(AppInfo, State) of
                 true ->
-                    ?INFO("Upgrading ~ts (~p)", [rebar_app_info:name(AppInfo),
-                                                 rebar_resource_v2:format_source(rebar_app_info:source(AppInfo))]),
+                    ?INFO("Upgrading ~ts", [rebar_resource_v2:format_source(AppInfo)]),
                     rebar_fetch:download_source(AppInfo, State);
                 false ->
                     case Upgrade of
@@ -420,11 +418,10 @@ maybe_upgrade(AppInfo, _AppDir, Upgrade, State) ->
             AppInfo
     end.
 
-warn_skip_deps(Name, Source, State) ->
-    Msg = "Skipping ~ts (from ~p) as an app of the same name "
+warn_skip_deps(AppInfo, State) ->
+    Msg = "Skipping ~ts as an app of the same name "
           "has already been fetched",
-    Args = [Name,
-            rebar_resource_v2:format_source(Source)],
+    Args = [rebar_resource_v2:format_source(AppInfo)],
     case rebar_state:get(State, deps_error_on_conflict, false) of
         false ->
             case rebar_state:get(State, deps_warning_on_conflict, true) of

--- a/src/rebar_resource_v2.erl
+++ b/src/rebar_resource_v2.erl
@@ -61,14 +61,20 @@ find_resource(Type, Resources) ->
 
 find_resource_state(Type, Resources) ->
     case lists:keyfind(Type, #resource.type, Resources) of
-        false ->            
+        false ->
             {error, not_found};
         #resource{state=State} ->
             State
     end.
 
-format_source({pkg, Name, Vsn, _Hash, _}) -> {pkg, Name, Vsn};
-format_source(Source) -> Source.
+format_source(AppInfo) ->
+    Name = rebar_app_info:name(AppInfo),
+    case rebar_app_info:source(AppInfo) of
+        {pkg, _Name, Vsn, _Hash, _} ->
+            io_lib:format("~ts v~s", [Name, Vsn]);
+        Source ->
+            io_lib:format("~ts (from ~p)", [Name, Source])
+    end.
 
 lock(AppInfo, State) ->
     resource_run(lock, rebar_app_info:source(AppInfo), [AppInfo], State).

--- a/test/rebar_deps_SUITE.erl
+++ b/test/rebar_deps_SUITE.erl
@@ -560,10 +560,13 @@ check_warnings(Warns, [{Name, Vsn} | Rest], Type) ->
 
 in_warnings(git, Warns, NameRaw, VsnRaw) ->
     Name = iolist_to_binary(NameRaw),
-    1 =< length([1 || {_, [AppName, {git, _, {_, Vsn}}]} <- Warns,
-                      AppName =:= Name, Vsn =:= VsnRaw]);
+    Vsn  = iolist_to_binary([$",VsnRaw,$"]),
+    1 =< length([1 || {_, [[AppName, $\s,$(,$f,$r,$o,$m,$\s,[${,["git",$,, _URL, $,,[${,["tag",$,, AppVsn], $}]],$}],$)]]} <- Warns,
+                      iolist_to_binary(AppName) =:= Name,
+                      iolist_to_binary(AppVsn) =:= Vsn]);
 in_warnings(pkg, Warns, NameRaw, VsnRaw) ->
     Name = iolist_to_binary(NameRaw),
     Vsn = iolist_to_binary(VsnRaw),
-    1 =< length([1 || {_, [AppName, {pkg, _, AppVsn}]} <- Warns,
-                      AppName =:= Name, AppVsn =:= Vsn]).
+    1 =< length([1 || {_, [[AppName, $\s,$v, AppVsn]]} <- Warns,
+                      iolist_to_binary(AppName) =:= Name,
+                      iolist_to_binary(AppVsn) =:= Vsn]).

--- a/test/rebar_install_deps_SUITE.erl
+++ b/test/rebar_install_deps_SUITE.erl
@@ -481,10 +481,13 @@ check_warnings(Warns, none, _Type) ->
 
 in_warnings(git, Warns, NameRaw, VsnRaw) ->
     Name = iolist_to_binary(NameRaw),
-    1 =< length([1 || {_, [AppName, {git, _, {_, Vsn}}]} <- Warns,
-                      AppName =:= Name, Vsn =:= VsnRaw]);
+    Vsn  = iolist_to_binary([$",VsnRaw,$"]),
+    1 =< length([1 || {_, [[AppName, $\s,$(,$f,$r,$o,$m,$\s,[${,["git",$,, _URL, $,,[${,["tag",$,, AppVsn], $}]],$}],$)]]} <- Warns,
+                      iolist_to_binary(AppName) =:= Name,
+                      iolist_to_binary(AppVsn) =:= Vsn]);
 in_warnings(pkg, Warns, NameRaw, VsnRaw) ->
     Name = iolist_to_binary(NameRaw),
     Vsn = iolist_to_binary(VsnRaw),
-    1 =< length([1 || {_, [AppName, {pkg, _, AppVsn}]} <- Warns,
-                      AppName =:= Name, AppVsn =:= Vsn]).
+    1 =< length([1 || {_, [[AppName, $\s,$v, AppVsn]]} <- Warns,
+                      iolist_to_binary(AppName) =:= Name,
+                      iolist_to_binary(AppVsn) =:= Vsn]).


### PR DESCRIPTION
Changes
```erlang
===> Verifying dependencies...
===> Upgrading lager ({pkg,<<"lager">>,<<"3.6.8">>})
===> Downloaded package, caching at /home/pete/.cache/rebar3/hex/hexpm/packages/lager-3.6.8.tar
===> No upgrade needed for amqp_client
===> No upgrade needed for jsx
===> Upgrading lager ({pkg,<<"lager">>,<<"3.6.9">>})
===> Version cached at /home/pete/.cache/rebar3/hex/hexpm/packages/lager-3.6.9.tar is up to date, reusing it
```
into
```erlang
===> Verifying dependencies...
===> Upgrading lager v3.6.8
===> Version cached at /home/pete/.cache/rebar3/hex/hexpm/packages/lager-3.6.8.tar is up to date, reusing it
===> No upgrade needed for amqp_client
===> No upgrade needed for jsx
===> Upgrading lager v3.6.9
===> Version cached at /home/pete/.cache/rebar3/hex/hexpm/packages/lager-3.6.9.tar is up to date, reusing it
```

In short:
```erlang
===> Fetching bbmustache ({pkg,<<"bbmustache">>,<<"1.6.0">>})
===> Fetching bbmustache v1.6.0
```