### PR TITLE
rebar3: ipv6 support for proxy

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -152,7 +152,23 @@ set_httpc_options(_, []) ->
 set_httpc_options(Scheme, Proxy) ->
     {ok, {_, UserInfo, Host, Port, _, _}} = http_uri:parse(Proxy),
     httpc:set_options([{Scheme, {{Host, Port}, []}}], rebar),
+    proxy_ipfamily(Host, inet:gethostbyname(Host)),
     set_proxy_auth(UserInfo).
+
+proxy_ipfamily(_Host, {ok, _}) ->
+    ok;
+proxy_ipfamily(Host, {error, nxdomain}) ->
+    maybe_proxy_family(Host, inet_db:res_option(inet6)).
+
+maybe_proxy_family(Host, true) ->
+    maybe_set_ipfamily(inet:gethostbyname(Host, inet), inet);
+maybe_proxy_family(Host, false) ->
+    maybe_set_ipfamily(inet:gethostbyname(Host, inet6), inet6).
+
+maybe_set_ipfamily({ok, _}, Family) ->
+    httpc:set_options([{ipfamily, Family}], rebar);
+maybe_set_ipfamily(_, _Family) ->
+    ok.
 
 compile(App, FirstFiles) ->
     Dir = filename:join(filename:absname("_build/default/lib/"), App),

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -926,7 +926,23 @@ set_httpc_options(Scheme, Proxy) ->
     URI = normalise_proxy(Scheme, Proxy),
     {ok, {_, UserInfo, Host, Port, _, _}} = http_uri:parse(URI),
     httpc:set_options([{Scheme, {{Host, Port}, []}}], rebar),
+    proxy_ipfamily(Host, inet:gethostbyname(Host)),
     set_proxy_auth(UserInfo).
+
+proxy_ipfamily(_Host, {ok, _}) ->
+    ok;
+proxy_ipfamily(Host, {error, nxdomain}) ->
+    maybe_proxy_family(Host, inet_db:res_option(inet6)).
+
+maybe_proxy_family(Host, true) ->
+    maybe_set_ipfamily(inet:gethostbyname(Host, inet), inet);
+maybe_proxy_family(Host, false) ->
+    maybe_set_ipfamily(inet:gethostbyname(Host, inet6), inet6).
+
+maybe_set_ipfamily({ok, _}, Family) ->
+    httpc:set_options([{ipfamily, Family}], rebar);
+maybe_set_ipfamily(_, _Family) ->
+    ok.
 
 normalise_proxy(Scheme, URI) ->
     case re:run(URI, "://", [unicode]) of


### PR DESCRIPTION
Solves #2071, IPV6 support for proxy, by trying to resolve proxy
host name without specific IP address family. If it fails, it
attempts a different IP family, and in case that succeeds, it
sets up HTTP client profile to use IP family that worked.