### PR TITLE
Trigger rebuilds when OTP compiler version changes

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -20,10 +20,11 @@ main(_) ->
     %% cause weird failures when compilers get modified between releases.
     rm_rf("_build/prod"),
     %% The same pattern happens with default/ as well, particularly when
-    %% developing new things. 
-    %% Keep other deps in default/lib for build environments like Nix
+    %% developing new things.
+    %% Keep other deps in <profile>/lib for build environments like Nix
     %% where internet access is disabled that deps are not downloadable.
     rm_rf("_build/default/lib/rebar"),
+    rm_rf("_build/test/lib/rebar"),
 
     %% We fetch a few deps from hex for boostraping,
     %% so we must compile r3_safe_erl_term.xrl which

--- a/src/rebar_compiler.erl
+++ b/src/rebar_compiler.erl
@@ -215,6 +215,7 @@ prepare_compiler_env(Compiler, Apps) ->
     %% necessary for erlang:function_exported/3 to work as expected
     %% called here for clarity as it's required by both opts_changed/2
     %% and erl_compiler_opts_set/0 in needed_files
+    application:load(compiler),
     _ = code:ensure_loaded(compile),
     _ = code:ensure_loaded(Compiler),
     ok.

--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -145,9 +145,10 @@ compile_and_track(Source, [{Ext, OutDir}], Config, ErlOpts) ->
     rebar_compiler_epp:flush(),
     BuildOpts = [{outdir, OutDir} | ErlOpts],
     Target = target_base(OutDir, Source) ++ Ext,
+    {ok, CompileVsn} = application:get_key(compiler, vsn),
     AllOpts = case erlang:function_exported(compile, env_compiler_options, 0) of
-        true  -> BuildOpts ++ compile:env_compiler_options();
-        false -> BuildOpts
+        true  -> [{compiler_version, CompileVsn}] ++ BuildOpts ++ compile:env_compiler_options();
+        false -> [{compiler_version, CompileVsn}] ++ BuildOpts
     end,
     case compile:file(Source, BuildOpts) of
         {ok, _Mod} ->
@@ -237,9 +238,10 @@ target_base(OutDir, Source) ->
     filename:join(OutDir, filename:basename(Source, ".erl")).
 
 opts_changed(Graph, NewOpts, Target, TargetBase) ->
+    {ok, CompileVsn} = application:get_key(compiler, vsn),
     TotalOpts = case erlang:function_exported(compile, env_compiler_options, 0) of
-        true  -> NewOpts ++ compile:env_compiler_options();
-        false -> NewOpts
+        true  -> [{compiler_version, CompileVsn}] ++ NewOpts ++ compile:env_compiler_options();
+        false -> [{compiler_version, CompileVsn}] ++ NewOpts
     end,
     TargetOpts = case digraph:vertex(Graph, Target) of
         {_Target, {artifact, Opts}} -> % tracked dep is found
@@ -273,7 +275,9 @@ compile_info(Target) ->
     case beam_lib:chunks(Target, [compile_info]) of
         {ok, {_mod, Chunks}} ->
             CompileInfo = proplists:get_value(compile_info, Chunks, []),
-            {ok, proplists:get_value(options, CompileInfo, [])};
+            CompileVsn = proplists:get_value(version, CompileInfo, "unknown"),
+            {ok, [{compiler_version, CompileVsn}
+                  | proplists:get_value(options, CompileInfo, [])]};
         {error, beam_lib, Reason} ->
             ?WARN("Couldn't read debug info from ~p for reason: ~p", [Target, Reason]),
             {error, Reason}

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -113,11 +113,16 @@ handle_plugin(Profile, Plugin, State, Upgrade) ->
         ToBuild = rebar_prv_install_deps:cull_compile(Sorted, []),
 
         %% Add already built plugin deps to the code path
