### PR TITLE
re-enable use of rebar_packages_cdn in rebar_pkg_resource

### DIFF
--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -24,7 +24,7 @@
 -define(DEFAULT_RELEASE_DIR, "rel").
 -define(CONFIG_VERSION, "1.2.0").
 -define(SUPPORTED_CONFIG_VERSIONS, ["1.1.0", "1.2.0"]). % older were untagged
--define(DEFAULT_CDN, "https://repo.hex.pm/").
+-define(DEFAULT_CDN, "https://repo.hex.pm").
 -define(REMOTE_PACKAGE_DIR, "tarballs").
 -define(LOCK_FILE, "rebar.lock").
 -define(DEFAULT_COMPILER_SOURCE_FORMAT, relative).

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -131,13 +131,12 @@ run_aux(State, RawArgs) ->
     rebar_utils:check_min_otp_version(rebar_state:get(State1, minimum_otp_vsn, undefined)),
     rebar_utils:check_blacklisted_otp_versions(rebar_state:get(State1, blacklisted_otp_vsns, undefined)),
 
-    %% Change the default hex CDN
-    State2 = case os:getenv("HEX_CDN") of
-                 false ->
-                     State1;
-                 CDN ->
-                     rebar_state:set(State1, rebar_packages_cdn, CDN)
+    %% Maybe change the default hex CDN
+    HexCDN = case os:getenv("HEX_CDN") of
+                 false -> ?DEFAULT_CDN;
+                 CDN -> CDN
              end,
+    State2 = rebar_state:set(State1, rebar_packages_cdn, HexCDN),
 
     Compilers = application:get_env(rebar, compilers, []),
     State0 = rebar_state:compilers(State2, Compilers),


### PR DESCRIPTION
This closes PR #2197 and its parent issue #2196 

 It looks like the value of `rebar_packages_cdn`  being used as the `repo_url` was being used up until https://github.com/erlang/rebar3/pull/1884 , though it is no clear why. 