### PR TITLE
Ensure EDoc opts in umbrella apps are respected

### DIFF
--- a/src/rebar_prv_edoc.erl
+++ b/src/rebar_prv_edoc.erl
@@ -45,7 +45,10 @@ do(State) ->
                     AppName = rebar_utils:to_list(rebar_app_info:name(AppInfo)),
                     ?INFO("Running edoc for ~ts", [AppName]),
                     AppDir = rebar_app_info:dir(AppInfo),
-                    AppRes = (catch edoc:application(list_to_atom(AppName), AppDir, EdocOptsAcc)),
+                    AppOpts = rebar_app_info:opts(AppInfo),
+                    %% order of the merge is important to allow app opts overrides
+                    AppEdocOpts = rebar_opts:get(AppOpts, edoc_opts, []) ++ EdocOptsAcc,
+                    AppRes = (catch edoc:application(list_to_atom(AppName), AppDir, AppEdocOpts)),
                     rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, AppInfo, State),
                     case {AppRes, ShouldAccPaths} of
                         {ok, true} ->

--- a/test/rebar_edoc_SUITE.erl
+++ b/test/rebar_edoc_SUITE.erl
@@ -52,7 +52,15 @@ multiapp(Config) ->
               "barer1")),
     ?assert(file_content_matches(
               filename:join([AppsDir, "apps", "foo", "doc", "foo.html"]),
-              "apps/bar1/doc/bar1.html")).
+              "apps/bar1/doc/bar1.html")),
+    %% Options such from rebar.config in the app themselves are
+    %% respected
+    ?assert(file_content_matches(
+        filename:join([AppsDir, "apps", "foo", "doc", "overview-summary.html"]),
+        "foo_custom_title"
+    )),
+    ok.
+
 
 error_survival(Config) ->
     RebarConfig = [],

--- a/test/rebar_edoc_SUITE_data/foo/apps/foo/rebar.config
+++ b/test/rebar_edoc_SUITE_data/foo/apps/foo/rebar.config
@@ -1,0 +1,1 @@
+{edoc_opts, [{title, "foo_custom_title"}]}.

--- a/test/rebar_edoc_SUITE_data/foo/rebar.config
+++ b/test/rebar_edoc_SUITE_data/foo/rebar.config
@@ -1,0 +1,1 @@
+{edoc_opts, [{title, "forced wrong title to be overridden"}]}.


### PR DESCRIPTION
This adds an additional loading and merging of options for EDoc using
the values from the top-level along with those specified in the
rebar.config of an umbrella application.

The app-specific config values are prepended to the global ones; this
can likely cause some problems with manual path handling, but is
unlikely to happen in practice and the rest seems to work fine based on
order

Fixes the issue in #2114