### PR TITLE
upgrade relx to 3.30.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
         {providers,           "1.7.0"},
         {getopt,              "1.0.1"},
         {bbmustache,          "1.6.0"},
-        {relx,                "3.29.0"},
+        {relx,                "3.30.0"},
         {cf,                  "0.2.2"},
         {cth_readable,        "1.4.3"},
         {eunit_formatters,    "0.5.0"}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},0},
  {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.7.0">>},0},
- {<<"relx">>,{pkg,<<"relx">>,<<"3.29.0">>},0},
+ {<<"relx">>,{pkg,<<"relx">>,<<"3.30.0">>},0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.3">>},0}]}.
 [
 {pkg_hash,[
@@ -21,6 +21,6 @@
  {<<"getopt">>, <<"C73A9FA687B217F2FF79F68A3B637711BB1936E712B521D8CE466B29CBF7808A">>},
  {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>},
  {<<"providers">>, <<"BBF730563914328EC2511D205E6477A94831DB7297DE313B3872A2B26C562EAB">>},
- {<<"relx">>, <<"CEDB052F2417784C939AE23FE2EF2C243B6A272C419B85510B33BC1C55728082">>},
+ {<<"relx">>, <<"F28F745053118331B2C873B8CA3CE812A760FC664836ACA5554055AD712BA47F">>},
  {<<"ssl_verify_fun">>, <<"6C49665D4326E26CD4A5B7BD54AA442B33DADFB7C5D59A0D0CD0BF5534BBFBD7">>}]}
 ].


### PR DESCRIPTION
Lots of goodies:

- [Include dist and epmd arguments from vm.args in remote console and nodetool calls](https://github.com/erlware/relx/pull/710)
- [Don't require a cookie in the start script](https://github.com/erlware/relx/pull/708)
- [use RELX_OUT_FILE_PATH to write configs generated from `.src` files](https://github.com/erlware/relx/pull/700)
- [Only create `$RUNNER_LOG_DIR` when `start` is called in extended start script](https://github.com/erlware/relx/pull/699)
- [Fix inclusion of vm.args.src in tarball](https://github.com/erlware/relx/pull/698)
- [Fix parameter shift on win32 for extension commands](https://github.com/erlware/relx/pull/695)
