### PR TITLE
Feature shell.script_file in rebar.config.sample

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -219,7 +219,7 @@
 
 %% apps to auto-boot with `rebar3 shell'; defaults to apps
 %% specified in a `relx' tuple, if any.
-{shell, [{apps, [app1, app2]}]}.
+{shell, [{apps, [app1, app2]}, {script_file, "shell.escript"}]}.
 
 %% == xref ==
 


### PR DESCRIPTION
I was a bit surprise at the fact the option is named `--shell` on the CLI, but `script_file` in `rebar.config`, so add this small example in the hopes this doesn't surprise others.

I don't actually know if the online documentation features a section on what `rebar.config` is supposed to look like, for the various "commands".