### PR TITLE
Eliminate lock file warnings when upgrading from 1.1.0 locks

### DIFF
--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -23,6 +23,7 @@
 -define(DEFAULT_TEST_DEPS_DIR, "test/lib").
 -define(DEFAULT_RELEASE_DIR, "rel").
 -define(CONFIG_VERSION, "1.2.0").
+-define(SUPPORTED_CONFIG_VERSIONS, ["1.1.0", "1.2.0"]). % older were untagged
 -define(DEFAULT_CDN, "https://repo.hex.pm/").
 -define(REMOTE_PACKAGE_DIR, "tarballs").
 -define(LOCK_FILE, "rebar.lock").

--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -69,7 +69,7 @@ consult_lock_file(File) ->
     case Terms of
         [] ->
             [];
-        [Locks] when is_list(Locks) -> % beta lock file
+        [Locks] when is_list(Locks) -> % beta/1.0.0 lock file
             read_attrs(beta, Locks, []);
         [{Vsn, Locks}|Attrs] when is_list(Locks) -> % versioned lock file
             %% Because this is the first version of rebar3 to introduce a lock
@@ -79,10 +79,16 @@ consult_lock_file(File) ->
                 ?CONFIG_VERSION ->
                     ok;
                 _ ->
-                    %% Make sure the warning below is to be shown whenever a version
-                    %% newer than the current one is being used, as we can't parse
-                    %% all the contents of the lock file properly.
-                    warn_vsn_once()
+                    case lists:member(Vsn, ?SUPPORTED_CONFIG_VERSIONS) of
+                        true ->
+                            ok;
+                        false ->
+                            %% Make sure the warning below is to be shown
+                            %% whenever a version newer than the current
+                            %% one is being used, as we can't parse all the
+                            %% contents of the lock file properly.
+                            warn_vsn_once()
+                    end
             end,
             read_attrs(Vsn, Locks, Attrs)
     end.


### PR DESCRIPTION
The code was written at the time only one lockfile version was being
explicitly tagged (1.1.0), and all the other older ones were untagged.
In introducing the 1.2.0 format for external hashes, the current version
check still took place, but no provisions were made to explicitly check
between older or newer versions. As such, rebar3 would warn (prompting
people to upgrade) every time a lockfile on the 1.1.0 version (which is
likely over 99% of those in the wild as of today) would be encountered,
we'd prompt people to upgrade.

This patch introduces a constant for the list of supported tagged
versions for config/lock files, which allows to drop warnings when
rebar3 can transparently upgrade the lock file for the user.

It pre-supposes a potential "unsupported lock file" error could be added
in the future if a config format is not newer but in fact explicitly
deprecated. This isn't implemented but the current logic works towards
making that support possible.