### PR TITLE
try CIRRUS_TAG != '' for triggering cirrus for new tags

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,7 +39,7 @@ release_task:
     image: erlang:18
   depends_on:
     - test
-  only_if: $CIRRUS_RELEASE != ""
+  only_if: $CIRRUS_TAG != ''
   script: |
     apt-get update
     apt-get install -y s3cmd


### PR DESCRIPTION
Maybe this will work for publishing escripts when a new release is tagged.