### PR TITLE
Name the app being escriptized

### DIFF
--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -85,7 +85,7 @@ do(State) ->
             Err;
         _ ->
             AppInfo1 = rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, AppInfo0, State),
-            ?INFO("Building escript...", []),
+            ?INFO("Building escript for ~s...", [rebar_app_info:name(AppInfo0)]),
             Res = escriptize(State, AppInfo1),
             rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, AppInfo1, State),
             Res


### PR DESCRIPTION
Since the compiler refactor changed the order of steps and all hooks get
applied at once, knowing which app is being escriptized isn't really
obvious, particularly when many apps individually define their own 'main
app' and they get run at once.

This adds the name of the main app being run when escriptizing it to make
it clear what goes on, especially if there are failures.

This was reported in https://github.com/erlang/rebar3/pull/2211#issuecomment-615937628