### PR TITLE
Add powershell script generation option for escriptize on windows; use for rebar3 itself

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,6 @@ jobs:
     - name: Install Erlang
       run: choco install erlang
     - name: Compile
-      run: cmd.exe /c 'bootstrap.bat'
+      run: bootstrap.ps1
     - name: CT tests
-      run: cmd.exe /c 'rebar3.cmd ct'
+      run: rebar3.ps1 ct

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,6 @@ jobs:
     - name: Install Erlang
       run: choco install erlang
     - name: Compile
-      run: bootstrap.ps1
+      run: .\bootstrap.ps1
     - name: CT tests
-      run: rebar3.ps1 ct
+      run: .\rebar3.ps1 ct

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _checkouts
 .rebar3
 rebar3
 rebar3.cmd
+rebar3.ps1
 _build
 .depsolver_plt
 *.beam

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,1 @@
+& escript.exe bootstrap @args

--- a/rebar.config
+++ b/rebar.config
@@ -24,6 +24,7 @@
              ]}.
 
 {escript_name, rebar3}.
+{escript_wrappers_windows, ["cmd", "powershell"]}.
 {escript_comment, "%%Rebar3 3.14.0-rc1\n"}.
 {escript_emu_args, "%%! +sbtu +A1\n"}.
 %% escript_incl_extra is for internal rebar-private use only.

--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -149,6 +149,8 @@
 {escript_main_app, application}.
 %% Name of the resulting escript executable
 {escript_name, "application"}.
+%% Wrapper type(s) for escript executable on windows
+{escript_wrappers_windows, ["cmd","powershell"]}.
 %% apps (other than main and deps) to be included
 {escript_incl_apps, []}.
 %% Executable escript lines

--- a/rebar3.ps1
+++ b/rebar3.ps1
@@ -1,0 +1,1 @@
+& escript.exe (Get-Item $PSCommandPath).Basename @args

--- a/rebar3.ps1
+++ b/rebar3.ps1
@@ -1,1 +1,0 @@
-& escript.exe (Get-Item $PSCommandPath).Basename @args

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -143,7 +143,7 @@ escriptize(State0, App) ->
             {ok, #file_info{mode = Mode}} = file:read_file_info(Filename),
             ok = file:change_mode(Filename, Mode bor 8#00111);
         {win32, _} ->
-            write_windows_scripts(Filename, rebar_state:get(State, escript_wrappers_windows, []))
+            write_windows_scripts(Filename, rebar_state:get(State, escript_wrappers_windows, ["cmd"]))
     end,
     {ok, State}.
 

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -143,7 +143,7 @@ escriptize(State0, App) ->
             {ok, #file_info{mode = Mode}} = file:read_file_info(Filename),
             ok = file:change_mode(Filename, Mode bor 8#00111);
         {win32, _} ->
-            write_windows_script(Filename)
+            write_windows_scripts(Filename, rebar_state:get(State, escript_wrappers_windows, []))
     end,
     {ok, State}.
 
@@ -272,9 +272,17 @@ def(Rm, State, Key, Default) ->
 rm_newline(String) ->
     [C || C <- String, C =/= $\n].
 
-write_windows_script(Target) ->
+write_windows_scripts(Target, Wrappers) ->
+    lists:foreach(fun(Wrapper) -> write_windows_script(Target, Wrapper) end, Wrappers).
+
+write_windows_script(Target, "powershell") ->
+    CmdPath = unicode:characters_to_list(Target) ++ ".ps1",
+    CmdScript="& escript.exe (Get-Item $PSCommandPath).Basename @args\r\n",
+    ok = file:write_file(CmdPath, CmdScript);
+write_windows_script(Target, _) ->
     CmdPath = unicode:characters_to_list(Target) ++ ".cmd",
     CmdScript=
         "@echo off\r\n"
         "escript.exe \"%~dpn0\" %*\r\n",
     ok = file:write_file(CmdPath, CmdScript).
+

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -277,7 +277,7 @@ write_windows_scripts(Target, Wrappers) ->
 
 write_windows_script(Target, "powershell") ->
     CmdPath = unicode:characters_to_list(Target) ++ ".ps1",
-    CmdScript="& escript.exe (Get-Item $PSCommandPath).Basename @args\r\n",
+    CmdScript="& escript.exe \"$PSScriptRoot\\$((Get-Item $PSCommandPath).Basename)\" @args\r\n",
     ok = file:write_file(CmdPath, CmdScript);
 write_windows_script(Target, _) ->
     CmdPath = unicode:characters_to_list(Target) ++ ".cmd",


### PR DESCRIPTION
You must have been expecting this ;)

This adds bootstrap.ps1 and a powershell escriptize wrapper for windows.

rebar.config setting is, for example, `{escript_wrappers_windows, ["cmd", "powershell"]}` which will write BOTH <escript>.cmd and <escript>.ps1.

Can be set to both, one, the other, or none at all.

Updated rebar.config to create both.

Updated workflow to make use of ps1 version.