### PR TITLE
Do not override private repo urls wit default CDN

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -146,3 +146,4 @@ Justin Wood
 Guilherme Andrade
 Manas Chaudhari
 Luís Rascão
+Jorge Diz Pico


### PR DESCRIPTION
**Summary:** Packages in hex repos defined in rebar.config cannot be fetched as their URL is always overriden.

**How to reproduce:**

- Deploy any local hex repo (e.g. by using the default instructions for [mini_repo](https://github.com/wojtekmach/mini_repo)) and publish a package.
- Create a new app (e.g. `rebar3 new lib foo`)
- Configure your new app to fetch that dependency from the private repo with a rebar.config like this:

```
{erl_opts, [debug_info, rebar3_hex]}.
{deps, [foo]}.
{hex, [
   {repos, [
      #{name => <<"test_repo">>,
        repo_url => <<"http://localhost:4000/repos/test_repo">>,
        repo_public_key => <<"...">>
       }
   ]}
]}.
```
- Run `rebar3 deps`

**Expectation:** dep is fetched correctly.

**Result:** dep is not downloaded, as `repo.hex.pm` is accessed instead.

**Reason found:** though the `/packages` URL for the repos are queried correctly, when the associated `/tarballs` URL are built, any value in `$HEX_CDN` or (if empty) `"repo.hex.pm"` is used instead of the expected `repo_url` provided in config for it.

**Fix proposed:** `$HEX_CDN` or the default `"repo.hex.pm"` are only used if a `repo_url` is not provided.