### PR TITLE
OTP-22.0 readiness

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,11 +1,11 @@
 test_task:
   container:
     matrix:
+      - image: erlang:22
       - image: erlang:21
       - image: erlang:20
       - image: erlang:19
       - image: erlang:18
-      - image: erlang:17
   test_script: |
     ./bootstrap
     ./rebar3 ct

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: erlang
 matrix:
   include:
     - os: linux
-      otp_release: 17.5
-    - os: linux
       otp_release: 18.3
     - os: linux
       otp_release: 19.3
@@ -11,6 +9,8 @@ matrix:
       otp_release: 20.0
     - os: linux
       otp_release: 21.0
+    - os: linux
+      otp_release: 22.0
     - os: osx
       language: generic
 before_script:

--- a/rebar.config
+++ b/rebar.config
@@ -29,8 +29,7 @@
 {escript_incl_extra, [{"relx/priv/templates/*", "_build/default/lib/"},
                       {"rebar/priv/templates/*", "_build/default/lib/"}]}.
 
-{erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
-            {platform_define, "^(19|2)", rand_only},
+{erl_opts, [{platform_define, "^(19|2)", rand_only},
             {platform_define, "^2", unicode_str},
             {platform_define, "^(2[1-9])|(20\\\\.3)", filelib_find_source},
             {platform_define, "^(R|1|20)", fun_stacktrace},

--- a/rebar.config
+++ b/rebar.config
@@ -45,7 +45,7 @@
 
 %% Profiles
 {profiles, [{test, [
-                   {deps, [{meck, "0.8.12"}]},
+                   {deps, [{meck, "0.8.13"}]},
                    {erl_opts, [debug_info, nowarn_export_all]}
                    ]
             },

--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -55,23 +55,9 @@
                    state :: term(),
                    implementation :: rebar_resource | rebar_resource_v2}).
 
--ifdef(namespaced_types).
 -type rebar_dict() :: dict:dict().
--else.
--type rebar_dict() :: dict().
--endif.
-
--ifdef(namespaced_types).
 -type rebar_digraph() :: digraph:graph().
--else.
--type rebar_digraph() :: digraph().
--endif.
-
--ifdef(namespaced_types).
 -type rebar_set() :: sets:set().
--else.
--type rebar_set() :: set().
--endif.
 
 -ifdef(fun_stacktrace).
 -define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(),).

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -972,7 +972,7 @@ get_proxy_auth() ->
         {ok, ProxyAuth} -> ProxyAuth
     end.
 
--spec rebar_utils:is_list_of_strings(term()) -> boolean().
+-spec is_list_of_strings(term()) -> boolean().
 is_list_of_strings(List) when not is_list(hd(List)) ->
     false;
 is_list_of_strings(List) when is_list(hd(List)) ->


### PR DESCRIPTION
- fixes some bad typespecs that crashed tests on OTP-22
- removes namespaced_types workaround from when `dict()` became `dict:dict()`
- deprecates OTP-17 while adding OTP-22 to keep our version window identical (done in CI)