### PR TITLE
Add basic linting for .app file

### DIFF
--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -100,12 +100,43 @@ validate_application_info(AppInfo, AppDetail) ->
         undefined ->
             false;
         AppFile ->
+            lint_detail(AppDetail, AppFile),
             case proplists:get_value(modules, AppDetail) of
                 undefined ->
                     ?PRV_ERROR({module_list, AppFile});
                 List ->
                     has_all_beams(EbinDir, List)
             end
+    end.
+
+-spec lint_detail(list(), file:filename_all()) -> ok.
+lint_detail(AppDetail, AppFile) ->
+    lint_description(AppDetail, AppFile),
+    lint_applications(AppDetail, AppFile).
+
+-spec lint_description(list(), file:filename_all()) -> ok.
+lint_description(AppDetail, AppFile) ->
+    case proplists:get_value(description, AppDetail, "") of
+        "" -> ?WARN("~p is missing description entry", [AppFile]);
+        _ -> ok
+    end.
+
+-spec lint_applications(list(), file:filename_all()) -> ok.
+lint_applications(AppDetail, AppFile) ->
+    case proplists:get_value(applications, AppDetail, []) of
+        [] -> ?WARN("~p is missing applications entry", [AppFile]);
+        AppList when is_list(AppList) ->
+            case lists:member(kernel, AppList) of
+                false ->
+                    ?WARN("~p is missing kernel from applications list", [AppFile]);
+                true -> ok
+            end,
+            case lists:member(stdlib, AppList) of
+                false ->
+                    ?WARN("~p is missing stdlib from applications list", [AppFile]);
+                true -> ok
+            end;
+        _ -> ?WARN("~p requires a list for applications key", [AppFile])
     end.
 
 %% @doc parses all dependencies from the root of the project

--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -123,8 +123,8 @@ lint_description(AppDetail, AppFile) ->
 
 -spec lint_applications(list(), file:filename_all()) -> ok.
 lint_applications(AppDetail, AppFile) ->
-    case proplists:get_value(applications, AppDetail, []) of
-        [] -> ?WARN("~p is missing applications entry", [AppFile]);
+    case proplists:get_value(applications, AppDetail) of
+        undefined -> ?WARN("~p is missing applications entry", [AppFile]);
         AppList when is_list(AppList) ->
             case lists:member(kernel, AppList) of
                 false ->

--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -136,7 +136,7 @@ lint_applications(AppDetail, AppFile) ->
                     ?WARN("~p is missing stdlib from applications list", [AppFile]);
                 true -> ok
             end;
-        _ -> ?WARN("~p requires a list for applications key", [AppFile])
+        _ -> ?WARN("~p requires a list for applications value", [AppFile])
     end.
 
 %% @doc parses all dependencies from the root of the project

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -2324,8 +2324,6 @@ app_file_linting(Config) ->
     History = meck:history(rebar_log),
     Warnings = [{Str, Args} || {_, {rebar_log, log, [warn, Str, Args]}, _} <- History],
 
-    ct:pal("Warnings Length: ~p", [length(Warnings)]),
-    ct:pal("Warnings: ~p", [Warnings]),
     ?assert(none /= proplists:lookup("~p is missing description entry", Warnings)),
     ?assert(none /= proplists:lookup("~p is missing kernel from applications list", Warnings)),
     ?assert(none /= proplists:lookup("~p is missing stdlib from applications list", Warnings)).


### PR DESCRIPTION
Resolves #980 

This currently just checks for the existence of the description and applications
keys and that the applications list has kernel and stdlib in it.

If there are other things that could be linted, I would be happy to add them.