### PR TITLE
bug when reread_config running on OTP 17

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -460,7 +460,7 @@ reread_config(ConfigList, Opts) ->
     %% NB: we attempt to mimic -config here, which survives app reload,
     %% hence {persistent, true}.
     SetEnv = case version_tuple(?MODULE:otp_release()) of
-        {X, _, _} when X =< 17 ->
+        {X, _, _} when X < 17 ->
             fun application:set_env/3;
         _ ->
             fun (App, Key, Val) -> application:set_env(App, Key, Val, [{persistent, true}]) end


### PR DESCRIPTION
There was a bug in latest rebar3 when running rebar3 ct on OTP 17.5. The ct process would be terminated automatically without any error printed. 
After digging it turned out the configuration file, either defined in rebar.config or passed by parameter --sys_config is not loaded properly when running rebar3 ct. 

From the release here: https://github.com/erlang/otp/releases/tag/OTP-17.0 we can see {persistent, boolean()} is supported from otp 17, so when reread_config, rebar3 should call application:set_env(App, Key, Val, [{persistent, true}]) for OTP releases **>** 17. 

After the modification, locally rebar3 ct now works properly. 