### PR TITLE
Allow for hooks to apply to several commands

### DIFF
--- a/src/rebar_hooks.erl
+++ b/src/rebar_hooks.erl
@@ -75,6 +75,10 @@ run_hooks(Dir, Type, Command, Opts, State) ->
                                   apply_hook(Dir, Env, Hook);
                              ({C, _}=Hook) when C =:= Command ->
                                   apply_hook(Dir, Env, Hook);
+                             ({C, _}=Hook) when is_list(C), is_atom(hd(C)) ->
+                                  lists:member(Command, C) andalso apply_hook(Dir, Env, Hook);
+                             ({_, C, _}=Hook) when is_list(C), is_atom(hd(C)) ->
+                                  lists:member(Command, C) andalso apply_hook(Dir, Env, Hook);
                              (_) ->
                                   continue
                           end, Hooks)


### PR DESCRIPTION
This patch allows for list definitions in hooks:
```
{pre_hooks, [{[compile,clean], "rm -f c_src/*.o"}]}.
```
This eliminates redundancy when identical actions need to be carried out for different hook phases.