### PR TITLE
Another Compiler Refactor: Performance & Cleanup

### DIFF
--- a/src/rebar_compiler_dag.erl
+++ b/src/rebar_compiler_dag.erl
@@ -3,7 +3,7 @@
 -module(rebar_compiler_dag).
 -export([init/4, maybe_store/5, terminate/1]).
 -export([prune/5, populate_sources/5, populate_deps/3, propagate_stamps/1,
-         compile_order/2]).
+         compile_order/2, store_artifact/4]).
 
 -include("rebar.hrl").
 
@@ -191,6 +191,10 @@ maybe_store(G, Dir, Compiler, Label, CritMeta) ->
 %% Get rid of the live state for the digraph; leave disk stuff in place.
 terminate(G) ->
     true = digraph:delete(G).
+
+store_artifact(G, Source, Target, Meta) ->
+    digraph:add_vertex(G, Target, {artifact, Meta}),
+    digraph:add_edge(G, Target, Source, artifact).
 
 %%%%%%%%%%%%%%%
 %%% PRIVATE %%%

--- a/src/rebar_compiler_dag.erl
+++ b/src/rebar_compiler_dag.erl
@@ -405,8 +405,6 @@ find_app_(Path, [{AppPath, AppName}|Rest]) ->
             find_app_(Path, Rest)
     end.
 
-
-
 %% @private Return what should be the base name of an erl file, relocated to the
 %% target directory. For example:
 %% target_base("ebin/", "src/my_module.erl", ".erl", ".beam") -> "ebin/my_module.beam"

--- a/src/rebar_parallel.erl
+++ b/src/rebar_parallel.erl
@@ -1,0 +1,56 @@
+%%% @doc
+%%% This module contains a small parallel dispatch queue that allows
+%%% to take a list of jobs and run as many of them in parallel as there
+%%% are schedulers ongoing.
+%%%
+%%% Original design by Max Fedorov in the rebar compiler, then generalised
+%%% and extracted here to be reused in other circumstances.
+%%% @end
+-module(rebar_parallel).
+-export([queue/5]).
+-include("rebar.hrl").
+
+queue(Tasks, WorkF, WArgs, Handler, HArgs) ->
+    Parent = self(),
+    Worker = fun() -> worker(Parent, WorkF, WArgs) end,
+    Jobs = min(length(Tasks), erlang:system_info(schedulers)),
+    ?DEBUG("Starting ~B worker(s)", [Jobs]),
+    Pids = [spawn_monitor(Worker) || _ <- lists:seq(1, Jobs)],
+    parallel_dispatch(Tasks, Pids, Handler, HArgs).
+
+parallel_dispatch([], [], _, _) ->
+    [];
+parallel_dispatch(Targets, Pids, Handler, Args) ->
+    receive
+        {ready, Worker} when is_pid(Worker), Targets =:= [] ->
+            Worker ! empty,
+            parallel_dispatch(Targets, Pids, Handler, Args);
+        {ready, Worker} when is_pid(Worker) ->
+            [Task|Tasks] = Targets,
+            Worker ! {task, Task},
+            parallel_dispatch(Tasks, Pids, Handler, Args);
+        {'DOWN', Mref, _, Pid, normal} ->
+            NewPids = lists:delete({Pid, Mref}, Pids),
+            parallel_dispatch(Targets, NewPids, Handler, Args);
+        {'DOWN', _Mref, _, _Pid, Info} ->
+            ?ERROR("Task failed: ~p", [Info]),
+            ?FAIL;
+        {result, Result} ->
+            case Handler(Result, Args) of
+                ok ->
+                    parallel_dispatch(Targets, Pids, Handler, Args);
+                {ok, Acc} ->
+                    [Acc | parallel_dispatch(Targets, Pids, Handler, Args)]
+            end
+    end.
+
+worker(QueuePid, F, Args) ->
+    QueuePid ! {ready, self()},
+    receive
+        {task, Task} ->
+            QueuePid ! {result, F(Task, Args)},
+            worker(QueuePid, F, Args);
+        empty ->
+            ok
+    end.
+

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -309,7 +309,7 @@ build_rebar3_apps(DAGs, Apps, State) ->
     LastDAG = lists:last(DAGs),
     %% we actually need to compile each DAG one after the other to prevent
     %% issues where a .yrl file that generates a .erl file gets to be seen.
