### PR TITLE
Do not apply overrides to a root application.

### DIFF
--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -27,7 +27,7 @@ all() ->
      profile_deps, deps_build_in_prod, only_deps,
      override_deps, override_add_deps, override_del_deps,
      override_opts, override_add_opts, override_del_opts,
-     apply_overrides_exactly_once,
+     apply_overrides_exactly_once, override_only_deps,
      profile_override_deps, profile_override_add_deps, profile_override_del_deps,
      profile_override_opts, profile_override_add_opts, profile_override_del_opts,
      include_file_relative_to_working_directory, include_file_in_src,
@@ -1442,10 +1442,11 @@ override_del_deps(Config) ->
     ).
 
 override_opts(Config) ->
-    AppDir = ?config(apps, Config),
+    AppsDir = ?config(apps, Config),
 
     Name = rebar_test_utils:create_random_name("app1_"),
     Vsn = rebar_test_utils:create_random_vsn(),
+    AppDir = filename:join([AppsDir, "apps", Name]),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     RebarConfig = [
@@ -1460,12 +1461,12 @@ override_opts(Config) ->
         ]}
     ],
 
-    rebar_test_utils:create_config(AppDir, RebarConfig),
+    rebar_test_utils:create_config(AppsDir, RebarConfig),
 
     rebar_test_utils:run_and_check(
          Config, RebarConfig, ["compile"], {ok, [{app, Name}]}),
 
-    Path = filename:join([AppDir, "_build", "default", "lib", Name, "ebin"]),
+    Path = filename:join([AppsDir, "_build", "default", "lib", Name, "ebin"]),
     code:add_patha(Path),
 
     Mod = list_to_atom("not_a_real_src_" ++ Name),
@@ -1502,11 +1503,35 @@ apply_overrides_exactly_once(Config) ->
     rebar_test_utils:run_and_check(
       Config, RebarConfig, ["ct", "--compile_only"], {ok, [{app, Name}, {dep, "some_dep"}], "test"}).
 
-override_add_opts(Config) ->
+override_only_deps(Config) ->
     AppDir = ?config(apps, Config),
 
     Name = rebar_test_utils:create_random_name("app1_"),
     Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    RebarConfig = [
+        {deps, []}, %% with deps enabled, this test fails
+        {overrides, [
+            {add, [
+                {erl_opts, [{d, bad, a}, {d, bad, b}]}
+            ]}
+        ]}
+    ],
+
+    rebar_test_utils:create_config(AppDir, RebarConfig),
+
+    rebar_test_utils:run_and_check(
+         Config, RebarConfig, ["compile"], {ok, [{app, Name}]}),
+
+    ok.
+
+override_add_opts(Config) ->
+    AppsDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    AppDir = filename:join([AppsDir, "apps", Name]),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     RebarConfig = [
@@ -1520,12 +1545,12 @@ override_add_opts(Config) ->
         ]}
     ],
 
-    rebar_test_utils:create_config(AppDir, RebarConfig),
+    rebar_test_utils:create_config(AppsDir, RebarConfig),
 
     rebar_test_utils:run_and_check(
          Config, RebarConfig, ["compile"], {ok, [{app, Name}]}),
 
-    Path = filename:join([AppDir, "_build", "default", "lib", Name, "ebin"]),
+    Path = filename:join([AppsDir, "_build", "default", "lib", Name, "ebin"]),
     code:add_patha(Path),
 
     Mod = list_to_atom("not_a_real_src_" ++ Name),
@@ -1534,10 +1559,11 @@ override_add_opts(Config) ->
     true = lists:member(warn_missing_spec, proplists:get_value(options, Mod:module_info(compile), [])).
 
 override_del_opts(Config) ->
-    AppDir = ?config(apps, Config),
+    AppsDir = ?config(apps, Config),
 
     Name = rebar_test_utils:create_random_name("app1_"),
     Vsn = rebar_test_utils:create_random_vsn(),
+    AppDir = filename:join([AppsDir, "apps", Name]),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     RebarConfig = [
@@ -1552,18 +1578,19 @@ override_del_opts(Config) ->
         ]}
     ],
 
-    rebar_test_utils:create_config(AppDir, RebarConfig),
+    rebar_test_utils:create_config(AppsDir, RebarConfig),
 
     rebar_test_utils:run_and_check(
          Config, RebarConfig, ["compile"], {ok, [{app, Name}]}),
 
-    Path = filename:join([AppDir, "_build", "default", "lib", Name, "ebin"]),
+    Path = filename:join([AppsDir, "_build", "default", "lib", Name, "ebin"]),
     code:add_patha(Path),
 
     Mod = list_to_atom("not_a_real_src_" ++ Name),
 
     true = lists:member(compressed, proplists:get_value(options, Mod:module_info(compile), [])),
-    false = lists:member(warn_missing_spec, proplists:get_value(options, Mod:module_info(compile), [])).
+    false = lists:member(warn_missing_spec, proplists:get_value(options, Mod:module_info(compile), [])),
+    ok.
 
 profile_override_deps(Config) ->
     Deps = rebar_test_utils:expand_deps(git, [{"some_dep", "0.0.1", [{"other_dep", "0.0.1", []}]}]),
