### PR TITLE
Extract rebar3 libs in a version dependent directory when using local commands

### DIFF
--- a/src/rebar_prv_local_install.erl
+++ b/src/rebar_prv_local_install.erl
@@ -83,6 +83,9 @@ extract_escript(State, ScriptPath) ->
             throw(?PRV_ERROR({non_writeable, OutputDir}))
     end,
 
+    ?INFO("Removing existing rebar3 libs from ~ts...", [OutputDir]),
+    rebar_file_utils:rm_rf(filename:join(OutputDir, "*")),
+
     ?INFO("Extracting rebar3 libs to ~ts...", [OutputDir]),
     zip:extract(Archive, [{cwd, OutputDir}]),
 


### PR DESCRIPTION
Removes all existing applications in `~/.cache/rebar3/lib` while leaving the top-level directory (`lib`) intact.

Should close #2307, as `local upgrade` calls to `local install`'s `extract_escript`.

I did not find any tests related to either module, if there's any let me know so that I can update this PR :)