### PR TITLE
format error from provider init and print as warning

### DIFF
--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -489,8 +489,11 @@ create_logic_providers(ProviderModules, State0) ->
     try
         lists:foldl(fun(ProviderMod, StateAcc) ->
                             case providers:new(ProviderMod, StateAcc) of
+                                {error, {Mod, Error}} ->
+                                    ?WARN("~ts", [Mod:format_error(Error)]),
+                                    StateAcc;
                                 {error, Reason} ->
-                                    ?ERROR(Reason++"~n", []),
+                                    ?WARN(Reason++"~n", []),
                                     StateAcc;
                                 {ok, StateAcc1} ->
                                     StateAcc1


### PR DESCRIPTION
Found this because one of the `rebar_mix` providers was returning an error tuple and that caused rebar3 to crash since it tried to simply append a `"\n"`

I also change the log type to warning since it doesn't, and shouldn't, stop execution if a provider fails to init since we don't know if it will be used or not.