### PR TITLE
Escape more characters for shell stuff

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -962,7 +962,7 @@ url_append_path(Url, ExtraPath) ->
 escape_chars(Str) when is_atom(Str) ->
     escape_chars(atom_to_list(Str));
 escape_chars(Str) ->
-    re:replace(Str, "([ ()?`!$&;\"\'])", "\\\\&",
+    re:replace(Str, "([ ()?`!$&;\"\'\|\\t|~<>])", "\\\\&",
                [global, {return, list}, unicode]).
 
 %% "escape inside these"


### PR DESCRIPTION
As reported by Alexey Pronin, this would let people potentially pass in
URLs that can call to command execution.

While running arbitrary code is kind of our bread and butter, it makes
sense to at least play nicely and escape more characters:

- the pipe (`|`) which can be used to run subcommands
- the tab (`\t`) which the shell interprets as a space.
- the home directory (`~`) just because the expansion could behave funny
- redirection (`<` and `>`) to avoid problems with data setting up
  streams