### PR TITLE
Fixing duplicate macro definition in umbrella edoc

### DIFF
--- a/test/rebar_edoc_SUITE.erl
+++ b/test/rebar_edoc_SUITE.erl
@@ -3,7 +3,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
 
-all() -> [multiapp, error_survival].
+all() -> [multiapp, multiapp_macros, error_survival].
 
 init_per_testcase(multiapp, Config) ->
     application:load(rebar),
@@ -14,6 +14,19 @@ init_per_testcase(multiapp, Config) ->
     ec_file:copy(filename:join([DataDir, "foo"]), AppsDir, [recursive]),
     Verbosity = rebar3:log_level(),
     rebar_log:init(command_line, Verbosity),
+    State = rebar_state:new([{base_dir, filename:join([AppsDir, "_build"])}
+                            ,{root_dir, AppsDir}]),
+    [{apps, AppsDir}, {state, State}, {name, Name} | Config];
+init_per_testcase(multiapp_macros, Config) ->
+    application:load(rebar),
+    DataDir = ?config(data_dir, Config),
+    PrivDir = ?config(priv_dir, Config),
+    Name = rebar_test_utils:create_random_name("multiapp_macros"),
+    AppsDir = filename:join([PrivDir, rebar_test_utils:create_random_name(Name)]),
+    ec_file:copy(filename:join([DataDir, "foo"]), AppsDir, [recursive]),
+    ok = ec_file:remove(filename:join([AppsDir, "apps", "foo"]), [recursive]),
+    %Verbosity = rebar3:log_level(),
+    %rebar_log:init(command_line, Verbosity),
     State = rebar_state:new([{base_dir, filename:join([AppsDir, "_build"])}
                             ,{root_dir, AppsDir}]),
     [{apps, AppsDir}, {state, State}, {name, Name} | Config];
@@ -61,6 +74,48 @@ multiapp(Config) ->
     )),
     ok.
 
+multiapp_macros(Config) ->
+    RebarConfig = [{edoc_opts, [
+        preprocess,
+        {macros, [{m1, x1}, {m2, x2}]},
+        {def, [{d1, "1"}, {d2, "1"}]}
+    ]}],
+    AppConfig = {edoc_opts, [
+        {preprocess, true},
+        {macros, [{m2, f2}, {m3, f3}]},
+        {def, [{d2, "2"}, {d3, "2"}]}
+    ]},
+    DebugModule = "
+    -module(debug).
+    -ifndef(m1). -define(m1,z1). -endif.
+    -ifndef(m2). -define(m2,z2). -endif.
+    -ifndef(m3). -define(m3,z3). -endif.
+    -export([?m1 /0, ?m2 /0, ?m3 /0]).
+
+    %% @doc
+    %% d1:{@d1}
+    %% d2:{@d2}
+    %% d3:{@d3}
+    %% @end
+    ?m1 () -> ok.
+    ?m2 () -> ok.
+    ?m3 () -> ok.
+    ",
+    AppsDir = ?config(apps, Config),
+    ct:pal("AppsDir: ~s", [AppsDir]),
+    ok = file:write_file(filename:join([AppsDir, "apps", "bar1", "rebar.config"]),
+                         io_lib:format("~p.~n", [AppConfig])),
+    ok = file:write_file(filename:join([AppsDir, "apps", "bar1", "src", "debug.erl"]),
+                         DebugModule),
+    rebar_test_utils:run_and_check(Config, RebarConfig, ["edoc"], {ok, []}),
+    DocFile = filename:join([AppsDir, "apps", "bar1", "doc", "debug.html"]),
+    ?assert(file_content_matches(DocFile, "d1:1")), % config layered
+    ?assert(file_content_matches(DocFile, "d2:2")),
+    ?assert(file_content_matches(DocFile, "d3:2")),
+    ?assert(file_content_matches(DocFile, "x1/0")), % elided in config drop
+    ?assert(file_content_matches(DocFile, "f2/0")),
+    ?assert(file_content_matches(DocFile, "f3/0")),
+    ok.
 
 error_survival(Config) ->
     RebarConfig = [],

--- a/test/rebar_edoc_SUITE.erl
+++ b/test/rebar_edoc_SUITE.erl
@@ -25,8 +25,8 @@ init_per_testcase(multiapp_macros, Config) ->
     AppsDir = filename:join([PrivDir, rebar_test_utils:create_random_name(Name)]),
     ec_file:copy(filename:join([DataDir, "foo"]), AppsDir, [recursive]),
     ok = ec_file:remove(filename:join([AppsDir, "apps", "foo"]), [recursive]),
-    %Verbosity = rebar3:log_level(),
-    %rebar_log:init(command_line, Verbosity),
+    Verbosity = rebar3:log_level(),
+    rebar_log:init(command_line, Verbosity),
     State = rebar_state:new([{base_dir, filename:join([AppsDir, "_build"])}
                             ,{root_dir, AppsDir}]),
     [{apps, AppsDir}, {state, State}, {name, Name} | Config];


### PR DESCRIPTION
When in umbrella mode (or through multiple profiles), users can specify
macros for EDocs based on either the {def, ...} or the {macros, ...}
arguments.

This patch replaces the prior options merging for umbrellas to use the
rebar3 tup_umerge utils to remove identical duplicates while preserving
correct ordering, and manually merges the {macros, ...} definitions
while ke eping the correct precedence rules since these appear (given
their behaviour) to be all individually extracted and passed as `{d,
...}` to  the compiler so that epp expands them. This compiler
function freaks out on any re-defined macros and explodes.

Do note that the macros with `{def, ...}` are edoc macros and do not
suffer from that issue, safely deduplicating multiple definitions.

this fixes #2131 