### PR TITLE
Fix reloading logger_level

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -493,7 +493,7 @@ reread_logger_config() ->
         _ ->
             %% Extract and apply settings related to primary configuration
             %% -- primary config is used for settings shared across handlers
-            LogLvlPrimary = proplists:get_value(logger_info, KernelCfg, all),
+            LogLvlPrimary = proplists:get_value(logger_level, KernelCfg, all),
             {FilterDefault, Filters} =
               case lists:keyfind(filters, 1, KernelCfg) of
                   false -> {log, []};


### PR DESCRIPTION
OTP kernel application use "logger_level" configuration for configuring
level in primary configuration.
rebar3 uses "logger_info" for this purpose - ths is little bit confusing
and probably mistake.
This commit will unify behavior between kernel and rebar3o

Fixes: 0303567d95f0 ("Reload logger config in shell")