### PR TITLE
Support ENV var for mix in the bare compiler

### DIFF
--- a/src/rebar_prv_bare_compile.erl
+++ b/src/rebar_prv_bare_compile.erl
@@ -53,7 +53,11 @@ do(State) ->
     {RawOpts, _} = rebar_state:command_parsed_args(State),
     Paths = proplists:get_value(paths, RawOpts),
     Sep = proplists:get_value(separator, RawOpts, " "),
-    OutDir = proplists:get_value(outdir, RawOpts, rebar_dir:get_cwd()),
+    %% Because mix won't check for versions, it instead sets this variable
+    %% that it knows older rebar3 version will ignore so we play nice and
+    %% honor it.
+    DefaultOutDir = os:getenv("REBAR_BARE_COMPILER_OUTPUT_DIR", rebar_dir:get_cwd()),
+    OutDir = proplists:get_value(outdir, RawOpts, DefaultOutDir),
     [ code:add_pathsa(filelib:wildcard(PathWildcard))
       || PathWildcard <- rebar_string:lexemes(Paths, Sep) ],
 


### PR DESCRIPTION
None of the version checks are considered safe enough by mix
maintainers, and so the agreed upon mechanism is to just set this
environment variable, which will be supported implicitly by rebar3
versions that can handle it.

This lets build artifacts (aside from some priv/ issues with plugins) to
properly be located within their build folder rather than the deps
folder, as the --outdir switch would otherwise have done.

CC @starbelly was this merged in mix?