### PR TITLE
make app file linting configurable

### DIFF
--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -32,6 +32,7 @@
          app_src_to_app/2,
          validate_application_info/1,
          validate_application_info/2,
+         lint_app_file/2,
          parse_deps/5,
          parse_deps/6,
          parse_dep/6,
@@ -101,7 +102,6 @@ validate_application_info(AppInfo, AppDetail) ->
         undefined ->
             false;
         AppFile ->
-            lint_detail(AppDetail, AppFile),
             case proplists:get_value(modules, AppDetail) of
                 undefined ->
                     ?PRV_ERROR({module_list, AppFile});
@@ -110,8 +110,8 @@ validate_application_info(AppInfo, AppDetail) ->
             end
     end.
 
--spec lint_detail(list(), file:filename_all()) -> ok.
-lint_detail(AppDetail, AppFile) ->
+-spec lint_app_file(list(), file:filename_all()) -> ok.
+lint_app_file(AppDetail, AppFile) ->
     lint_description(AppDetail, AppFile),
     lint_applications(AppDetail, AppFile).
 

--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -75,12 +75,22 @@ validate_app(State, App) ->
         {ok, [{application, AppName, AppData}]} ->
             case validate_name(AppName, AppFile) of
                 ok ->
+                    lint_app_file(App, AppData, AppFile),
                     validate_app_modules(State, App, AppData);
                 Error ->
                     Error
             end;
         {error, Reason} ->
             ?PRV_ERROR({file_read, rebar_app_info:name(App), ".app", Reason})
+    end.
+
+lint_app_file(App, AppData, AppFile) ->
+    AppOpts = rebar_app_info:opts(App),
+    case rebar_opts:get(AppOpts, lint_app_file, true) of
+        true ->
+            rebar_app_utils:lint_app_file(AppData, AppFile);
+        false ->
+            ok
     end.
 
 validate_app_modules(State, App, AppData) ->


### PR DESCRIPTION
As many dependencies including Erlang/OTP itself throws warnings when
app file is imperfect, let's give an option to the user to turn off these
warnings.