### PR TITLE
Add symlink to the `ct_run` of the last commot test run

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -78,6 +78,7 @@ do(State, Tests) ->
                     {ok, State};
                 Error ->
                     rebar_paths:set_paths([plugins, deps], State),
+                    symlink_to_last_ct_logs(State),
                     Error
             end;
         Error ->


### PR DESCRIPTION
Implements #1734. In case of not being able to create the
symlink rebar3 warns through `?DEBUG`.