### PR TITLE
Fix tests in Windows; adjust absolute paths

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -466,9 +466,10 @@ absolute_path(Path) ->
             {ok, Dir} = file:get_cwd(),
             filename:join([Dir, Path]);
         volumerelative ->
-            Volume = hd(filename:split(Path)),
+            [Letter, $: | _] = filename:nativename(filename:absname(Path)),
+            Volume = [Letter, $:],
             {ok, Dir} = file:get_cwd(Volume),
-            filename:join([Dir, Path])
+            Volume ++ filename:join([Dir, Path])
     end.
 
 %% @doc normalizing a path removes all of the `..' and the

--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -322,7 +322,7 @@ robocopy_mv_and_rename(Source, Dest, SrcDir, SrcName, DestDir, DestName) ->
     end.
 
 robocopy_file(SrcPath, DestPath, FileName) ->
-    Cmd = ?FMT("robocopy /move /e \"~ts\" \"~ts\" \"~ts\"",
+    Cmd = ?FMT("robocopy /move /e \"~ts\" \"~ts\" \"~ts\" 1> nul",
                [rebar_utils:escape_double_quotes(SrcPath),
                 rebar_utils:escape_double_quotes(DestPath),
                 rebar_utils:escape_double_quotes(FileName)]),
@@ -338,7 +338,7 @@ robocopy_file(SrcPath, DestPath, FileName) ->
     end.
 
 robocopy_dir(Source, Dest) ->
-    Cmd = ?FMT("robocopy /move /e \"~ts\" \"~ts\"",
+    Cmd = ?FMT("robocopy /move /e \"~ts\" \"~ts\" 1> nul",
                [rebar_utils:escape_double_quotes(Source),
                 rebar_utils:escape_double_quotes(Dest)]),
     Res = rebar_utils:sh(Cmd,

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -2534,13 +2534,17 @@ split_project_apps_hooks(Config) ->
     ok = filelib:ensure_dir(filename:join([AppDir2, "src", "dummy"])),
     ok = filelib:ensure_dir(filename:join([AppDir2, "include", "dummy"])),
     ok = filelib:ensure_dir(filename:join([HookDir, "dummy"])),
+    Cmd = case os:type() of
+        {win32, _} -> "dir /B";
+        _ -> "ls"
+    end,
     Cfg = fun(Name) ->
-        [{pre_hooks, [{compile, "ls "++HookDir++" > "++filename:join(HookDir, "pre-compile-"++Name)},
-                      {erlc_compile, "ls "++HookDir++" > "++filename:join(HookDir, "pre-erlc-"++Name)},
-                      {app_compile, "ls "++HookDir++" > "++filename:join(HookDir, "pre-app-"++Name)}]},
-         {post_hooks, [{compile, "ls "++HookDir++" > "++filename:join(HookDir, "post-compile-"++Name)},
-                       {erlc_compile, "ls "++HookDir++" > "++filename:join(HookDir, "post-erlc-"++Name)},
-                       {app_compile, "ls "++HookDir++" > "++filename:join(HookDir, "post-app-"++Name)}]}
+        [{pre_hooks, [{compile,      Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "pre-compile-"++Name)++"\""},
+                      {erlc_compile, Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "pre-erlc-"++Name)++"\""},
+                      {app_compile,  Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "pre-app-"++Name)++"\""}]},
+         {post_hooks, [{compile,      Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "post-compile-"++Name)++"\""},
+                       {erlc_compile, Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "post-erlc-"++Name)++"\""},
+                       {app_compile,  Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "post-app-"++Name)++"\""}]}
         ]
     end,
     ok = file:write_file(filename:join(AppDir1, "rebar.config"),

--- a/test/rebar_file_utils_SUITE.erl
+++ b/test/rebar_file_utils_SUITE.erl
@@ -150,9 +150,11 @@ canonical_path(_Config) ->
 
 absolute_path(_Config) ->
     %% We find the root so that the name works both on unix-likes and
-    %% with Windows.
+    %% with Windows. Starting on OTP-22, filename:join/1 drops the drive letter,
+    %% and split/1 and absname both normalize c:\\ to c:/ -- going onwards, we
+    %% start normalizing the same way as well to prevent issues.
     Root = case os:type() of
-               {win32, _} -> filename:nativename(filename:absname("/")); % C:\, with proper drive
+               {win32, _} -> filename:absname(filename:nativename("/")); % C:\, with proper drive
                _ -> "/"
            end,
     ?assertEqual(filename:absname(Root), rebar_file_utils:absolute_path("/")),
@@ -165,18 +167,20 @@ absolute_path(_Config) ->
 
 normalized_path(_Config) ->
     %% We find the root so that the name works both on unix-likes and
-    %% with Windows.
+    %% with Windows. Starting on OTP-22, filename:join/1 drops the drive letter,
+    %% and split/1 and absname both normalize c:\\ to c:/ -- going onwards, we
+    %% start normalizing the same way as well to prevent issues.
     Root = case os:type() of
-               {win32, _} -> filename:nativename(filename:absname("/")); % C:\, with proper drive
+               {win32, _} -> filename:absname(filename:nativename("/")); % c:/, with proper drive
                _ -> "/"
            end,
-    ?assertEqual(filename:nativename(Root), rebar_file_utils:normalized_path("/")),
+    ?assertEqual(Root, rebar_file_utils:normalized_path("/")),
     ?assertEqual("../..", rebar_file_utils:normalized_path("/../../..")),
     ?assertEqual(Root ++ "foo", rebar_file_utils:normalized_path("/foo/bar/..")),
     ?assertEqual(Root ++ "foo", rebar_file_utils:normalized_path("/foo/../foo")),
     ?assertEqual(Root ++ "foo", rebar_file_utils:normalized_path("/foo/.")),
     ?assertEqual(Root ++ "foo", rebar_file_utils:normalized_path("/foo/./.")),
-    ?assertEqual(filename:nativename(Root ++ "foo/bar"),
+    ?assertEqual(Root ++ "foo/bar",
                  rebar_file_utils:normalized_path("/foo/./bar")).
 
 resolve_link(_Config) ->

--- a/test/rebar_hooks_SUITE.erl
+++ b/test/rebar_hooks_SUITE.erl
@@ -133,8 +133,12 @@ bare_compile_hooks_default_ns(Config) ->
 
     HookFile = filename:join([?config(priv_dir, Config), "bare-post.hook"]),
 
+    Cmd = case os:type() of
+        {win32, _} -> "dir";
+        _ -> "ls"
+    end,
     ConfOpts = [{provider_hooks, [{post, [{compile, clean}]}]},
-                {post_hooks, [{compile, "ls > " ++ HookFile}]}],
+                {post_hooks, [{compile, Cmd ++ " > " ++ HookFile}]}],
     RConfFile = rebar_test_utils:create_config(AppDir, ConfOpts),
     {ok, RConf} = file:consult(RConfFile),
     rebar_test_utils:run_and_check(


### PR DESCRIPTION
Starting with OTP-22, Erlang started changing how volume names are handled in
windows: filename:join/1 drops drive letters, filename:split/2 and
file:absname/1 use c:/ as a form instead of c:\\\\

We adjust the file_utils and their tests accordingly.

Rebar3.14 has new tests that were not windows ready and those are fixed.

Relx has two failing tests that are not covered in this branch.

Tested in Windows 10 with Powershell.