### PR TITLE
de-duplicate dependency list in rebar_compiler_erl.erl

### DIFF
--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -245,21 +245,20 @@ module_to_erl(Mod) ->
     atom_to_list(Mod) ++ ".erl".
 
 parse_attrs(Fd, Includes, Dir) ->
-    DupIncludes = case io:parse_erl_form(Fd, "") of
-                      {ok, Form, _Line} ->
-                          case erl_syntax:type(Form) of
-                              attribute ->
-                                  NewIncludes = process_attr(Form, Includes, Dir),
-                                  parse_attrs(Fd, NewIncludes, Dir);
-                              _ ->
-                                  parse_attrs(Fd, Includes, Dir)
-                          end;
-                      {eof, _} ->
-                          Includes;
-                      _Err ->
-                          parse_attrs(Fd, Includes, Dir)
-                  end,
-    lists:usort(DupIncludes).
+    case io:parse_erl_form(Fd, "") of
+        {ok, Form, _Line} ->
+            case erl_syntax:type(Form) of
+                attribute ->
+                    NewIncludes = process_attr(Form, Includes, Dir),
+                    parse_attrs(Fd, NewIncludes, Dir);
+                _ ->
+                    parse_attrs(Fd, Includes, Dir)
+            end;
+        {eof, _} ->
+            lists:usort(Includes);
+        _Err ->
+            parse_attrs(Fd, Includes, Dir)
+    end.
 
 process_attr(Form, Includes, Dir) ->
     AttrName = erl_syntax:atom_value(erl_syntax:attribute_name(Form)),

--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -78,7 +78,7 @@ needed_files(Graph, FoundFiles, _, AppInfo) ->
 dependencies(Source, SourceDir, Dirs) ->
     case file:open(Source, [read]) of
         {ok, Fd} ->
-            Incls = parse_attrs(Fd, [], SourceDir),
+            Incls = lists:usort(parse_attrs(Fd, [], SourceDir)),
             AbsIncls = expand_file_names(Incls, Dirs),
             ok = file:close(Fd),
             AbsIncls;


### PR DESCRIPTION
Ey up,

I've got a fair sized purerl project (https://github.com/purerl/) and noticed it was taking quite a bit of time to compile suddenly after a recent rebar update, it was hanging between

```
===> run_hooks("/home/robashton/[redacted]/apps/[redacted]", pre_hooks, erlc_compile) -> no hooks defined

 ------ HANG IS HERE

===> erlopts [ redacted ]

```

So I dug into the source code to work out why this was the case.

https://github.com/erlang/rebar3/blob/master/src/rebar_compiler_erl.erl#L81

Is the start of my issues, each file generated by the purerl compiler has -file attributes up the wazoo, with each function having a reference back to the original .purs file in my source/package structure. For example

```purescript
-file(".psc-package/id3as-20190706_2/arrays/v5.0.0-erl1/src/Data/Array/NonEmpty/Internal.purs", 40).
unfoldable1NonEmptyArray() -> (data_unfoldable1@ps:unfoldable1Array()).
-file(".psc-package/id3as-20190706_2/arrays/v5.0.0-erl1/src/Data/Array/NonEmpty/Internal.purs", 42).
traversableWithIndexNonEmptyArray() -> (data_traversableWithIndex@ps:traversableWithIndexArray()).
-file(".psc-package/id3as-20190706_2/arrays/v5.0.0-erl1/src/Data/Array/NonEmpty/Internal.purs", 41).
traversableNonEmptyArray() -> (data_traversable@ps:traversableArray()).
-file(".psc-package/id3as-20190706_2/arrays/v5.0.0-erl1/src/Data/Array/NonEmpty/Internal.purs", 19).
showNonEmptyArray() -> fun (DictShow) ->

```

To further compound this, this list isn't de-dupped at all so when we descend into  expand_file_names, we're running it multiple times (literally dozens if not hundreds) per file.

https://github.com/erlang/rebar3/blob/master/src/rebar_compiler_erl.erl#L326

to further compound *this*, these files aren't regular (another issue in itself) so that means we then descend into

https://github.com/erlang/rebar3/blob/master/src/rebar_compiler_erl.erl#L332

which means we're now searching my .psc-package folder for that file if I'm reading that right.

Total time per file is up to about 500ms, and it's now taking me over 5 minutes to compile my project. De-dupping this list gets me down to 5 seconds. (There is some work to how many timestamps are touched by the purerl compiler but that is by the by).

===

If there is a subtlety I'm missing here with my change then that's fine - I have hopefully at the very least expressed my intent with this PR and blurb. 



