### PR TITLE
add vsn that is the evaluated application vsn

### DIFF
--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -364,8 +364,9 @@ create_app_info(AppInfo, AppDir, AppFile) ->
             Applications = proplists:get_value(applications, AppDetails, []),
             IncludedApplications = proplists:get_value(included_applications, AppDetails, []),
             AppInfo1 = rebar_app_info:name(
-                         rebar_app_info:original_vsn(
-                           rebar_app_info:dir(AppInfo, AppDir), AppVsn), AppName),
+                         rebar_app_info:vsn(
+                           rebar_app_info:original_vsn(
+                             rebar_app_info:dir(AppInfo, AppDir), AppVsn), AppVsn), AppName),
             AppInfo2 = rebar_app_info:applications(
                          rebar_app_info:app_details(AppInfo1, AppDetails), Applications),
             AppInfo3 = rebar_app_info:included_applications(AppInfo2, IncludedApplications),

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -25,6 +25,8 @@
          parent/2,
          original_vsn/1,
          original_vsn/2,
+         vsn/1,
+         vsn/2,
          priv_dir/1,
          applications/1,
          applications/2,
@@ -86,6 +88,7 @@
                      app_file_src_script:: file:filename_all() | undefined,
                      app_file           :: file:filename_all() | undefined,
                      original_vsn       :: binary() | undefined,
+                     vsn                :: binary() | undefined,
                      parent=root        :: binary() | root,
                      app_details=[]     :: list(),
                      applications=[]    :: list(),
@@ -131,6 +134,7 @@ new(AppName) ->
                  {ok, t()}.
 new(AppName, Vsn) ->
     {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
+                     vsn=Vsn,
                      original_vsn=Vsn}}.
 
 %% @doc build a complete version of the app info with all fields set.
