### PR TITLE
Fix git_subdir after "revert change to lock for regular git resource"

### DIFF
--- a/src/rebar_git_subdir_resource.erl
+++ b/src/rebar_git_subdir_resource.erl
@@ -22,7 +22,7 @@ init(Type, _State) ->
 
 lock(AppInfo, _) ->
     {git_subdir, Url, Checkout, Dir} = rebar_app_info:source(AppInfo),
-    {git, Url1, {ref, Ref}, _Opts} =
+    {git, Url1, {ref, Ref}} =
         rebar_git_resource:lock_(rebar_app_info:dir(AppInfo), {git, Url, Checkout}),
     {git_subdir, Url1, {ref, Ref}, Dir}.
 


### PR DESCRIPTION
Commit 029cbcc7 changed the return value of `rebar_git_resource:lock_/2`