### PR TITLE
Add a build_deps property in the .app.src

### DIFF
--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -347,20 +347,24 @@ create_app_info(AppInfo, AppDir, AppFile) ->
     AppVsn = proplists:get_value(vsn, AppDetails),
     Applications = proplists:get_value(applications, AppDetails, []),
     IncludedApplications = proplists:get_value(included_applications, AppDetails, []),
+    BuildDeps = proplists:get_value(build_deps, AppDetails, []),
     AppInfo1 = rebar_app_info:name(
                  rebar_app_info:original_vsn(
                    rebar_app_info:dir(AppInfo, AppDir), AppVsn), AppName),
     AppInfo2 = rebar_app_info:applications(
                  rebar_app_info:app_details(AppInfo1, AppDetails),
                  IncludedApplications++Applications),
-    Valid = case rebar_app_utils:validate_application_info(AppInfo2) =:= true
-                andalso rebar_app_info:has_all_artifacts(AppInfo2) =:= true of
+    AppInfo3 = rebar_app_info:build_deps(
+                 rebar_app_info:app_details(AppInfo2, AppDetails),
+                 BuildDeps),
+    Valid = case rebar_app_utils:validate_application_info(AppInfo3) =:= true
+                andalso rebar_app_info:has_all_artifacts(AppInfo3) =:= true of
                 true ->
                     true;
                 _ ->
                     false
             end,
-    rebar_app_info:dir(rebar_app_info:valid(AppInfo2, Valid), AppDir).
+    rebar_app_info:dir(rebar_app_info:valid(AppInfo3, Valid), AppDir).
 
 %% @doc Read in and parse the .app file if it is availabe. Do the same for
 %% the .app.src file if it exists.

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -27,6 +27,8 @@
          priv_dir/1,
          applications/1,
          applications/2,
+         build_deps/1,
+         build_deps/2,
          profiles/1,
          profiles/2,
          deps/1,
@@ -97,7 +99,9 @@
                      is_checkout=false  :: boolean(),
                      valid              :: boolean() | undefined,
                      project_type       :: project_type(),
-                     is_available=false :: boolean()}).
+                     is_available=false :: boolean(),
+                     build_deps=[]      :: list()
+                     }).
 
 %%============================================================================
 %% types
@@ -405,6 +409,17 @@ applications(#app_info_t{applications=Applications}) ->
 -spec applications(t(), list()) -> t().
 applications(AppInfo=#app_info_t{}, Applications) ->
     AppInfo#app_info_t{applications=Applications}.
+
+%% @doc returns the list of build_deps the app depends on.
+-spec build_deps(t()) -> list().
+build_deps(#app_info_t{build_deps=Applications}) ->
+    Applications.
+
+%% @doc sets the list of build_deps the app depends on.
+%% Should be obtained from the app file.
+-spec build_deps(t(), list()) -> t().
+build_deps(AppInfo=#app_info_t{}, Applications) ->
+    AppInfo#app_info_t{build_deps=Applications}.
 
 %% @doc returns the list of active profiles
 -spec profiles(t()) -> list().

--- a/src/rebar_digraph.erl
+++ b/src/rebar_digraph.erl
@@ -109,6 +109,9 @@ find_app_by_name(Name, Apps) ->
 %% for building the app.
 -spec all_apps_deps(rebar_app_info:t()) -> [binary()].
 all_apps_deps(App) ->
-    Applications = lists:usort([atom_to_binary(X, utf8) || X <- rebar_app_info:applications(App)]),
+    Applications = lists:usort([
+        atom_to_binary(X, utf8) ||
+        X <- rebar_app_info:applications(App) ++ rebar_app_info:build_deps(App)
+    ]),
     Deps = lists:usort(lists:map(fun({Name, _}) -> Name; (Name) -> Name end, rebar_app_info:deps(App))),
     lists:umerge(Deps, Applications).


### PR DESCRIPTION
This allows us to reliably compile an application in an umbrella project before others.

Fixes #1847 for us.