### PR TITLE
Add Pradeep Palaniappan to Contributors list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ All contributors and rebar3 maintainers are generally unpaid developers
 working on the project in their own free time with limited resources. We
 ask for respect and understanding and will try to provide the same back.
 
+Pradeep Palaniappan
+
 ## Requesting or implementing a feature
 
 Before requesting or implementing a new feature, please do the following:

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -150,6 +150,10 @@ download_(Dir, {git, Url, {ref, Ref}}, _State) ->
     ok = filelib:ensure_dir(Dir),
     maybe_warn_local_url(Url),
     git_clone(ref, git_vsn(), Url, Dir, Ref);
+download_(Dir, {git, Url, {dir, Path}}, _State) ->
+    ok = filelib:ensure_dir(Dir),
+    maybe_warn_local_url(Url),
+    git_clone(dir, git_vsn(), Url, Dir, Path);
 download_(Dir, {git, Url, Rev}, _State) ->
     ?WARN("WARNING: It is recommended to use {branch, Name}, {tag, Tag} or {ref, Ref}, otherwise updating the dep may not work as expected.", []),
     ok = filelib:ensure_dir(Dir),
@@ -209,6 +213,12 @@ git_clone(rev,_Vsn,Url,Dir,Rev) ->
                          rebar_utils:escape_chars(filename:basename(Dir))]),
                    [{cd, filename:dirname(Dir)}]),
     rebar_utils:sh(?FMT("git checkout -q ~ts", [rebar_utils:escape_chars(Rev)]),
+                   [{cd, Dir}]);
+%% To fetch the application directly from gerrit
+git_clone(dir, _Vsn, Url, Dir, Path) ->
+    rebar_utils:sh(?FMT("git archive --remote=~ts HEAD:~ts | tar xf -",
+                        [rebar_utils:escape_chars(Url),
+                         rebar_utils:escape_chars(Path)]),
                    [{cd, Dir}]).
 
 git_vsn() ->


### PR DESCRIPTION
The rebar3 git resource provider can be used to import any Erlang application from a
git repository. Unfortunately, it assumes that the top directory of the application 
is it the repository root. Like this:

"foo_project/"

%% Current rebar.config syntax
{deps, [{foo_project, {git, "git://github.com/foo/foo_project.git",
                   {branch, "master"}}}]}.

The above syntax will fetch whole application, which is inside the foo_project.
Under foo_project/ contains lots of application, which is used by other team.
As we do not want foo_project/ to be split into one repository per application

Add a new optional configuration option called 'dir' which defines the application 
top directory:

"foo_project/lib/foo"

{deps, [{foo, {git, "git://github.com/foo/foo_project.git", {dir, "lib/foo"}}}]}.

This will take the foo/ application from foo_project/ in the lib/foo directory.

This contribution will be able to help lots of people.