### PR TITLE
Fix keep_logs option crashing when having more than N directories

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -49,6 +49,9 @@
     {exclude_mods, [rebar_prv_alias]}
 ]}.
 
+%% Keep only the logs of the last 5 runs
+{ct_opts, [{keep_logs, 5}]}.
+
 %% Profiles
 {profiles, [{test, [
                    {deps, [{meck, "0.8.13"}]},


### PR DESCRIPTION
rebar3 would crash if the option `{keep_logs, N}` was present and
there were more than N run directories in the log dir, so if the
option is found we keep the N-1 newest directories and delete the
rest.

While we are at it, as this should fix the crash, let's limit the
number of logs runs to keep from test runs in rebar3 to 5.