### PR TITLE
Disable bbmustache escaping

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
         {parse_trans,         "3.3.0"}, % force otp-21 compat
         {providers,           "1.8.1"},
         {getopt,              "1.0.1"},
-        {bbmustache,          "1.6.1"},
+        {bbmustache,          "1.8.0"},
         {relx,                "3.33.0"},
         {cf,                  "0.2.2"},
         {cth_readable,        "1.4.6"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,5 @@
 {"1.1.0",
-[{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.6.1">>},0},
+[{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.8.0">>},0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.5.1">>},0},
  {<<"cf">>,{pkg,<<"cf">>,<<"0.2.2">>},0},
  {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.4.6">>},0},
@@ -12,7 +12,7 @@
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.5">>},0}]}.
 [
 {pkg_hash,[
- {<<"bbmustache">>, <<"9FB63FA60BD53AFBF47F02E6D8BD6B2BEAFC068E02E20975254DC7461FD4F397">>},
+ {<<"bbmustache">>, <<"A268D256B3D5C7CF9FD14ECED58977BC71AADB7CE412E883C3A2CD0A10F3CF27">>},
  {<<"certifi">>, <<"867CE347F7C7D78563450A18A6A28A8090331E77FA02380B4A21962A65D36EE5">>},
  {<<"cf">>, <<"7F2913FFF90ABCABD0F489896CFEB0B0674F6C8DF6C10B17A83175448029896C">>},
  {<<"cth_readable">>, <<"29DF6430584389B30D14B7D68D0EB7BC837ED31E2DF6E9D93598D4EC63B1E3BD">>},

--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -431,8 +431,11 @@ write_file(Output, Data, Force) ->
             {error, exists}
     end.
 
-%%
 %% Render a binary to a string, using mustache and the specified context
-%%
 render(Bin, Context) ->
-    bbmustache:render(rebar_utils:to_binary(Bin), Context, [{key_type, atom}]).
+    bbmustache:render(
+      rebar_utils:to_binary(Bin),
+      Context,
+      [{key_type, atom},
+       {escape_fun, fun(X) -> X end}] % disable HTML-style escaping
+    ).

--- a/test/rebar_new_SUITE.erl
+++ b/test/rebar_new_SUITE.erl
@@ -56,12 +56,12 @@ app_git_user(Config) ->
     Name = ?config(name, Config),
     rebar_test_utils:run_and_check(
         Config, [],
-        ["new", "test_app", Name, "author_name=some_name"],
+        ["new", "test_app", Name, "author_name=<some_name>"],
         {ok, []}
     ),
     validate_files(
         Config, Name,
-        [{"LICENSE", ["some_name", "git@email.com"]},
+        [{"LICENSE", ["<some_name>", "git@email.com"]},
          {"README.md", [Name]},
          {".gitignore", []},
          {"rebar.config", []},


### PR DESCRIPTION
Fixes #2161 

Since we generate text or erlang files, it seems useless to escape HTML by default.

As a drive-by thing, I updated bbmustache to its latest version.