### PR TITLE
use 'aws cp' when copying escript to s3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,4 +41,4 @@ jobs:
     - name: Copy rebar3 escript to S3
       if: "!github.event.release.prerelease"
       run: |
-        aws s3 sync ./rebar3 s3://rebar3
+        aws s3 cp ./rebar3 s3://rebar3


### PR DESCRIPTION
The last release failed to upload to S3 automatically. I noticed the nightly action has been working and uses a different command, so switching this to match nightly and hopefully work next time.