### PR TITLE
prv_plugins_upgrade: fix compilation of upgraded plugins

### DIFF
--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -6,7 +6,7 @@
          do/1,
          format_error/1]).
 
--export([compile/2, compile/3]).
+-export([compile/2, compile/3, compile/4]).
 
 -include_lib("providers/include/providers.hrl").
 -include("rebar.hrl").

--- a/test/rebar_plugins_SUITE.erl
+++ b/test/rebar_plugins_SUITE.erl
@@ -191,13 +191,17 @@ upgrade(Config) ->
                    {{iolist_to_binary(PkgName), <<"0.1.1">>}, []}]}
     ]),
 
+    %% beam file to verify plugin is acutally compiled
+    PluginBeam = filename:join([AppDir, "_build", "default", "plugins",
+                                PkgName, "ebin", [PkgName, ".beam"]]),
+
     RConfFile = rebar_test_utils:create_config(AppDir, [{plugins, [list_to_atom(PkgName)]}]),
     {ok, RConf} = file:consult(RConfFile),
 
     %% Build with deps.
     rebar_test_utils:run_and_check(
         Config, RConf, ["compile"],
-        {ok, [{app, Name}, {plugin, PkgName, <<"0.1.1">>}]}
+        {ok, [{app, Name, valid}, {file, PluginBeam}, {plugin, PkgName, <<"0.1.1">>}]}
      ),
 
     catch mock_pkg_resource:unmock(),
@@ -212,7 +216,7 @@ upgrade(Config) ->
     %% Build with deps.
     rebar_test_utils:run_and_check(
         Config, RConf, ["plugins", "upgrade", PkgName],
-        {ok, [{app, Name}, {plugin, PkgName, <<"0.1.3">>}]}
+        {ok, [{app, Name, valid}, {file, PluginBeam}, {plugin, PkgName, <<"0.1.3">>}]}
      ).
 
 upgrade_project_plugin(Config) ->


### PR DESCRIPTION
this fixes the issue where using 'rebar3 plugins upgrade P'
would result in a plugin's .app file having an empty
modules list. The code this replaces hadn't been touched
since rebar3 3.0.0-beta.3 and a lot of improvements have
gone into dep handling and the compiler since then. This
change should take advantage of those changes.