### PR TITLE
rebar3 dialyzer: Warn when debug_info is disabled

### DIFF
--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -474,6 +474,13 @@ proj_files(State) ->
     get_files(State, Apps, PltApps, [], PltMods).
 
 run_dialyzer(State, Opts, Output) ->
+    case debug_info(State) of
+        true ->
+            ok;
+        false ->
+            ?WARN("Add {erl_opts, [debug_info]} to rebar.config if Dialyzer fails to load Core Erlang.", []),
+            ok
+    end,
     %% dialyzer may return callgraph warnings when get_warnings is false
     case proplists:get_bool(get_warnings, Opts) of
         true ->
@@ -538,6 +545,10 @@ no_warnings() ->
 get_config(State, Key, Default) ->
     Config = rebar_state:get(State, dialyzer, []),
     proplists:get_value(Key, Config, Default).
+
+debug_info(State) ->
+    Config = rebar_state:get(State, erl_opts, []),
+    proplists:get_value(debug_info, Config, false).
 
 -spec collect_nested_dependent_apps([atom()]) -> [atom()].
 collect_nested_dependent_apps(RootApps) ->

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -478,7 +478,7 @@ run_dialyzer(State, Opts, Output) ->
         true ->
             ok;
         false ->
-            ?WARN("Add {erl_opts, [debug_info]} to rebar.config if Dialyzer fails to load Core Erlang.", []),
+            ?WARN("Add debug_info to compiler options (erl_opts) if Dialyzer fails to load Core Erlang.", []),
             ok
     end,
     %% dialyzer may return callgraph warnings when get_warnings is false
@@ -548,7 +548,7 @@ get_config(State, Key, Default) ->
 
 debug_info(State) ->
     Config = rebar_state:get(State, erl_opts, []),
-    proplists:get_value(debug_info, Config, false).
+    proplists:get_value(debug_info, Config, true).
 
 -spec collect_nested_dependent_apps([atom()]) -> [atom()].
 collect_nested_dependent_apps(RootApps) ->

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -155,6 +155,13 @@ plt_name(Prefix) ->
 
 do(Args, State, Plt) ->
     Output = get_output_file(State),
+    case debug_info(State) of
+        true ->
+            ok;
+        false ->
+            ?WARN("Add debug_info to compiler options (erl_opts) "
+                  "if Dialyzer fails to load Core Erlang.", [])
+    end,
     {PltWarnings, State1} = update_proj_plt(Args, State, Plt, Output),
     {Warnings, State2} = succ_typings(Args, State1, Plt, Output),
     case PltWarnings + Warnings of
@@ -474,13 +481,6 @@ proj_files(State) ->
     get_files(State, Apps, PltApps, [], PltMods).
 
 run_dialyzer(State, Opts, Output) ->
-    case debug_info(State) of
-        true ->
-            ok;
-        false ->
-            ?WARN("Add debug_info to compiler options (erl_opts) if Dialyzer fails to load Core Erlang.", []),
-            ok
-    end,
     %% dialyzer may return callgraph warnings when get_warnings is false
     case proplists:get_bool(get_warnings, Opts) of
         true ->
@@ -548,7 +548,9 @@ get_config(State, Key, Default) ->
 
 debug_info(State) ->
     Config = rebar_state:get(State, erl_opts, []),
-    proplists:get_value(debug_info, Config, true).
+    proplists:get_value(debug_info, Config, false) =/= false orelse
+    proplists:get_value(debug_info_key, Config, false) =/= false orelse
+    proplists:get_value(encrypt_debug_info, Config, false) =/= false.
 
 -spec collect_nested_dependent_apps([atom()]) -> [atom()].
 collect_nested_dependent_apps(RootApps) ->


### PR DESCRIPTION
### Problem

The `rebar3 dialyzer` command crashes when `debug_info` is missing (or `no_debug_info`) with an obscure message about Core Erlang:

```
$ rebar3 dialyzer
===> Verifying dependencies...
===> Compiling rf
===> Dialyzer starting, this may take a while...
===> Updating plt...
===> Resolving files...
===> Updating base plt...
===> Resolving files...
===> Removing 194 files from "/Users/jkakar/.cache/rebar3/rebar3_22.0.1_plt"...
===> Adding 9 files to "/Users/jkakar/.cache/rebar3/rebar3_22.0.1_plt"...
===> Error in dialyzing apps: Analysis failed with error:
Could not scan the following file(s):
  Could not get Core Erlang code for: /Users/jkakar/src/github.com/rufus-lang/rufus/rf/_build/default/lib/rf/ebin/rufus_typecheck_func_return_type.beam
  Could not get Core Erlang code for: /Users/jkakar/src/github.com/rufus-lang/rufus/rf/_build/default/lib/rf/ebin/rufus_typecheck_binary_op.beam
  Could not get Core Erlang code for: /Users/jkakar/src/github.com/rufus-lang/rufus/rf/_build/default/lib/rf/ebin/rufus_scan.beam
  Could not get Core Erlang code for: /Users/jkakar/src/github.com/rufus-lang/rufus/rf/_build/default/lib/rf/ebin/rufus_parse.beam
  Could not get Core Erlang code for: /Users/jkakar/src/github.com/rufus-lang/rufus/rf/_build/default/lib/rf/ebin/rufus_error.beam
  Could not get Core Erlang code for: /Users/jkakar/src/github.com/rufus-lang/rufus/rf/_build/default/lib/rf/ebin/rufus_compile_erlang.beam
  Could not get Core Erlang code for: /Users/jkakar/src/github.com/rufus-lang/rufus/rf/_build/default/lib/rf/ebin/rufus_compile.beam
  Could not get Core Erlang code for: /Users/jkakar/src/github.com/rufus-lang/rufus/rf/_build/default/lib/rf/ebin/rufus_annotate_locals.beam
  Could not get Core Erlang code for: /Users/jkakar/src/github.com/rufus-lang/rufus/rf/_build/default/lib/rf/ebin/rf.beam
Last messages in the log cache:
  Reading files and computing callgraph...
```

Trying to figure out why Dialyzer is failing here is non-obvious, since there are no issues related to this particular failure mode, and Google doesn't lead to help either. It's a serious issue because it's likely to hit you the first time you try to use `rebar3 dialyzer` with your project and stop you in your tracks.

### Solution

The `rebar3 dialyzer` command prints a warning message if you don't have `debug_info` enabled in `rebar.config`. Hopefully this will make it easier for users to recover from this failure mode:

```
$ rebar3 dialyzer
===> Verifying dependencies...
===> Compiling rf
===> Dialyzer starting, this may take a while...
===> Updating plt...
===> Resolving files...
===> Checking 181 files in "/Users/jkakar/src/github.com/rufus-lang/rufus/rf/_build/default/rebar3_22.0.1_plt"...
===> Add debug_info to compiler options (erl_opts) if Dialyzer fails to load Core Erlang.
===> Doing success typing analysis...
===> Resolving files...
===> Analyzing no files with "/Users/jkakar/src/github.com/rufus-lang/rufus/rf/_build/default/rebar3_22.0.1_plt"...
```