### PR TITLE
rebar_git_resource: fix {vsn, git} parser

### DIFF
--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -335,7 +335,8 @@ parse_tags(Dir) ->
         {ok, Line} ->
             case re:run(Line, "(\\(|\\s)(HEAD[^,]*,\\s)tag:\\s(v?([^,\\)]+))", [{capture, [3, 4], list}, unicode]) of
                 {match,[Tag, Vsn]} ->
-                    {Tag, Vsn};
+                    %% git tag can be repo_name/proj/05323498<hash>38, only want the hash
+                    {Tag, lists:last(rebar_string:lexemes(Vsn, "/"))};
                 nomatch ->
                     case rebar_utils:sh("git describe --tags --abbrev=0",
                             [{use_stdout, false}, return_on_error, {cd, Dir}]) of


### PR DESCRIPTION
rebar3 uses following git invocation when it needs to generate
vsn to put into app.src:
git -c color.ui=false log --oneline --no-walk --tags --decorate
It may return something like some_repo/some_project/12345678,
with some characters preceding actual hash. This leads to some
unusual version written into application resource file, e.g.
{vsn, "some_repo/some_project/123456678"}.
This does not work well with semantic versioning, and also
produces unexpected OTP application names and folder names,
e.g.
myapp-some_repo/some_project/12345678