-        PreBuiltPaths = [rebar_app_info:ebin_dir(A) || A <- Apps] -- ToBuild,
+        ToBuildPaths = [rebar_app_info:ebin_dir(A) || A <- ToBuild],
+        PreBuiltApps = [A || A <- Apps,
+                             Ebin <- [rebar_app_info:ebin_dir(A)],
+                             not lists:member(Ebin, ToBuildPaths)],
+        {PreUnsafe, PreSafe} = lists:partition(fun needs_rebuild/1, PreBuiltApps),
+        PreBuiltPaths = [rebar_app_info:ebin_dir(A) || A <- PreSafe],
         code:add_pathsa(PreBuiltPaths),
 
         %% Build plugin and its deps
-        [build_plugin(AppInfo, Apps, State2) || AppInfo <- ToBuild],
+        [build_plugin(AppInfo, Apps, State2) || AppInfo <- PreUnsafe++ToBuild],
 
         %% Add newly built deps and plugin to code path
         State3 = rebar_state:update_all_plugin_deps(State2, Apps),
@@ -163,5 +168,41 @@ validate_plugin(Plugin) ->
                     [];
                 true ->
                     [Plugin]
+            end
+    end.
+
+%% @private do a quick validation of whether a plugin is expected to need
+%% to be rebuilt; usually this is handled by the compiler, but since this
+%% module does quick filtering by detection, we need to discriminate against
+%% cases like the compiler version having changed that would otherwise
+%% trigger a rebuild.
+needs_rebuild(AppInfo) ->
+    Ebin = rebar_app_info:ebin_dir(AppInfo),
+    application:load(compiler),
+    {ok, CurrentCompileVsn} = application:get_key(compiler, vsn),
+    case find_some_beam(Ebin) of
+        {ok, Beam} ->
+            case beam_lib:chunks(Beam, [compile_info]) of
+                {ok, {_mod, Chunks}} ->
+                    CompileInfo = proplists:get_value(compile_info, Chunks, []),
+                    CompileVsn = proplists:get_value(version, CompileInfo, "unknown"),
+                    CurrentCompileVsn =/= CompileVsn;
+                _ ->
+                    %% could be built without debug_info
+                    false
+            end;
+        _ ->
+            %% well we would expect a plugin to have a beam file
+            true
+    end.
+
+find_some_beam(Path) ->
+    case file:list_dir(Path) of
+        {error, Reason} ->
+            {error, Reason};
+        {ok, Files} ->
+            case lists:dropwhile(fun(P) -> filename:extension(P) =/= ".beam" end, Files) of
+                [Beam|_] -> {ok, filename:join(Path, Beam)};
+                _ -> {error, no_beam}
             end
     end.

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -114,14 +114,13 @@ handle_plugin(Profile, Plugin, State, Upgrade) ->
 
         %% Add already built plugin deps to the code path
         ToBuildPaths = [rebar_app_info:ebin_dir(A) || A <- ToBuild],
-        PreBuiltApps = [A || A <- Apps,
-                             Ebin <- [rebar_app_info:ebin_dir(A)],
-                             not lists:member(Ebin, ToBuildPaths)],
-        PreBuiltPaths = [rebar_app_info:ebin_dir(A) || A <- PreBuiltApps],
+        PreBuiltPaths = [Ebin || A <- Apps,
+                                 Ebin <- [rebar_app_info:ebin_dir(A)],
+                                 not lists:member(Ebin, ToBuildPaths)],
         code:add_pathsa(PreBuiltPaths),
 
         %% Build plugin and its deps
-        build_plugins(ToBuild -- PreBuiltApps, Apps, State2),
+        build_plugins(ToBuild, Apps, State2),
 
         %% Add newly built deps and plugin to code path
         State3 = rebar_state:update_all_plugin_deps(State2, Apps),

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -436,7 +436,8 @@ warn_skip_deps(AppInfo, State) ->
 not_needs_compile(App) ->
     not(rebar_app_info:is_checkout(App))
         andalso rebar_app_info:valid(App)
-          andalso rebar_app_info:has_all_artifacts(App) =:= true.
+          andalso rebar_app_info:has_all_artifacts(App) =:= true
+            andalso not needs_rebuild(App).
 
 find_app_and_level_by_name([], _) ->
     false;
