### PR TITLE
use setup-erlang instead of container for github action nightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       image: erlang:${{ matrix.otp_version }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,11 +10,12 @@ jobs:
     name: Publish escript for every merge to master
     runs-on: ubuntu-latest
 
-    container:
-      image: erlang:19
-
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
+    - uses: gleam-lang/setup-erlang@v1.0.0
+      with:
+        otp-version: 19.3.6.13
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       image: erlang:19
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Compile
       run: ./bootstrap
     - name: CT tests


### PR DESCRIPTION
The `aws` command is installed in `ubuntu-latest` but the commands were running in the container without it. Using `setup-erlang` it installs to the VM instead of running a container.