### PR TITLE
add --all option for release building in parallel

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
         {getopt,              "1.0.1"},
         {bbmustache,          "1.8.0"},
         %% {relx,                "3.33.0"},
-        {relx, {git, "https://github.com/erlware/relx.git", {branch, "4.0.0"}}},
+        {relx, {git, "https://github.com/erlware/relx.git", {branch, "master"}}},
         {cf,                  "0.2.2"},
         {cth_readable,        "1.4.8"},
         {eunit_formatters,    "0.5.0"}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -10,7 +10,7 @@
  {<<"providers">>,{pkg,<<"providers">>,<<"1.8.1">>},0},
  {<<"relx">>,
   {git,"https://github.com/erlware/relx.git",
-       {ref,"aa6c81d265986f223fa347cacf3b9691e7b56f2f"}},
+       {ref,"0182d6aeca73c99c4fffaf7a94c8d21b2be3aa74"}},
   0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.5">>},0}]}.
 [

--- a/rebar.lock
+++ b/rebar.lock
@@ -10,7 +10,7 @@
  {<<"providers">>,{pkg,<<"providers">>,<<"1.8.1">>},0},
  {<<"relx">>,
   {git,"https://github.com/erlware/relx.git",
-       {ref,"0182d6aeca73c99c4fffaf7a94c8d21b2be3aa74"}},
+       {ref,"0d9d6255a53af63927f826c0b827b3741a8ed458"}},
   0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.5">>},0}]}.
 [


### PR DESCRIPTION
I haven't gone over this closely after realizing its blocked by https://bugs.erlang.org/browse/ERL-715 but I figured I'd still open this PR for reviews.

I may work on resolving the `release_handler` issues myself so this can be merged sooner than later.