### PR TITLE
revert change to lock for regular git resource from PR #2239

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -10,8 +10,7 @@
  {<<"providers">>,{pkg,<<"providers">>,<<"1.8.1">>},0},
  {<<"relx">>,
   {git,"https://github.com/erlware/relx.git",
-       {ref,"aa6c81d265986f223fa347cacf3b9691e7b56f2f"},
-       []},
+       {ref,"aa6c81d265986f223fa347cacf3b9691e7b56f2f"}},
   0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.5">>},0}]}.
 [


### PR DESCRIPTION
Not all of the changes to the git resource were reverted when
the sparse checkout support was moved to a new resource,
git_subdir_resource. This fixes issues caused by these changes
that were accidentally left.