### PR TITLE
Ignore `global` and `default` in empty profiles warning for `as`

### DIFF
--- a/src/rebar_prv_as.erl
+++ b/src/rebar_prv_as.erl
@@ -101,5 +101,7 @@ warn_on_empty_profile(Profiles, State) ->
     ProjectApps = rebar_state:project_apps(State),
     DefinedProfiles = rebar_state:get(State, profiles, []) ++
         lists:flatten([rebar_app_info:get(AppInfo, profiles, []) || AppInfo <- ProjectApps]),
-    [?WARN("No entry for profile ~ts in config.", [Profile]) ||
-        Profile <- Profiles, not(lists:keymember(list_to_atom(Profile), 1, DefinedProfiles))].
+    [?WARN("No entry for profile ~ts in config.", [Profile]) 
+     || Profile <- Profiles,
+        not lists:keymember(list_to_atom(Profile), 1, DefinedProfiles),
+        Profile =/= "global"].

--- a/src/rebar_prv_as.erl
+++ b/src/rebar_prv_as.erl
@@ -104,4 +104,5 @@ warn_on_empty_profile(Profiles, State) ->
     [?WARN("No entry for profile ~ts in config.", [Profile]) 
      || Profile <- Profiles,
         not lists:keymember(list_to_atom(Profile), 1, DefinedProfiles),
-        Profile =/= "global"].
+        Profile =/= "global", Profile =/= "default"],
+    ok.


### PR DESCRIPTION
Before:
```
→ rebar3 as global plugins list                               
===> No entry for profile global in config.                                      
--- Global plugins ---                                                                                                                                             
rebar3_hex (6.9.6+build.293.ref85a6cb4)      
```

After:
```
→ rebar3 as global plugins list                               
--- Global plugins ---                                                           
rebar3_hex (6.9.6+build.293.ref85a6cb4)                                          
```

Fixes #2369 