### PR TITLE
Introduce rebar_uri to avoid deprecation warnings on OTP 23 [master]

### DIFF
--- a/src/r3_hex_api.erl
+++ b/src/r3_hex_api.erl
@@ -16,8 +16,6 @@
 ]).
 -define(ERL_CONTENT_TYPE, <<"application/vnd.hex+erlang">>).
 
--import(rebar_utils, [to_list/1]).
-
 get(Config, Path) ->
     request(Config, get, Path, undefined).
 
@@ -30,24 +28,26 @@ put(Config, Path, Body) ->
 delete(Config, Path) ->
     request(Config, delete, Path, undefined).
 
-%% OTP 21+
 -ifdef (OTP_RELEASE).
-encode_query_string(List0) ->
-    %% uri_string:compose_query/1 only accepts proplists where values are lists
-    Pairs = lists:map(fun ({K, V}) -> {to_list(K), to_list(V)}
-                          end, List0),
-    list_to_binary(uri_string:compose_query(Pairs)).
--else.
+  -if(?OTP_RELEASE >= 23).
+    -compile({nowarn_deprecated_function, [{http_uri, encode, 1}]}).
+  -endif.
+-endif.
+
 %% @private
 encode_query_string(List) ->
     QueryString =
         join("&",
-            lists:map(fun ({K, V}) -> to_list(K) ++ "=" ++ to_list(V)
+            lists:map(fun
+                ({K, V}) when is_atom(V) ->
+                    atom_to_list(K) ++ "=" ++ atom_to_list(V);
+                ({K, V}) when is_binary(V) ->
+                    atom_to_list(K) ++ "=" ++ binary_to_list(V);
+                ({K, V}) when is_integer(V) ->
+                    atom_to_list(K) ++ "=" ++ integer_to_list(V)
             end, List)),
     Encoded = http_uri:encode(QueryString),
     list_to_binary(Encoded).
--endif.
-
 
 %% @private
 build_repository_path(#{api_repository := Repo}, Path) when is_binary(Repo) ->
@@ -61,20 +61,9 @@ build_organization_path(#{api_organization := Org}, Path) when is_binary(Org) ->
 build_organization_path(#{api_organization := undefined}, Path) ->
     Path.
 
-%% OTP 21+
--ifdef (OTP_RELEASE).
-%% @private
-join_path_segments(Segments) ->
-    Concatenated = join(<<"/">>, Segments),
-    %% uri_string:recompose/1 accepts path segments as a list,
-    %% both strings and binaries
-    list_to_binary(uri_string:recompose(#{path => Concatenated})).
--else.
 %% @private
 join_path_segments(Segments) ->
     erlang:iolist_to_binary(join(<<"/">>, lists:map(fun encode/1, Segments))).
--endif.
-
 
 %%====================================================================
 %% Internal functions
@@ -103,13 +92,10 @@ request(Config, Method, Path, Body) when is_binary(Path) and is_map(Config) ->
             Other
     end.
 
-%% OTP < 21
--ifndef (OTP_RELEASE).
 encode(Binary) when is_binary(Binary) ->
     encode(binary_to_list(Binary));
 encode(String) when is_list(String) ->
     http_uri:encode(String).
--endif.
 
 build_url(Path, #{api_url := URI}) ->
     <<URI/binary, "/", Path/binary>>.

--- a/src/r3_hex_api.erl
+++ b/src/r3_hex_api.erl
@@ -16,6 +16,8 @@
 ]).
 -define(ERL_CONTENT_TYPE, <<"application/vnd.hex+erlang">>).
 
+-import(rebar_utils, [to_list/1]).
+
 get(Config, Path) ->
     request(Config, get, Path, undefined).
 
@@ -32,10 +34,7 @@ delete(Config, Path) ->
 -ifdef (OTP_RELEASE).
 encode_query_string(List0) ->
     %% uri_string:compose_query/1 only accepts proplists where values are lists
-    Pairs = lists:map(fun ({K, V}) when is_atom(V)    -> {K, atom_to_list(V)};
-                          ({K, V}) when is_binary(V)  -> {K, binary_to_list(V)};
-                          ({K, V}) when is_integer(V) -> {K, integer_to_list(V)};
-                          ({K, V}) -> {K, V}
+    Pairs = lists:map(fun ({K, V}) -> {to_list(K), to_list(V)}
                           end, List0),
     list_to_binary(uri_string:compose_query(Pairs)).
 -else.
@@ -43,13 +42,7 @@ encode_query_string(List0) ->
 encode_query_string(List) ->
     QueryString =
         join("&",
-            lists:map(fun
-                ({K, V}) when is_atom(V) ->
-                    atom_to_list(K) ++ "=" ++ atom_to_list(V);
-                ({K, V}) when is_binary(V) ->
-                    atom_to_list(K) ++ "=" ++ binary_to_list(V);
-                ({K, V}) when is_integer(V) ->
-                    atom_to_list(K) ++ "=" ++ integer_to_list(V)
+            lists:map(fun ({K, V}) -> to_list(K) ++ "=" ++ to_list(V)
             end, List)),
     Encoded = http_uri:encode(QueryString),
     list_to_binary(Encoded).

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -117,8 +117,8 @@ parse_git_url(Url) ->
     end.
 parse_git_url(not_scp, Url) ->
     UriOpts = [{scheme_defaults, [{git, 9418} | http_uri:scheme_defaults()]}],
-    case http_uri:parse(Url, UriOpts) of
-        {ok, {_Scheme, _User, Host, _Port, Path, _Query}} ->
+    case rebar_uri:parse(Url, UriOpts) of
+        #{path := Path, host := Host} ->
             {ok, {Host, filename:rootname(Path, ".git")}};
         {error, Reason} ->
             {error, Reason}

--- a/src/rebar_hex_repos.erl
+++ b/src/rebar_hex_repos.erl
@@ -96,8 +96,8 @@ update_organizations(Repos) ->
                       {ok, Parent} = get_repo_config(ParentName, Repos),
                       ParentRepoUrl = rebar_utils:to_list(maps:get(repo_url, Parent)),
                       {ok, _RepoUrl} =
-                          rebar_utils:url_append_path(ParentRepoUrl,
-                                                      filename:join("repos", rebar_utils:to_list(RepoName))),
+                          rebar_uri:append_path(ParentRepoUrl,
+                                                filename:join("repos", rebar_utils:to_list(RepoName))),
                       %% still let the organization config override this constructed repo url
                       maps:merge(Parent#{repo_url => rebar_utils:to_binary(ParentRepoUrl)}, Repo);
                  (Repo) ->

--- a/src/rebar_uri.erl
+++ b/src/rebar_uri.erl
@@ -1,0 +1,44 @@
+%%% @doc multi-OTP version compatibility shim for working with URIs
+-module(rebar_uri).
+
+-ifdef (OTP_RELEASE).
+-export([parse/1]).
+
+-spec parse(URIString) -> URIMap when
+    URIString :: uri_string:uri_string(),
+    URIMap :: uri_string:uri_map() | uri_string:error().
+
+parse(URIString) ->
+    uri_string:parse(URIString).
+-else.
+-export([parse/1]).
+
+-spec parse(URIString) -> URIMap when
+    URIString :: iodata(),
+    URIMap :: map() | {error, atom(), term()}.
+
+parse(URIString) ->
+    case http_uri:parse(URIString) of
+        {error, Reason} ->
+            %% no additional parser/term info available to us,
+            %% e.g. see what uri_string returns in
+            %% uri_string:parse(<<"h$ttp:::://////lolz">>).
+            {error, Reason, ""};
+        {ok, {Scheme, UserInfo, Host, Port, Path, Query}} ->
+            #{
+                scheme => Scheme,
+                host => Host,
+                port => Port,
+                path => Path,
+                %% http_uri:parse/1 includes the leading question mark
+                %% in query string but uri_string:parse/1 leaves it out.
+                %% string:slice/2 isn't available in OTP <= 19.
+                query => case Query of
+                           [] -> "";
+                           _  -> string:substr(Query, 2)
+                         end,
+                userinfo => UserInfo
+            }
+    end.
+-endif.
+

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -64,7 +64,6 @@
          tup_find/2,
          line_count/1,
          set_httpc_options/0,
-         url_append_path/2,
          escape_chars/1,
          escape_double_quotes/1,
          escape_double_quotes_weak/1,
@@ -266,6 +265,8 @@ to_binary(A) when is_atom(A) -> atom_to_binary(A, unicode);
 to_binary(Str) -> unicode:characters_to_binary(Str).
 
 to_list(A) when is_atom(A) -> atom_to_list(A);
+to_list(B) when is_binary(B) -> unicode:characters_to_list(B);
+to_list(I) when is_integer(I) -> integer_to_list(I);
 to_list(Str) -> unicode:characters_to_list(Str).
 
 tup_dedup(List) ->
@@ -936,31 +937,6 @@ normalise_proxy(Scheme, URI) ->
         nomatch when Scheme =:= proxy -> "http://" ++ URI;
         _ -> URI
     end.
-
-%% OTP 21+
--ifdef (OTP_RELEASE).
-url_append_path(Url, ExtraPath) ->
-     case rebar_uri:parse(Url) of
-         #{path := Path} = Map ->
-             FullPath = filename:join(Path, ExtraPath),
-             {ok, uri_string:recompose(maps:update(path, FullPath, Map))};
-         _ ->
-             error
-     end.
--else.
-url_append_path(Url, ExtraPath) ->
-     case rebar_uri:parse(Url) of
-         #{scheme := Scheme, userinfo := UserInfo, host := Host, port := Port, path := Path, query := Query} ->
-             PrefixedQuery = case Query of
-                               []    -> [];
-                               Other -> lists:append(["?", Other])
-                             end,
-             {ok, lists:append([atom_to_list(Scheme), "://", UserInfo, Host, ":", integer_to_list(Port),
-                                filename:join(Path, ExtraPath), PrefixedQuery])};
-         _ ->
-             error
-     end.
--endif.
 
 %% escape\ as\ a\ shell\?
 escape_chars(Str) when is_atom(Str) ->

--- a/test/rebar_uri_SUITE.erl
+++ b/test/rebar_uri_SUITE.erl
@@ -1,0 +1,48 @@
+-module(rebar_uri_SUITE).
+
+-export([all/0,
+         parse/1,
+         append_path/1]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/file.hrl").
+
+all() ->
+    [parse].
+
+parse(_Config) ->
+    #{scheme := Scheme, host := Host, path := Path} = rebar_uri:parse("https://repo.hex.pm"),
+    ?assertEqual("https", Scheme),
+    ?assertEqual("repo.hex.pm", Host),
+    ?assert(lists:member(Path, ["", "/"])),
+
+    #{scheme := Scheme2, host := Host2, port := Port2, path := Path2, query := Query2} =
+        rebar_uri:parse("https://repo.hex.pm:443?foo=bar"),
+    ?assertEqual("https", Scheme2),
+    ?assertEqual("repo.hex.pm", Host2),
+    ?assertEqual(443, Port2),
+    ?assert(lists:member(Path2, ["", "/"])),
+    ?assertEqual("foo=bar", Query2),
+
+    #{scheme := Scheme3, host := Host3, path := Path3, query := Query3} =
+        rebar_uri:parse("https://repo.hex.pm/over/here?foo=bar"),
+    ?assertEqual("https", Scheme3),
+    ?assertEqual("repo.hex.pm", Host3),
+    ?assertEqual("/over/here", Path3),
+    ?assertEqual("foo=bar", Query3).
+
+append_path(_Config) ->
+    %% OTP version differences
+    {ok, Val1} = rebar_utils:append_path("https://repo.hex.pm", "/repos/org"),
+    ?assert(lists:member(Val1, [
+        "https://repo.hex.pm/repos/org",
+        "https://repo.hex.pm:443/repos/org"
+    ])),
+    {ok, Val2} = rebar_utils:append_path("https://repo.hex.pm?foo=bar", "/repos/org"),
+    ?assert(lists:member(Val2, [
+        "https://repo.hex.pm/repos/org?foo=bar",
+        "https://repo.hex.pm:443/repos/org?foo=bar"
+    ])),
+    ?assertEqual({ok, "https://repo.hex.pm:443/repos/org?foo=bar"},
+                 rebar_utils:append_path("https://repo.hex.pm:443?foo=bar", "/repos/org")).

--- a/test/rebar_utils_SUITE.erl
+++ b/test/rebar_utils_SUITE.erl
@@ -322,6 +322,16 @@ is_list_of_strings(_Config) ->
     ?assert(rebar_utils:is_list_of_strings("foo") == false).
 
 url_append_path(_Config) ->
-    ?assertEqual({ok, "https://repo.hex.pm:443/repos/org"}, rebar_utils:url_append_path("https://repo.hex.pm", "/repos/org")),
-    ?assertEqual({ok, "https://repo.hex.pm:443/repos/org?foo=bar"}, rebar_utils:url_append_path("https://repo.hex.pm",
-                                                                                      "/repos/org?foo=bar")).
+    %% OTP version differences
+    {ok, Val1} = rebar_utils:url_append_path("https://repo.hex.pm", "/repos/org"),
+    ?assert(lists:member(Val1, [
+        "https://repo.hex.pm/repos/org",
+        "https://repo.hex.pm:443/repos/org"
+    ])),
+    {ok, Val2} = rebar_utils:url_append_path("https://repo.hex.pm?foo=bar", "/repos/org"),
+    ?assert(lists:member(Val2, [
+        "https://repo.hex.pm/repos/org?foo=bar",
+        "https://repo.hex.pm:443/repos/org?foo=bar"
+    ])),
+    ?assertEqual({ok, "https://repo.hex.pm:443/repos/org?foo=bar"},
+                 rebar_utils:url_append_path("https://repo.hex.pm:443?foo=bar", "/repos/org")).

--- a/test/rebar_utils_SUITE.erl
+++ b/test/rebar_utils_SUITE.erl
@@ -33,8 +33,7 @@
          sh_does_not_miss_messages/1,
          tup_merge/1,
          proxy_auth/1,
-        is_list_of_strings/1,
-        url_append_path/1]).
+        is_list_of_strings/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -50,7 +49,7 @@ all() ->
     [{group, args_to_tasks},
      sh_does_not_miss_messages,
      tup_merge,
-     proxy_auth, is_list_of_strings, url_append_path].
+     proxy_auth, is_list_of_strings].
 
 groups() ->
     [{args_to_tasks, [], [empty_arglist,
@@ -320,18 +319,3 @@ is_list_of_strings(_Config) ->
     ?assert(rebar_utils:is_list_of_strings([])),
     ?assert(rebar_utils:is_list_of_strings("")),
     ?assert(rebar_utils:is_list_of_strings("foo") == false).
-
-url_append_path(_Config) ->
-    %% OTP version differences
-    {ok, Val1} = rebar_utils:url_append_path("https://repo.hex.pm", "/repos/org"),
-    ?assert(lists:member(Val1, [
-        "https://repo.hex.pm/repos/org",
-        "https://repo.hex.pm:443/repos/org"
-    ])),
-    {ok, Val2} = rebar_utils:url_append_path("https://repo.hex.pm?foo=bar", "/repos/org"),
-    ?assert(lists:member(Val2, [
-        "https://repo.hex.pm/repos/org?foo=bar",
-        "https://repo.hex.pm:443/repos/org?foo=bar"
-    ])),
-    ?assertEqual({ok, "https://repo.hex.pm:443/repos/org?foo=bar"},
-                 rebar_utils:url_append_path("https://repo.hex.pm:443?foo=bar", "/repos/org")).


### PR DESCRIPTION
See #2191 for the background.

The new module attempts to act as a shim between `http_uri` (deprecated in OTP 23) and `uri_string` (available as of OTP 21+) with as little wheel reinvention as possible.

