### PR TITLE
Add missing credits

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -145,3 +145,4 @@ Bryan Paxton
 Justin Wood
 Guilherme Andrade
 Manas Chaudhari
+Luís Rascão


### PR DESCRIPTION
Today I've noticed that @lrascao , who contributed to earlier improvements to `rebar3`, is not part of the `THANKS` file.

This PR intends on changing that. He'll likely not care at all about this and consider it a pointless checkbox, but for such a small effort, I thought: "why not."