-    ?INFO("Analyzing applications", []),
+    ?INFO("Analyzing applications...", []),
     [begin
          {Ctx, ReorderedApps} = rebar_compiler:analyze_all(DAG, Apps),
          lists:foreach(


### PR DESCRIPTION
This is a big PR, more easily reviewed by commit.

## Changeset

- [Extract artifact tracking to DAG module ](https://github.com/erlang/rebar3/commit/90bead231032af39dcdf54dde47d85259cd1030a): I just cleaned up a thing that was a bad abstraction, and re-located artifact tracking within the DAG module. This was necessary when attempting an [unsuccessful parallelism effort](https://github.com/erlang/rebar3/compare/master...ferd:parallelize-compile) that didn't yield good results in practice. Also fixes a bug where `erl_first_file` entries weren't properly tracked in the DAG.
- [Extract & Generalize parallel queue from compiler](https://github.com/erlang/rebar3/commit/235543d398087694a1cc86ce558cb0794be4f4bd) where I take @max-au's code to turn module-level compiling parallel and moved it out to a standalone module. I believe the logic to run as many tasks as there are schedulers is worth reusing more internally (it was useful in my failed attempts). I believe this could be useful in further optimization work down the road.
That commit also fixes a few type issues and a latent bug in a bad pattern match that some plugins could have tripped on.
- [A few low-hanging fruits for a speedup](https://github.com/erlang/rebar3/commit/9a2898a6ee5ded14952046fb662694ef232f839f) by shifting common code out of a tight loop. In some cases, that could give me ~5-10% speedups on some builds.
- Finally there is [this big boy of a commit that fixes DAG pruning for extra_src_dirs in large repos](https://github.com/erlang/rebar3/commit/a2f10e31cfc8340dd69339783e95311f7f455231). This one is tricky so I'll expand on many paragraphs below.

We run the analysis for an extra_src_dir by making a fake app for it, but send in the app alone for analysis.

In the current master, the DAG pruning routine looks at the DAG and files submitted and goes "this right here is a project with 99% of its apps deleted". It then tries to prune the whole DAG except for some test files. The code "works" simply because there's a false-positive check that makes sure the file is on disk before removing it for the DAG. 

Of course this is a lot costlier than just checking the graph, And ends up making extra dir runs where ~80% of the time is spent double-checking the false positives for file deletions.

This commit fixes this by merging in all extra_src fake apps and making them run in a single analysis phase, meaning we only pay the cost of the DAG pruning once for the whole project, making it faster than any sparse repo.

There's also a small patch needed for the root-level extra src dirs; turns out that since the context-handling in the `rebar_compiler` uses a map to store content, running single-pass analysis clobbered entries for a given app if they had more than one extra_src_dir in there.

I also took the time to clean up the ordering of that file.

## Benchmarks
I replicated the troublesome monorepos of larger corporations that we have received reports about. The benchmark mostly focuses on "null" builds, where the app was already built and we just re-compile it a second time. This lets us evaluate the cost of just scanning for changes, without accounting for externalities like hooks or the Erlang compiler.

The problem mentioned was specifically with `rebar3 as test compile` being really dog slow due to `extra_src_dirs`

Set up an experiment by doing the following, which creates a project with over 300 apps, even if they contain only 2-3 modules each:

```zsh
→ rebar3 new umbrella extrapps
→ cd extrapps/apps/
→ for i in {1..300}     
  do
   rebar3 new app app_${i}
   mkdir app_${i}/test
   echo "-module(app_${i}_SUITE). " > app_${i}/test/app_${i}_SUITE.erl
done
→ cd ../
```

Here are my results as run on my small VPS with 2 cores.

* **Master**:
  * `rebar3 compile:  7.32s user 1.93s system 165% cpu 5.582 total` 
  * `rebar3 as test compile:  44.55s user 10.19s system 149% cpu 36.674 total` 
* **This PR**:
  * `rebar3 compile:  7.05s user 2.29s system 160% cpu 5.824 total`
  * `rebar3 as test compile:  10.47s user 2.10s system 128% cpu 9.819 total`

Having ~1 second of jitter either way on all runs was pretty predictable. There is no clear change either way on `rebar3 compile` but with `rebar3 as test compile` it's obvious that we're now going around 4x faster on that case. It's not a fixed cost though; it grows worse as you add more apps with more modules.
