### PR TITLE
Simplify windows script

### DIFF
--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -276,7 +276,5 @@ write_windows_script(Target) ->
     CmdPath = unicode:characters_to_list(Target) ++ ".cmd",
     CmdScript=
         "@echo off\r\n"
-        "setlocal\r\n"
-        "set rebarscript=%~f0\r\n"
-        "escript.exe \"%rebarscript:.cmd=%\" %*\r\n",
+        "escript.exe \"%~dpn0\" %*\r\n",
     ok = file:write_file(CmdPath, CmdScript).


### PR DESCRIPTION
setlocal not required as not setting rebarscript
rebarscript not required as we can use %~dpn0 directly
%~dpn0 is (d)irectory, (p)ath and (n)ame of script file, without (e)xtension.

**NOTE:** On windows, a clean clone of rebar3, bootstrap.bat, rebar3 escriptize, followed by rebar3 ct fails producing a rebar3.crashdump.

It also constantly says 
_===> Rebar3 detected a lock file from a newer version. It will be loaded in compatibility mode, but important information may be missing or lost. It is recommended to upgrade Rebar3._

Is that normal for master?