### PR TITLE
checking epmd is started without a crash

### DIFF
--- a/src/rebar_dist_utils.erl
+++ b/src/rebar_dist_utils.erl
@@ -51,7 +51,7 @@ find_options(State) ->
 %%% PRIVATE %%%
 %%%%%%%%%%%%%%%
 start(Name, Type, Opts) ->
-    case erl_epmd:names() of
+    case net_adm:names() of
         {error, _} ->
             start_epmd();
         {ok, _} ->

--- a/src/rebar_dist_utils.erl
+++ b/src/rebar_dist_utils.erl
@@ -51,13 +51,13 @@ find_options(State) ->
 %%% PRIVATE %%%
 %%%%%%%%%%%%%%%
 start(Name, Type, Opts) ->
-    case dist_up(net_kernel:start([Name, Type])) of
-        false ->
-            start_epmd(),
-            dist_up(net_kernel:start([Name, Type])) orelse warn_dist();
-        true ->
+    case erl_epmd:names() of
+        {error, _} ->
+            start_epmd();
+        {ok, _} ->
             ok
     end,
+    dist_up(net_kernel:start([Name, Type])) orelse warn_dist(),
     setup_cookie(Opts).
 
 dist_up({error,{{shutdown,{_,net_kernel,{'EXIT',nodistribution}}},_}}) -> false;


### PR DESCRIPTION
executing `rebar3 shell` when epmd is not running causes a crash log
```erlang
=SUPERVISOR REPORT==== 5-May-2020::10:44:23.655292 ===
    supervisor: {local,net_sup}
    errorContext: start_error
    reason: {'EXIT',nodistribution}
    offender: [{pid,undefined},
               {id,net_kernel},
               {mfargs,{net_kernel,start_link,
                                   [['dderl@127.0.0.1',longnames],false]}},
               {restart_type,permanent},
               {shutdown,2000},
               {child_type,worker}]
=CRASH REPORT==== 5-May-2020::10:44:23.654275 ===
  crasher:
    initial call: net_kernel:init/1
    pid: <0.550.0>
    registered_name: []
    exception exit: {error,badarg}
      in function  gen_server:init_it/6 (gen_server.erl, line 358)
    ancestors: [net_sup,kernel_sup,<0.46.0>]
    message_queue_len: 0
    messages: []
    links: [#Port<0.49>,<0.547.0>]
    dictionary: [{longnames,true}]
    trap_exit: true
    status: running
    heap_size: 376
    stack_size: 27
    reductions: 11369
  neighbours:
```
This PR checks if epmd is running using `erl_epmd:names/0`  