@@ -1665,10 +1692,11 @@ profile_override_del_deps(Config) ->
     ).
 
 profile_override_opts(Config) ->
-    AppDir = ?config(apps, Config),
+    AppsDir = ?config(apps, Config),
 
     Name = rebar_test_utils:create_random_name("app1_"),
     Vsn = rebar_test_utils:create_random_vsn(),
+    AppDir = filename:join([AppsDir, "apps", Name]),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     RebarConfig = [
@@ -1687,12 +1715,12 @@ profile_override_opts(Config) ->
         ]}
     ],
 
-    rebar_test_utils:create_config(AppDir, RebarConfig),
+    rebar_test_utils:create_config(AppsDir, RebarConfig),
 
     rebar_test_utils:run_and_check(
          Config, RebarConfig, ["as", "a", "compile"], {ok, [{app, Name}]}),
 
-    Path = filename:join([AppDir, "_build", "a", "lib", Name, "ebin"]),
+    Path = filename:join([AppsDir, "_build", "a", "lib", Name, "ebin"]),
     code:add_patha(Path),
 
     Mod = list_to_atom("not_a_real_src_" ++ Name),
@@ -1701,10 +1729,11 @@ profile_override_opts(Config) ->
     false = lists:member(warn_missing_spec, proplists:get_value(options, Mod:module_info(compile), [])).
 
 profile_override_add_opts(Config) ->
-    AppDir = ?config(apps, Config),
+    AppsDir = ?config(apps, Config),
 
     Name = rebar_test_utils:create_random_name("app1_"),
     Vsn = rebar_test_utils:create_random_vsn(),
+    AppDir = filename:join([AppsDir, "apps", Name]),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     RebarConfig = [
@@ -1722,12 +1751,12 @@ profile_override_add_opts(Config) ->
         ]}
     ],
 
-    rebar_test_utils:create_config(AppDir, RebarConfig),
+    rebar_test_utils:create_config(AppsDir, RebarConfig),
 
     rebar_test_utils:run_and_check(
          Config, RebarConfig, ["as", "a", "compile"], {ok, [{app, Name}]}),
 
-    Path = filename:join([AppDir, "_build", "a", "lib", Name, "ebin"]),
+    Path = filename:join([AppsDir, "_build", "a", "lib", Name, "ebin"]),
     code:add_patha(Path),
 
     Mod = list_to_atom("not_a_real_src_" ++ Name),
@@ -1736,10 +1765,11 @@ profile_override_add_opts(Config) ->
     true = lists:member(warn_missing_spec, proplists:get_value(options, Mod:module_info(compile), [])).
 
 profile_override_del_opts(Config) ->
-    AppDir = ?config(apps, Config),
+    AppsDir = ?config(apps, Config),
 
     Name = rebar_test_utils:create_random_name("app1_"),
     Vsn = rebar_test_utils:create_random_vsn(),
+    AppDir = filename:join([AppsDir, "apps", Name]),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     RebarConfig = [
@@ -1758,18 +1788,19 @@ profile_override_del_opts(Config) ->
         ]}
     ],
 
-    rebar_test_utils:create_config(AppDir, RebarConfig),
+    rebar_test_utils:create_config(AppsDir, RebarConfig),
 
     rebar_test_utils:run_and_check(
          Config, RebarConfig, ["as", "a", "compile"], {ok, [{app, Name}]}),
 
-    Path = filename:join([AppDir, "_build", "a", "lib", Name, "ebin"]),
+    Path = filename:join([AppsDir, "_build", "a", "lib", Name, "ebin"]),
     code:add_patha(Path),
 
     Mod = list_to_atom("not_a_real_src_" ++ Name),
 
     true = lists:member(compressed, proplists:get_value(options, Mod:module_info(compile), [])),
-    false = lists:member(warn_missing_spec, proplists:get_value(options, Mod:module_info(compile), [])).
+    false = lists:member(warn_missing_spec, proplists:get_value(options, Mod:module_info(compile), [])),
+    ok.
 
 profile_deps(Config) ->
     Deps = rebar_test_utils:expand_deps(git, [{"some_dep", "0.0.1", [{"other_dep", "0.0.1", []}]}]),


### PR DESCRIPTION
Overrides should apply to a layer below where they are declared. This
patch makes it so if the project root is an application (i.e. it isn't
'root' and therefore not an umbrella project), we omit applying
overrides in rebar_app_discover.

This in turn required changing a bunch of tests, because all the tests
worked with the idea that all overrides applied to all apps to validate
that they get inherited properly. The changes re-structure the cases so
they are written with an umbrella app, demonstrating that the changes
stick.

This addresses https://github.com/erlang/rebar3/issues/2082 partially (still need to add docs)

The big risk here is whether any important project in the wild
relied on the bad application of at-large overrides to make their main
app in a non-umbrella work. I'm thinking the chance is low enough (it
would have been accidental and not "ah yes this is how the feature ought
to work", IMO) that this PR might be worth it.