### PR TITLE
Fix epmd start on windows

### DIFF
--- a/src/rebar_dist_utils.erl
+++ b/src/rebar_dist_utils.erl
@@ -67,7 +67,7 @@ start_epmd() ->
     %% Indirectly boot EPMD through calling Erlang so that we don't risk
     %% attaching it to the current proc
     ?CONSOLE("Attempting to start epmd...", []),
-    os:cmd("erl -sname a -eval 'halt(0).'").
+    os:cmd("erl -sname a -noinput -eval \"halt(0).\"").
 
 warn_dist() ->
     ?ERROR("Erlang Distribution failed, falling back to nonode@nohost.", []).


### PR DESCRIPTION
Windows does not have the same quoting rules as Unix so we need to use platform independent quoting. Also for os:cmd like operations we do not expect the program to read any input so in order for it to work on windows we should put `-noinput` there.

See #2113 and https://bugs.erlang.org/browse/ERL-994 for more details.