### PR TITLE
Prevent crash in Erlang/OTP 24 (upcoming)

### DIFF
--- a/src/r3_hex_pb_names.erl
+++ b/src/r3_hex_pb_names.erl
@@ -211,8 +211,7 @@ decode_msg_1_catch(Bin, MsgName, TrUserData) ->
 -else.
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
     try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason ->
-        StackTrace = erlang:get_stacktrace(),
+    catch ?WITH_STACKTRACE(Class, Reason, Stacktrace)
         error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -endif.

--- a/src/r3_hex_pb_package.erl
+++ b/src/r3_hex_pb_package.erl
@@ -289,8 +289,7 @@ decode_msg_1_catch(Bin, MsgName, TrUserData) ->
 -else.
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
     try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason ->
-        StackTrace = erlang:get_stacktrace(),
+    catch ?WITH_STACKTRACE(Class, Reason, Stacktrace)
         error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -endif.

--- a/src/r3_hex_pb_signed.erl
+++ b/src/r3_hex_pb_signed.erl
@@ -183,8 +183,7 @@ decode_msg_1_catch(Bin, MsgName, TrUserData) ->
 -else.
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
     try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason ->
-        StackTrace = erlang:get_stacktrace(),
+    catch ?WITH_STACKTRACE(Class, Reason, Stacktrace)
         error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -endif.

--- a/src/r3_hex_pb_versions.erl
+++ b/src/r3_hex_pb_versions.erl
@@ -255,8 +255,7 @@ decode_msg_1_catch(Bin, MsgName, TrUserData) ->
 -else.
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
     try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason ->
-        StackTrace = erlang:get_stacktrace(),
+    catch ?WITH_STACKTRACE(Class, Reason, Stacktrace)
         error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -endif.


### PR DESCRIPTION
I'm trying to use `rebar3` with local Erlang/OTP (from `master`) `Erlang/OTP 24 [DEVELOPMENT] [erts-11.0.3]`.<sup>[1]</sup>

Since `:get_stacktrace` is no longer available, I'm getting runtime issues.

This is the potential fix for that, following what is already implemented in other parts of the tool.

___
<sup>[1]</sup> this is not a complete attempt at making sure we're Erlang/OTP 24 -ready; this is just a localized fix that's preventing me from moving forward.