### PR TITLE
RFC: Make global plugins use a major OTP directory

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -102,7 +102,8 @@ checkouts_dir(State, App) ->
 plugins_dir(State) ->
     case lists:member(global, rebar_state:current_profiles(State)) of
         true ->
-            filename:join([base_dir(State), global_config_dir(State), rebar_state:get(State, plugins_dir, ?DEFAULT_PLUGINS_DIR)]);
+            [Major | _] = re:split(rebar_utils:otp_release(), "\\.", [{return, list}]),
+            filename:join([base_dir(State), global_config_dir(State), rebar_state:get(State, plugins_dir, ?DEFAULT_PLUGINS_DIR), Major]);
         false ->
             filename:join(base_dir(State), rebar_state:get(State, plugins_dir, ?DEFAULT_PLUGINS_DIR))
     end.

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -93,7 +93,7 @@ handle_plugins(Profile, Plugins, State, Upgrade) ->
     %% Set deps dir to plugins dir so apps are installed there
     Locks = rebar_state:lock(State),
     DepsDir = rebar_state:get(State, deps_dir, ?DEFAULT_DEPS_DIR),
-    State1 = rebar_state:set(State, deps_dir, ?DEFAULT_PLUGINS_DIR),
+    State1 = rebar_state:set(State, deps_dir, plugins_dir(Profile)),
     %% Install each plugin individually so if one fails to install it doesn't effect the others
     {_PluginProviders, State2} =
         lists:foldl(fun(Plugin, {PluginAcc, StateAcc}) ->
@@ -105,6 +105,12 @@ handle_plugins(Profile, Plugins, State, Upgrade) ->
     %% reset deps dir
     State3 = rebar_state:set(State2, deps_dir, DepsDir),
     rebar_state:lock(State3, Locks).
+
+plugins_dir(global) ->
+    [Major | _] = re:split(rebar_utils:otp_release(), "\\.", [{return, list}]),
+    filename:join([?DEFAULT_PLUGINS_DIR, Major]);
+plugins_dir(_) ->
+    ?DEFAULT_PLUGINS_DIR.
 
 handle_plugin(Profile, Plugin, State, Upgrade) ->
     try

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -247,7 +247,8 @@ top_level_deps([{{Name, Vsn, Ref}, _} | Deps]) ->
 check_results(AppDir, Expected, ProfileRun) ->
     BuildDirs = filelib:wildcard(filename:join([AppDir, "_build", ProfileRun, "lib", "*"])),
     PluginDirs = filelib:wildcard(filename:join([AppDir, "_build", ProfileRun, "plugins", "*"])),
-    GlobalPluginDirs = filelib:wildcard(filename:join([AppDir, "global", "plugins", "*"])),
+    OTPVersion = erlang:system_info(otp_release),
+    GlobalPluginDirs = filelib:wildcard(filename:join([AppDir, "global", "plugins", OTPVersion, "*"])),
     CheckoutsDirs = filelib:wildcard(filename:join([AppDir, "_checkouts", "*"])),
     LockFile = filename:join([AppDir, "rebar.lock"]),
     Locks = lists:flatten(rebar_config:consult_lock_file(LockFile)),


### PR DESCRIPTION
This is a thing that came up after feedback from @eproxus regarding global plugins often breaking when switching major Erlang/OTP versions, when newer beam files won't load in older emulators. This happens particularly often with global plugins since the tendency to go up/down major versions is more frequent.

The idea here is to change the path of global plugins to be segmented per major OTP version such that they get re-built for each version and will avoid clashing.

Not sure this is a great idea: rebar.config files remain shared, upgrading a plugin will only upgrade a version at a time, and so on. This may create more obscure bugs and confusion down the line and may not be worth it.