### PR TITLE
make it possible to specify multiple checkouts directories

### DIFF
--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -17,7 +17,7 @@
 -define(DEFAULT_BASE_DIR, "_build").
 -define(DEFAULT_ROOT_DIR, ".").
 -define(DEFAULT_PROJECT_APP_DIRS, ["apps/*", "lib/*", "."]).
--define(DEFAULT_CHECKOUTS_DIR, "_checkouts").
+-define(DEFAULT_CHECKOUTS_DIRS, ["_checkouts"]).
 -define(DEFAULT_DEPS_DIR, "lib").
 -define(DEFAULT_PLUGINS_DIR, "plugins").
 -define(DEFAULT_TEST_DEPS_DIR, "test/lib").

--- a/src/rebar_env.erl
+++ b/src/rebar_env.erl
@@ -41,7 +41,7 @@ create_env(State, Opts) ->
         {"REBAR_DEPS_DIR",          filename:absname(rebar_dir:deps_dir(State))},
         {"REBAR_BUILD_DIR",         filename:absname(rebar_dir:base_dir(State))},
         {"REBAR_ROOT_DIR",          filename:absname(rebar_dir:root_dir(State))},
-        {"REBAR_CHECKOUTS_DIR",     filename:absname(rebar_dir:checkouts_dir(State))},
+        {"REBAR_CHECKOUTS_DIR",     build_checkout_dir_env(State)},
         {"REBAR_PLUGINS_DIR",       filename:absname(rebar_dir:plugins_dir(State))},
         {"REBAR_GLOBAL_CONFIG_DIR", filename:absname(rebar_dir:global_config_dir(State))},
         {"REBAR_GLOBAL_CACHE_DIR",  filename:absname(rebar_dir:global_cache_dir(Opts))},
@@ -57,6 +57,11 @@ create_env(State, Opts) ->
     ],
     EInterfaceVars = create_erl_interface_env(),
     lists:append([EnvVars, EInterfaceVars]).
+
+-spec build_checkout_dir_env(rebar_state:t()) -> string().
+build_checkout_dir_env(State) ->
+    Paths = [filename:absname(Dir) || Dir <- rebar_dir:checkouts_dir(State)],
+    string:join(Paths, ":").
 
 -spec create_erl_interface_env() -> list().
 create_erl_interface_env() ->

--- a/src/rebar_prv_plugins.erl
+++ b/src/rebar_prv_plugins.erl
@@ -45,6 +45,8 @@ do(State) ->
     ProjectPlugins = rebar_state:get(State, project_plugins, []),
     PluginsDirs = filelib:wildcard(filename:join(rebar_dir:plugins_dir(State), "*")),
     CheckoutsDirs = filelib:wildcard(filename:join(rebar_dir:checkouts_dir(State), "*")),
+    CheckoutsDirs =
+        lists:concat([ filelib:wildcard(filename:join(Dir, "*")) || Dir <- rebar_dir:checkouts_dir(State) ]),
     Apps = rebar_app_discover:find_apps(CheckoutsDirs++PluginsDirs, SrcDirs, all, State),
     display_plugins("Local plugins", Apps, Plugins ++ ProjectPlugins),
     {ok, State}.

--- a/test/rebar_dir_SUITE.erl
+++ b/test/rebar_dir_SUITE.erl
@@ -10,6 +10,7 @@
 -export([profile_src_dir_opts/1]).
 -export([retarget_path/1, alt_base_dir_abs/1, alt_base_dir_rel/1]).
 -export([global_cache_dir/1, default_global_cache_dir/1, overwrite_default_global_cache_dir/1]).
+-export([multiple_checkouts_dir/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -21,7 +22,7 @@ all() -> [default_src_dirs, default_extra_src_dirs, default_all_src_dirs,
           profile_src_dirs, profile_extra_src_dirs, profile_all_src_dirs,
           profile_src_dir_opts, top_src_dirs,
           retarget_path, alt_base_dir_abs, alt_base_dir_rel, global_cache_dir,
-          default_global_cache_dir, overwrite_default_global_cache_dir].
+          default_global_cache_dir, overwrite_default_global_cache_dir, multiple_checkouts_dir].
 
 init_per_testcase(default_global_cache_dir, Config) ->
     [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, _State} | Config] = rebar_test_utils:init_rebar_state(Config),
@@ -34,6 +35,8 @@ init_per_testcase(overwrite_default_global_cache_dir, Config) ->
     NewState = rebar_state:new([{base_dir, filename:join([AppsDir, "_build"])}
                             ,{root_dir, AppsDir}]),
     [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, NewState} | Config];
+init_per_testcase(multiple_checkouts_dir, Config) ->
+    rebar_test_utils:init_rebar_state(Config);
 init_per_testcase(_, Config) ->
     C = rebar_test_utils:init_rebar_state(Config),
     AppDir = ?config(apps, C),
@@ -282,3 +285,8 @@ overwrite_default_global_cache_dir(Config) ->
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
     Expected = ?config(priv_dir, Config),
     ?assertEqual(Expected, rebar_dir:global_cache_dir(rebar_state:opts(State))).
+
+multiple_checkouts_dir(Config) ->
+    CheckoutsDir = ?config(checkouts, Config),
+    RebarConfig = [{checkouts_dir, [CheckoutsDir, CheckoutsDir]}],
+    {ok, _State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return).


### PR DESCRIPTION
This adds the ability to specify multiple checkouts directories while also being compatible with the existing behavior. The following is possible:

```erlang
%% current behavior
{checkouts_dir, "_checkouts"}.
%% multiple checkouts directories
{checkouts_dir, ["_checkouts", "some/path/to/some/other/checkouts"]}.
```

Dependencies are discovered as before with the difference that when multiple checkouts directories are specified, the checkouts directory that is stated first is prioritized .