### PR TITLE
Use infinity timeout for rebar_compiler_epp resolve call

### DIFF
--- a/src/rebar_compiler_epp.erl
+++ b/src/rebar_compiler_epp.erl
@@ -71,9 +71,9 @@ flush() ->
 %% Caches result for subsequent requests.
 -spec resolve_source(atom() | file:filename_all(), [file:filename_all()]) -> {true, file:filename_all()} | false.
 resolve_source(Name, Dirs) when is_atom(Name) ->
-    gen_server:call(?MODULE, {resolve, atom_to_list(Name) ++ ".erl", Dirs}, 60000);
+    gen_server:call(?MODULE, {resolve, atom_to_list(Name) ++ ".erl", Dirs}, infinity);
 resolve_source(Name, Dirs) when is_list(Name) ->
-    gen_server:call(?MODULE, {resolve, Name, Dirs}, 60000).
+    gen_server:call(?MODULE, {resolve, Name, Dirs}, infinity).
 
 -record(state, {
     %% filesystem cache, denormalised

--- a/src/rebar_compiler_epp.erl
+++ b/src/rebar_compiler_epp.erl
@@ -71,9 +71,9 @@ flush() ->
 %% Caches result for subsequent requests.
 -spec resolve_source(atom() | file:filename_all(), [file:filename_all()]) -> {true, file:filename_all()} | false.
 resolve_source(Name, Dirs) when is_atom(Name) ->
-    gen_server:call(?MODULE, {resolve, atom_to_list(Name) ++ ".erl", Dirs});
+    gen_server:call(?MODULE, {resolve, atom_to_list(Name) ++ ".erl", Dirs}, 60000);
 resolve_source(Name, Dirs) when is_list(Name) ->
-    gen_server:call(?MODULE, {resolve, Name, Dirs}).
+    gen_server:call(?MODULE, {resolve, Name, Dirs}, 60000).
 
 -record(state, {
     %% filesystem cache, denormalised


### PR DESCRIPTION
I experienced timeout error like (file names are modified because it happened in closed source build):

```
===> Failed to get dependencies for /xxx/src/foobar.erl
{timeout,{gen_server,call,
                     [rebar_compiler_epp,
                      {resolve,"supervisor.erl",
                               ["/xxx/include",
                                "/xxx/src"]}]}}
```

This does NOT occur in my development environment but does
- on a small VM with single CPU core and a remote disk, and
- in continuous integration build environment (not sure what hardware/virtualization).

By adding explicit 60 second timeout, the error disappears.

-----

In my development environment (with relatively good CPU and SSD), I did some print-debug and found:
- is_dir call at https://github.com/erlang/rebar3/blob/master/src/rebar_compiler_epp.erl#L131 sometimes takes milliseconds to tens of milliseconds
- overall resolve call accumulates to about 500 milliseconds.

-----

I'm not sure the approach of this PR is correct direction, so I'm happy to have discussion.
