### PR TITLE
Update vendored in hex_core to version 0.5.1

### DIFF
--- a/src/r3_hex_api.erl
+++ b/src/r3_hex_api.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 %% @hidden
 

--- a/src/r3_hex_api_key.erl
+++ b/src/r3_hex_api_key.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 -module(r3_hex_api_key).
 -export([

--- a/src/r3_hex_api_package.erl
+++ b/src/r3_hex_api_package.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 -module(r3_hex_api_package).
 -export([get/2, search/3]).

--- a/src/r3_hex_api_package_owner.erl
+++ b/src/r3_hex_api_package_owner.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 -module(r3_hex_api_package_owner).
 -export([

--- a/src/r3_hex_api_release.erl
+++ b/src/r3_hex_api_release.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 -module(r3_hex_api_release).
 -export([

--- a/src/r3_hex_api_user.erl
+++ b/src/r3_hex_api_user.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 -module(r3_hex_api_user).
 -export([

--- a/src/r3_hex_core.erl
+++ b/src/r3_hex_core.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 %% @doc
 %% hex_core entrypoint module.

--- a/src/r3_hex_core.hrl
+++ b/src/r3_hex_core.hrl
@@ -1,3 +1,3 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
--define(HEX_CORE_VERSION, "0.5.0").
+-define(HEX_CORE_VERSION, "0.5.1").

--- a/src/r3_hex_erl_tar.erl
+++ b/src/r3_hex_erl_tar.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 %% @private
 %% Copied from https://github.com/erlang/otp/blob/OTP-20.0.1/lib/stdlib/src/erl_tar.erl

--- a/src/r3_hex_erl_tar.hrl
+++ b/src/r3_hex_erl_tar.hrl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 % Copied from https://github.com/erlang/otp/blob/OTP-20.0.1/lib/stdlib/src/erl_tar.hrl
 

--- a/src/r3_hex_filename.erl
+++ b/src/r3_hex_filename.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 % @private
 % Excerpt from https://github.com/erlang/otp/blob/OTP-20.0.1/lib/stdlib/src/filename.erl#L761-L788

--- a/src/r3_hex_http.erl
+++ b/src/r3_hex_http.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 -module(r3_hex_http).
 -export([request/5]).

--- a/src/r3_hex_http_httpc.erl
+++ b/src/r3_hex_http_httpc.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 %% @hidden
 

--- a/src/r3_hex_pb_names.erl
+++ b/src/r3_hex_pb_names.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 %% -*- coding: utf-8 -*-
 %% Automatically generated, do not edit

--- a/src/r3_hex_pb_package.erl
+++ b/src/r3_hex_pb_package.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 %% -*- coding: utf-8 -*-
 %% Automatically generated, do not edit

--- a/src/r3_hex_pb_signed.erl
+++ b/src/r3_hex_pb_signed.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 %% -*- coding: utf-8 -*-
 %% Automatically generated, do not edit

--- a/src/r3_hex_pb_versions.erl
+++ b/src/r3_hex_pb_versions.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 %% -*- coding: utf-8 -*-
 %% Automatically generated, do not edit

--- a/src/r3_hex_registry.erl
+++ b/src/r3_hex_registry.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 -module(r3_hex_registry).
 -export([

--- a/src/r3_hex_repo.erl
+++ b/src/r3_hex_repo.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 -module(r3_hex_repo).
 -export([
@@ -161,7 +161,9 @@ tarball_url(Config, Name, Version) ->
 build_url(#{repo_url := URI, repo_organization := Org}, Path) when is_binary(Org) ->
     <<URI/binary, "/repos/", Org/binary, "/", Path/binary>>;
 build_url(#{repo_url := URI, repo_organization := undefined}, Path) ->
-    <<URI/binary, "/", Path/binary>>.
+    <<URI/binary, "/", Path/binary>>;
+build_url(Config, Path) ->
+    build_url(Config#{repo_organization => undefined}, Path).
 
 tarball_filename(Name, Version) ->
     <<Name/binary, "-", Version/binary, ".tar">>.

--- a/src/r3_hex_tarball.erl
+++ b/src/r3_hex_tarball.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 -module(r3_hex_tarball).
 -export([create/2, create_docs/1, unpack/2, format_checksum/1, format_error/1]).

--- a/src/r3_safe_erl_term.xrl
+++ b/src/r3_safe_erl_term.xrl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.5.0, do not edit manually
+%% Vendored from hex_core v0.5.1, do not edit manually
 
 %%% Author  : Robert Virding
 %%% Purpose : Token definitions for Erlang.


### PR DESCRIPTION
  version 0.5.1 is a maintenance release of hex_core specifically for rebar3 which contains a configuration update. Prior to v0.5.1 if no repo_organization key was set this could result in a function clause error. The behavior is to now set repo_organization to undefined in this case.