### PR TITLE
rebar3: Add new option 'dir'

### DIFF
--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -150,6 +150,10 @@ download_(Dir, {git, Url, {ref, Ref}}, _State) ->
     ok = filelib:ensure_dir(Dir),
     maybe_warn_local_url(Url),
     git_clone(ref, git_vsn(), Url, Dir, Ref);
+download_(Dir, {git, Url, {dir, Path}}, _State) ->
+    ok = filelib:ensure_dir(Dir),
+    maybe_warn_local_url(Url),
+    git_clone(dir, git_vsn(), Url, Dir, Path);
 download_(Dir, {git, Url, Rev}, _State) ->
     ?WARN("WARNING: It is recommended to use {branch, Name}, {tag, Tag} or {ref, Ref}, otherwise updating the dep may not work as expected.", []),
     ok = filelib:ensure_dir(Dir),
@@ -209,6 +213,12 @@ git_clone(rev,_Vsn,Url,Dir,Rev) ->
                          rebar_utils:escape_chars(filename:basename(Dir))]),
                    [{cd, filename:dirname(Dir)}]),
     rebar_utils:sh(?FMT("git checkout -q ~ts", [rebar_utils:escape_chars(Rev)]),
+                   [{cd, Dir}]);
+%% To fetch the application directly from gerrit
+git_clone(dir, _Vsn, Url, Dir, Path) ->
+    rebar_utils:sh(?FMT("git archive --remote=~ts HEAD:~ts | tar xf -",
+                        [rebar_utils:escape_chars(Url),
+                         rebar_utils:escape_chars(Path)]),
                    [{cd, Dir}]).
 
 git_vsn() ->


### PR DESCRIPTION
Modify the resource provider plugin in order to support new option
called 'dir' which will indicate the path of the application. Once the
path is known it will fetch the application using the 'git archive'
command.

The rebar3 git resource provider can be used to import any Erlang application from a
git repository. Unfortunately, it assumes that the top directory of the application
is it the repository root. Like this:

"foo_project/"

%% Current rebar.config syntax
{deps, [{foo_project, {git, "git://github.com/foo/foo_project.git",
{branch, "master"}}}]}.

The above syntax will fetch whole application, which is inside the foo_project.
Under foo_project/ contains lots of application, which is used by other team.
As we do not want foo_project/ to be split into one repository per application

Add a new optional configuration option called 'dir' which defines the application
top directory:

"foo_project/lib/foo"

{deps, [{foo, {git, "git://github.com/foo/foo_project.git", {dir, "lib/foo"}}}]}.

This will take the foo/ application from foo_project/ in the lib/foo directory.

This contribution will be able to help lots of people.