### PR TITLE
Only lint app files when compiling

### DIFF
--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -37,6 +37,7 @@
          parse_dep/6,
          expand_deps_sources/2,
          dep_to_app/7,
+         lint_app_info/1,
          format_error/1]).
 
 -include("rebar.hrl").
@@ -101,7 +102,6 @@ validate_application_info(AppInfo, AppDetail) ->
         undefined ->
             false;
         AppFile ->
-            lint_detail(AppDetail, AppFile),
             case proplists:get_value(modules, AppDetail) of
                 undefined ->
                     ?PRV_ERROR({module_list, AppFile});
@@ -109,6 +109,11 @@ validate_application_info(AppInfo, AppDetail) ->
                     has_all_beams(EbinDir, List)
             end
     end.
+
+lint_app_info(AppInfo) ->
+    AppDetails = rebar_app_info:app_details(AppInfo),
+    AppFile = rebar_app_info:app_file(AppInfo),
+    lint_detail(AppDetails, AppFile).
 
 -spec lint_detail(list(), file:filename_all()) -> ok.
 lint_detail(AppDetail, AppFile) ->

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -247,6 +247,7 @@ has_all_artifacts(AppInfo1) ->
         {false, File} ->
             throw(?PRV_ERROR({missing_artifact, File}));
         true ->
+            rebar_app_utils:lint_app_info(AppInfo1),
             true
     end.
 

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -41,7 +41,6 @@ all() ->
      dont_recompile_when_erl_compiler_options_env_does_not_change,
      recompile_when_erl_compiler_options_env_changes,
      rebar_config_os_var,
-
      app_file_linting].
 
 groups() ->


### PR DESCRIPTION
This allows to reduce the number of noise to only checking deps' app
files when they're built, rather than on every run.

Since main apps and checkouts are still compiled every time, the linting
takes place there and then with a higher frequency.

Potential alternative implementation to #2081 