### PR TITLE
Move `absolute_path/2` and `normalized_path` to `rebar_file_utils`

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -191,42 +191,6 @@ processing_base_dir(State, Dir) ->
     AbsDir = filename:absname(Dir),
     AbsDir =:= rebar_state:get(State, base_dir).
 
-%% @doc make a path absolute
--spec make_absolute_path(file:filename()) -> file:filename().
-make_absolute_path(Path) ->
-    case filename:pathtype(Path) of
-        absolute ->
-            Path;
-        relative ->
-            {ok, Dir} = file:get_cwd(),
-            filename:join([Dir, Path]);
-        volumerelative ->
-            Volume = hd(filename:split(Path)),
-            {ok, Dir} = file:get_cwd(Volume),
-            filename:join([Dir, Path])
-    end.
-
-%% @doc normalizing a path removes all of the `..' and the
-%% `.' segments it may contain.
--spec make_normalized_path(file:filename()) -> file:filename().
-make_normalized_path(Path) ->
-    AbsPath = make_absolute_path(Path),
-    Components = filename:split(AbsPath),
-    make_normalized_path(Components, []).
-
-%% @private drops path fragments for normalization
--spec make_normalized_path([string()], [string()]) -> file:filename().
-make_normalized_path([], NormalizedPath) ->
-    filename:join(lists:reverse(NormalizedPath));
-make_normalized_path([H|T], NormalizedPath) ->
-    case H of
-        "." when NormalizedPath == [], T == [] -> make_normalized_path(T, ["."]);
-        "."  -> make_normalized_path(T, NormalizedPath);
-        ".." when NormalizedPath == [] -> make_normalized_path(T, [".."]);
-        ".." when hd(NormalizedPath) =/= ".." -> make_normalized_path(T, tl(NormalizedPath));
-        _    -> make_normalized_path(T, [H|NormalizedPath])
-    end.
-
 %% @doc take a source and a target path, and relativize the target path
 %% onto the source.
 %%
@@ -239,8 +203,8 @@ make_normalized_path([H|T], NormalizedPath) ->
 %% '''
 -spec make_relative_path(file:filename(), file:filename()) -> file:filename().
 make_relative_path(Source, Target) ->
-    AbsSource = make_normalized_path(Source),
-    AbsTarget = make_normalized_path(Target),
+    AbsSource = rebar_file_utils:normalized_path(Source),
+    AbsTarget = rebar_file_utils:normalized_path(Target),
     do_make_relative_path(filename:split(AbsSource), filename:split(AbsTarget)).
 
 %% @private based on fragments of paths, replace the number of common
@@ -301,7 +265,7 @@ raw_src_dirs(Type, Opts, Default) ->
 
 %% @private normalizes relative paths so that ./a/b/c/ => a/b/c
 normalize_relative_path(Path) ->
-    make_normalized_path(filename:split(Path), []).
+    rebar_file_utils:normalized_path(filename:split(Path), []).
 
 %% @doc returns all the source directories (`src_dirs' and
 %% `extra_src_dirs').

--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -249,8 +249,8 @@ extra_src_dirs(Opts, Default) ->
 src_dirs(Type, Opts, Default) ->
     lists:usort([
         case D0 of
-            {D,_} -> normalize_relative_path(D);
-            _ -> normalize_relative_path(D0)
+            {D,_} -> rebar_file_utils:normalize_relative_path(D);
+            _ -> rebar_file_utils:normalize_relative_path(D0)
         end || D0 <- raw_src_dirs(Type,Opts,Default)]).
 
 %% @private extracts the un-formatted src_dirs or extra_src_dirs
@@ -262,10 +262,6 @@ raw_src_dirs(Type, Opts, Default) ->
         []   -> Default;
         Dirs -> Dirs
     end.
-
-%% @private normalizes relative paths so that ./a/b/c/ => a/b/c
-normalize_relative_path(Path) ->
-    rebar_file_utils:normalized_path(filename:split(Path), []).
 
 %% @doc returns all the source directories (`src_dirs' and
 %% `extra_src_dirs').

--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -45,7 +45,7 @@
          canonical_path/1,
          absolute_path/1,
          normalized_path/1,
-         normalized_path/2,
+         normalize_relative_path/1,
          resolve_link/1,
          split_dirname/1,
          ensure_dir/1]).
@@ -491,6 +491,11 @@ normalized_path([H|T], NormalizedPath) ->
         ".." when hd(NormalizedPath) =/= ".." -> normalized_path(T, tl(NormalizedPath));
         _    -> normalized_path(T, [H|NormalizedPath])
     end.
+
+%% @doc normalizes relative paths so that ./a/b/c/ => a/b/c
+-spec normalize_relative_path(string()) -> file:filename().
+normalize_relative_path(Path) ->
+    normalized_path(filename:split(Path), []).
 
 %% @doc returns canonical target of path if path is a link, otherwise returns path
 -spec resolve_link(string()) -> string().

--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -43,6 +43,9 @@
          touch/1,
          path_from_ancestor/2,
          canonical_path/1,
+         absolute_path/1,
+         normalized_path/1,
+         normalized_path/2,
          resolve_link/1,
          split_dirname/1,
          ensure_dir/1]).
@@ -452,6 +455,42 @@ canonical_path(Acc, ["."|Rest])       -> canonical_path(Acc, Rest);
 canonical_path([_|Acc], [".."|Rest])  -> canonical_path(Acc, Rest);
 canonical_path([], [".."|Rest])       -> canonical_path([], Rest);
 canonical_path(Acc, [Component|Rest]) -> canonical_path([Component|Acc], Rest).
+
+%% @doc make a path absolute
+-spec absolute_path(file:filename()) -> file:filename().
+absolute_path(Path) ->
+    case filename:pathtype(Path) of
+        absolute ->
+            Path;
+        relative ->
+            {ok, Dir} = file:get_cwd(),
+            filename:join([Dir, Path]);
+        volumerelative ->
+            Volume = hd(filename:split(Path)),
+            {ok, Dir} = file:get_cwd(Volume),
+            filename:join([Dir, Path])
+    end.
+
+%% @doc normalizing a path removes all of the `..' and the
+%% `.' segments it may contain.
+-spec normalized_path(file:filename()) -> file:filename().
+normalized_path(Path) ->
+    AbsPath = absolute_path(Path),
+    Components = filename:split(AbsPath),
+    normalized_path(Components, []).
+
+%% @private drops path fragments for normalization
+-spec normalized_path([string()], [string()]) -> file:filename().
+normalized_path([], NormalizedPath) ->
+    filename:join(lists:reverse(NormalizedPath));
+normalized_path([H|T], NormalizedPath) ->
+    case H of
+        "." when NormalizedPath == [], T == [] -> normalized_path(T, ["."]);
+        "."  -> normalized_path(T, NormalizedPath);
+        ".." when NormalizedPath == [] -> normalized_path(T, [".."]);
+        ".." when hd(NormalizedPath) =/= ".." -> normalized_path(T, tl(NormalizedPath));
+        _    -> normalized_path(T, [H|NormalizedPath])
+    end.
 
 %% @doc returns canonical target of path if path is a link, otherwise returns path
 -spec resolve_link(string()) -> string().


### PR DESCRIPTION
As suggested in #2223, `make_absolute_path/2` and `make_normalized_path/2`
should, instead of being exported in `rebar_dir`, be moved to
`rebar_file_utils` and renamed (decided to simply remove the `make`
from their names since in that module there is already a path related
function called `canonical_path`).