@@ -138,6 +142,7 @@ new(AppName, Vsn) ->
                  {ok, t()}.
 new(AppName, Vsn, Dir) ->
     {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
+                     vsn=Vsn,
                      original_vsn=Vsn,
                      fetch_dir=rebar_utils:to_list(Dir),
                      dir=rebar_utils:to_list(Dir),
@@ -149,6 +154,7 @@ new(AppName, Vsn, Dir) ->
                  {ok, t()}.
 new(AppName, Vsn, Dir, Deps) ->
     {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
+                     vsn=Vsn,
                      original_vsn=Vsn,
                      fetch_dir=rebar_utils:to_list(Dir),
                      dir=rebar_utils:to_list(Dir),
@@ -162,6 +168,7 @@ new(AppName, Vsn, Dir, Deps) ->
 new(Parent, AppName, Vsn, Dir, Deps) ->
     {ok, #app_info_t{name=rebar_utils:to_binary(AppName),
                      parent=Parent,
+                     vsn=Vsn,
                      original_vsn=Vsn,
                      fetch_dir=rebar_utils:to_list(Dir),
                      dir=rebar_utils:to_list(Dir),
@@ -170,7 +177,7 @@ new(Parent, AppName, Vsn, Dir, Deps) ->
                      deps=Deps}}.
 
 app_to_map(#app_info_t{name=Name,
-                       original_vsn=Vsn,
+                       vsn=Vsn,
                        applications=Applications,
                        included_applications=IncludedApplications,
                        out_dir=OutDir,
@@ -420,6 +427,16 @@ original_vsn(#app_info_t{original_vsn=Vsn}) ->
 -spec original_vsn(t(), binary() | string()) -> t().
 original_vsn(AppInfo=#app_info_t{}, Vsn) ->
     AppInfo#app_info_t{original_vsn=Vsn}.
+
+%% @doc returns the version of the app after evaluation
+-spec vsn(t()) -> binary().
+vsn(#app_info_t{vsn=Vsn}) ->
+    Vsn.
+
+%% @doc sets the evaluated vsn of the app
+-spec vsn(t(), binary() | string()) -> t().
+vsn(AppInfo=#app_info_t{}, Vsn) ->
+    AppInfo#app_info_t{vsn=Vsn}.
 
 %% @doc returns the list of applications the app depends on.
 -spec applications(t()) -> list().

--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -46,12 +46,10 @@ compile(State, App) ->
                        undefined ->
                            App;
                        AppFileSrc ->
-                           File = preprocess(State, App, AppFileSrc),
-                           rebar_app_info:app_file(App, File)
+                           preprocess(State, App, AppFileSrc)
                    end;
                AppFileSrcScript ->
-                   File = preprocess(State, App, AppFileSrcScript),
-                   rebar_app_info:app_file(App, File)
+                   preprocess(State, App, AppFileSrcScript)
            end,
 
     %% Load the app file and validate it.
@@ -92,12 +90,12 @@ validate_app_modules(State, App, AppData) ->
         true ->
             case rebar_app_utils:validate_application_info(App, AppData) of
                 true ->
-                    {ok, rebar_app_info:original_vsn(App, AppVsn)};
+                    {ok, rebar_app_info:original_vsn(rebar_app_info:vsn(App, AppVsn), AppVsn)};
                 Error ->
                     Error
             end;
         false ->
-            {ok, rebar_app_info:original_vsn(App, AppVsn)}
+            {ok, rebar_app_info:original_vsn(rebar_app_info:vsn(App, AppVsn), AppVsn)}
     end.
 
 preprocess(State, AppInfo, AppSrcFile) ->
@@ -130,7 +128,7 @@ preprocess(State, AppInfo, AppSrcFile) ->
             AppFile = rebar_app_utils:app_src_to_app(OutDir, AppSrcFile),
             ok = rebar_file_utils:write_file_if_contents_differ(AppFile, Spec, utf8),
 
-            AppFile;
+            rebar_app_info:app_file(rebar_app_info:vsn(AppInfo, Vsn), AppFile);
         {error, Reason} ->
             throw(?PRV_ERROR({file_read, rebar_app_info:name(AppInfo), ".app.src", Reason}))
     end.

--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -85,17 +85,16 @@ validate_app_modules(State, App, AppData) ->
     %% In general, the list of modules is an important thing to validate
     %% for compliance with OTP guidelines and upgrade procedures.
     %% However, some people prefer not to validate this list.
-    AppVsn = proplists:get_value(vsn, AppData),
     case rebar_state:get(State, validate_app_modules, true) of
         true ->
             case rebar_app_utils:validate_application_info(App, AppData) of
                 true ->
-                    {ok, rebar_app_info:original_vsn(rebar_app_info:vsn(App, AppVsn), AppVsn)};
+                    {ok, App};
                 Error ->
                     Error
             end;
         false ->
-            {ok, rebar_app_info:original_vsn(rebar_app_info:vsn(App, AppVsn), AppVsn)}
+            {ok, App}
     end.
 
 preprocess(State, AppInfo, AppSrcFile) ->

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -40,13 +40,14 @@ do(State) ->
 
     Providers = rebar_state:providers(State),
     Deps = rebar_state:deps_to_build(State),
-    copy_and_build_apps(State, Providers, Deps),
+    CompiledDeps = copy_and_build_apps(State, Providers, Deps),
+    State0 = rebar_state:merge_all_deps(State, CompiledDeps),
 
     State1 = case IsDepsOnly of
                  true ->
-                     State;
+                     State0;
                  false ->
-                     handle_project_apps(Providers, State)
+                     handle_project_apps(Providers, State0)
              end,
 
     rebar_paths:set_paths([plugins], State1),

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -31,7 +31,7 @@
          project_apps/1, project_apps/2,
          deps_to_build/1, deps_to_build/2,
          all_plugin_deps/1, all_plugin_deps/2, update_all_plugin_deps/2,
-         all_deps/1, all_deps/2, update_all_deps/2,
+         all_deps/1, all_deps/2, update_all_deps/2, merge_all_deps/2,
          namespace/1, namespace/2,
 
          deps_names/1,
@@ -353,6 +353,9 @@ update_all_plugin_deps(State=#state_t{all_plugin_deps=Apps}, NewApps) ->
 
 update_all_deps(State=#state_t{all_deps=Apps}, NewApps) ->
     State#state_t{all_deps=Apps++NewApps}.
+
+merge_all_deps(State=#state_t{all_deps=Apps}, UpdatedApps) when is_list(UpdatedApps) ->
+    State#state_t{all_deps=lists:ukeymerge(2, lists:keysort(2, UpdatedApps), lists:keysort(2, Apps))}.
 
 namespace(#state_t{namespace=Namespace}) ->
     Namespace.


### PR DESCRIPTION
I forgot to push this and don't remember if it was complete or not.

The issue was pointed out by @max-au with the latest relx. It would get the vsn like, `{cmd, "..."}` or `git` instead of what that evaluates to. The change is to have a separate key for the evaluated version and the original version.