@@ -446,3 +447,33 @@ find_app_and_level_by_name([App|Apps], Name) ->
         _ -> find_app_and_level_by_name(Apps, Name)
     end.
 
+needs_rebuild(AppInfo) ->
+    Ebin = rebar_app_info:ebin_dir(AppInfo),
+    application:load(compiler),
+    {ok, CurrentCompileVsn} = application:get_key(compiler, vsn),
+    case find_some_beam(Ebin) of
+        {ok, Beam} ->
+            case beam_lib:chunks(Beam, [compile_info]) of
+                {ok, {_mod, Chunks}} ->
+                    CompileInfo = proplists:get_value(compile_info, Chunks, []),
+                    CompileVsn = proplists:get_value(version, CompileInfo, "unknown"),
+                    CurrentCompileVsn =/= CompileVsn;
+                _ ->
+                    %% could be built without debug_info
+                    false
+            end;
+        _ ->
+            %% well we would expect a plugin to have a beam file
+            true
+    end.
+
+find_some_beam(Path) ->
+    case file:list_dir(Path) of
+        {error, Reason} ->
+            {error, Reason};
+        {ok, Files} ->
+            case lists:dropwhile(fun(P) -> filename:extension(P) =/= ".beam" end, Files) of
+                [Beam|_] -> {ok, filename:join(Path, Beam)};
+                _ -> {error, no_beam}
+            end
+    end.

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -987,7 +987,12 @@ recompile_when_dag_opts_change(Config) ->
     %% change the config in the DAG...
     [digraph:add_vertex(G, Beam, {artifact, [{d, some_define}]}) || Beam <- Beams],
     digraph:add_vertex(G, '$r3_dirty_bit', true), % trigger a save
-    rebar_compiler_dag:maybe_store(G, DepsDir, rebar_compiler_erl, "project_apps", []),
+    %% the rebar_compiler_erl module is annotated with a compiler version
+    %% to help rebuild deps
+    {ok, CompileVsn} = application:get_key(compiler, vsn),
+    CritMeta = [{compiler, CompileVsn}],
+
+    rebar_compiler_dag:maybe_store(G, DepsDir, rebar_compiler_erl, "project_apps", CritMeta),
     rebar_compiler_dag:terminate(G),
     %% ... but don't change the actual rebar3 config...
     rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name}]}),


### PR DESCRIPTION
This fix is done in three parts:

1. Add the compiler version to the data tracked in the DAG, and extract
   it from source file (when the DAG isn't around) for comparisons. Then
   on each build job, check for the compiler version as a build option
   like every other one.

   A change in compiler version represents a change in build options,
   which triggers a rebuild
2. Make it work for deps. This is done by reworking DAGs metadata
   annotations so that they contain the compiler version and can
   invalidate the culling of deps done by the install_deps phase when
   the DAG is mismatching, and then handing off the dep set to be
   rebuilt more deeply with the regular definition in 1.
3. Make it work for plugins. This requires more work because plugins
   that can find their ebin/ dir are assumed to be pre-built. This can be
   covered by using the facilities developed in 2 along with the deps-only
   compiler switch to fold the plugin workflow into the one for deps.
   This removes a legacy code path we maintained for plugins only,
   and removes a subtle bug introduced in 3.14 where _checkouts plugins
   would not copy their include/ or priv/ directories.

This patch also includes a fix on the path pruning for plugins, which
mistakenly subtracted AppInfo records from file paths; the intent was
to use the ebin dir as a comparison, which this patch fixes.

No tests have been added at this point. I'm not too sure how to make
these tests work when compiler versions need to change from pre-built
projects to work. Ad-hoc tests on my end seem to show that this works
for apps, deps, project plugins, and global plugins.

There is also obvious work required to extract common bits for the checks
but I wanted to validate this approach (and its cost!) with people first.

CC @michalmuskala and @eproxus since I know you both asked for this.
CC @max-au to see if this kind of added checks has too big of an impact
on your build times