### PR TITLE
Disable windows on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,11 +18,12 @@ osx_test_task:
     ./bootstrap
     ./rebar3 ct
 
-windows_test_task:
-  windows_container:
-    image: cirrusci/windowsservercore:2019
-    os_version: 2019
-  install_script: choco install -y erlang
-  test_script: |
-    ./bootstrap
-    ./rebar3 ct
+# Windows CI appears broken for now and never passes
+#windows_test_task:
+#  windows_container:
+#    image: cirrusci/windowsservercore:2019
+#    os_version: 2019
+#  install_script: choco install -y erlang
+#  test_script: |
+#    ./bootstrap
+#    ./rebar3 ct


### PR DESCRIPTION
This never passes even if it works on Windows 10 machines and on Circle
CI's runs.