### PR TITLE
remove warning when booting applications in the shell

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -440,9 +440,6 @@ reread_config(AppsToStart, State) ->
     end.
 
 boot_apps(Apps) ->
-    ?WARN("The rebar3 shell is a development tool; to deploy "
-            "applications in production, consider using releases "
-            "(http://www.rebar3.org/docs/releases)", []),
     Normalized = normalize_boot_apps(Apps),
     Res = [application:ensure_all_started(App) || App <- Normalized],
     _ = [?INFO("Booted ~p", [App])


### PR DESCRIPTION
This warning is emitted every single time one starts a shell with applications
configured for automatic startup (e.g. `{shell, [{apps, [cowboy]}]}`).

Infortunately it does not make any sense: people who use this feature need it
to interact with their application or library during development, and are
therefore subjected to the warning every single time they start the shell even
though this is the right way to use it.

While the shell is not to be used to run applications in productions, those
who do it won't be stopped by a warning.

Ultimately, the warning annoys people who use the feature as intended, and do
nothing to stop people who abuse it. Thus I believe it should be removed.

See https://github.com/erlang/rebar3/issues/2206.

close #2206