### PR TITLE
OTP 23 [master] compatibility

### DIFF
--- a/src/r3_hex_api.erl
+++ b/src/r3_hex_api.erl
@@ -28,7 +28,7 @@ put(Config, Path, Body) ->
 delete(Config, Path) ->
     request(Config, delete, Path, undefined).
 
--compile({nowarn_deprecated_function, [http_uri, encode, 1]}).
+-compile({nowarn_deprecated_function, [{http_uri, encode, 1}]}).
 
 %% @private
 encode_query_string(List) ->

--- a/src/r3_hex_api.erl
+++ b/src/r3_hex_api.erl
@@ -28,6 +28,8 @@ put(Config, Path, Body) ->
 delete(Config, Path) ->
     request(Config, delete, Path, undefined).
 
+-compile({nowarn_deprecated_function, [http_uri, encode, 1]}).
+
 %% @private
 encode_query_string(List) ->
     QueryString =

--- a/src/r3_hex_api.erl
+++ b/src/r3_hex_api.erl
@@ -28,7 +28,11 @@ put(Config, Path, Body) ->
 delete(Config, Path) ->
     request(Config, delete, Path, undefined).
 
--compile({nowarn_deprecated_function, [{http_uri, encode, 1}]}).
+-ifdef (OTP_RELEASE).
+  -if(?OTP_RELEASE >= 23).
+    -compile({nowarn_deprecated_function, [{http_uri, encode, 1}]}).
+  -endif.
+-endif.
 
 %% @private
 encode_query_string(List) ->

--- a/src/r3_hex_tarball.erl
+++ b/src/r3_hex_tarball.erl
@@ -201,7 +201,7 @@ do_unpack(Files, Output) ->
 finish_unpack({error, _} = Error) ->
     Error;
 finish_unpack(#{metadata := Metadata, files := Files, output := Output}) ->
-    _Version = maps:get("VERSION", Files),
+    true = maps:is_key("VERSION", Files),
     Checksum = decode_base16(maps:get("CHECKSUM", Files)),
     ContentsBinary = maps:get("contents.tar.gz", Files),
     case unpack_tarball(ContentsBinary, Output) of

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -100,6 +100,9 @@ compare_url(Dir, Url) ->
     ?DEBUG("Comparing git url ~p with ~p", [ParsedUrl, ParsedCurrentUrl]),
     ParsedCurrentUrl =:= ParsedUrl.
 
+-compile({nowarn_deprecated_function, [{http_uri, parse, 2},
+                                       {http_uri, scheme_defaults, 0}]}).
+
 parse_git_url(Url) ->
     %% Checks for standard scp style git remote
     case re:run(Url, ?SCP_PATTERN, [{capture, [host, path], list}, unicode]) of
@@ -351,7 +354,7 @@ parse_tags(Dir) ->
     end.
 
 git_clone_options() ->
-    Option = case os:getenv("REBAR_GIT_CLONE_OPTIONS") of 
+    Option = case os:getenv("REBAR_GIT_CLONE_OPTIONS") of
         false -> "" ;       %% env var not set
         Opt ->              %% env var set to empty or others
             Opt

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -100,8 +100,12 @@ compare_url(Dir, Url) ->
     ?DEBUG("Comparing git url ~p with ~p", [ParsedUrl, ParsedCurrentUrl]),
     ParsedCurrentUrl =:= ParsedUrl.
 
--compile({nowarn_deprecated_function, [{http_uri, parse, 2},
-                                       {http_uri, scheme_defaults, 0}]}).
+-ifdef (OTP_RELEASE).
+  -if(?OTP_RELEASE >= 23).
+    -compile({nowarn_deprecated_function, [{http_uri, parse, 2},
+                                           {http_uri, scheme_defaults, 0}]}).
+  -endif.
+-endif.
 
 parse_git_url(Url) ->
     %% Checks for standard scp style git remote

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -908,6 +908,9 @@ get_http_vars(Scheme) ->
     Config = rebar_config:consult_file(GlobalConfigFile),
     proplists:get_value(Scheme, Config, OS).
 
+-compile({nowarn_deprecated_function, [{http_uri, parse, 1},
+                                       {http_uri, decode, 1}]}).
+
 set_httpc_options() ->
     set_httpc_options(https_proxy, get_http_vars(https_proxy)),
     set_httpc_options(proxy, get_http_vars(http_proxy)).

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -908,8 +908,12 @@ get_http_vars(Scheme) ->
     Config = rebar_config:consult_file(GlobalConfigFile),
     proplists:get_value(Scheme, Config, OS).
 
--compile({nowarn_deprecated_function, [{http_uri, parse, 1},
-                                       {http_uri, decode, 1}]}).
+-ifdef (OTP_RELEASE).
+  -if(?OTP_RELEASE >= 23).
+    -compile({nowarn_deprecated_function, [{http_uri, parse, 1},
+                                           {http_uri, decode, 1}]}).
+  -endif.
+-endif.
 
 set_httpc_options() ->
     set_httpc_options(https_proxy, get_http_vars(https_proxy)),


### PR DESCRIPTION
Team RabbitMQ tests OTP versions from 20.3 to master in our CI/CD pipelines. Recent OTP master changes introduce additional warnings that make Rebar bootstrap fail.

Unfortunately, there is no URI utility function module that's both available in OTP 20 and not deprecated in OTP 23. So this PR suppresses a few warnings for now. I hope that's acceptable.