### PR TITLE
Rework DEBUG=1 mode to be user-centric output and introduce separate DIAGNOSTIC=1 mode for implementer-level logging

### DIFF
--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -1,7 +1,4 @@
-%% TODO: rename FAIL to ABORT once we require at least R13B04 for
-%% building rebar. Macros with different arity were not supported by the
-%% compiler before 13B04.
--define(FAIL, rebar_utils:abort()).
+-define(ABORT, rebar_utils:abort()).
 -define(ABORT(Str, Args), rebar_utils:abort(Str, Args)).
 
 -define(CONSOLE(Str, Args), io:format(Str++"~n", Args)).

--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -6,6 +6,7 @@
 
 -define(CONSOLE(Str, Args), io:format(Str++"~n", Args)).
 
+-define(DIAGNOSTIC(Str, Args), rebar_log:log(diagnostic, Str, Args)).
 -define(DEBUG(Str, Args), rebar_log:log(debug, Str, Args)).
 -define(INFO(Str, Args), rebar_log:log(info, Str, Args)).
 -define(WARN(Str, Args), rebar_log:log(warn, Str, Args)).

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -283,12 +283,16 @@ set_options(State, {Options, NonOptArgs}) ->
 log_level() ->
     case os:getenv("QUIET") of
         Q when Q == false; Q == "" ->
-            DefaultLevel = rebar_log:default_level(),
-            case os:getenv("DEBUG") of
-                D when D == false; D == "" ->
-                    DefaultLevel;
+            case os:getenv("DIAGNOSTIC") of
+                Di when Di == false; Di == "" ->
+                    case os:getenv("DEBUG") of
+                        D when D == false; D == "" ->
+                            rebar_log:default_level();
+                        _ ->
+                            rebar_log:debug_level()
+                    end;
                 _ ->
-                    DefaultLevel + 3
+                    rebar_log:diagnostic_level()
             end;
          _ ->
             rebar_log:error_level()

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -339,7 +339,7 @@ handle_error({error, {Module, Reason}}, Stacktrace) ->
     case code:which(Module) of
         non_existing ->
             ?CRASHDUMP("~p: ~p~n~p~n~n", [Module, Reason, Stacktrace]),
-            ?ERROR("Uncaught error in rebar_core. Run with DEBUG=1 to stacktrace or consult rebar3.crashdump", []),
+            ?ERROR("Uncaught error in rebar_core. Run with DIAGNOSTIC=1 to stacktrace or consult rebar3.crashdump", []),
             ?DEBUG("Uncaught error: ~p ~p", [Module, Reason]),
             ?INFO("When submitting a bug report, please include the output of `rebar3 report \"your command\"`", []);
         _ ->
@@ -353,7 +353,7 @@ handle_error(Error, StackTrace) ->
     %% Nothing should percolate up from rebar_core;
     %% Dump this error to console
     ?CRASHDUMP("Error: ~p~n~p~n~n", [Error, StackTrace]),
-    ?ERROR("Uncaught error in rebar_core. Run with DEBUG=1 to see stacktrace or consult rebar3.crashdump", []),
+    ?ERROR("Uncaught error in rebar_core. Run with DIAGNOSTIC=1 to see stacktrace or consult rebar3.crashdump", []),
     ?DEBUG("Uncaught error: ~p", [Error]),
     case StackTrace of
         [] -> ok;

--- a/src/rebar_api.erl
+++ b/src/rebar_api.erl
@@ -24,7 +24,7 @@
 
 %% @doc Interrupts program flow
 -spec abort() -> no_return().
-abort() -> ?FAIL.
+abort() -> ?ABORT.
 
 %% @doc like {@link error/2}, except it also raises an
 %% exception to interrupt program flow.

--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -31,6 +31,12 @@ do(State, LibDirs) ->
     %% There may be a top level src which is an app and there may not
     %% Find it here if there is, otherwise define the deps parent as root
     TopLevelApp = define_root_app(Apps, State),
+    ?DEBUG("Found top-level apps: [~ts]~n\tusing config: ~p",
+           [case lists:flatten([[",",rebar_app_info:name(App)] || App <- Apps]) of
+                [] -> "";
+                Str -> tl(Str)
+            end,
+            [{src_dirs, SrcDirs}, {lib_dirs, LibDirs}]]),
 
     %% Handle top level deps
     State1 = lists:foldl(fun(Profile, StateAcc) ->

--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -195,7 +195,7 @@ compile_each([Source | Rest], Config, CompileFn) ->
             ?ERROR("Compiling ~ts failed", [NewSource]),
             maybe_report(Error),
             ?DEBUG("Compilation failed: ~p", [Error]),
-            ?FAIL
+            ?ABORT
     end,
     compile_each(Rest, Config, CompileFn).
 

--- a/src/rebar_compiler.erl
+++ b/src/rebar_compiler.erl
@@ -321,21 +321,21 @@ compile_worker(Source, [Opts, Config, Outs, CompilerMod]) ->
     {Result, Source}.
 
 compile_handler({ok, Source}, _Args) ->
-    ?DEBUG("~sCompiled ~s", [rebar_utils:indent(1), Source]),
+    ?DEBUG("~sCompiled ~s", [rebar_utils:indent(1), filename:basename(Source)]),
     ok;
 compile_handler({{ok, Tracked}, Source}, [_, Tracking]) when Tracking ->
-    ?DEBUG("~sCompiled ~s", [rebar_utils:indent(1), Source]),
+    ?DEBUG("~sCompiled ~s", [rebar_utils:indent(1), filename:basename(Source)]),
     {ok, Tracked};
 compile_handler({{ok, Warnings}, Source}, _Args) ->
     report(Warnings),
-    ?DEBUG("~sCompiled ~s", [rebar_utils:indent(1), Source]),
+    ?DEBUG("~sCompiled ~s", [rebar_utils:indent(1), filename:basename(Source)]),
     ok;
 compile_handler({{ok, Tracked, Warnings}, Source}, [_, Tracking]) when Tracking ->
     report(Warnings),
-    ?DEBUG("~sCompiled ~s", [rebar_utils:indent(1), Source]),
+    ?DEBUG("~sCompiled ~s", [rebar_utils:indent(1), filename:basename(Source)]),
     {ok, Tracked};
 compile_handler({skipped, Source}, _Args) ->
-    ?DEBUG("~sSkipped ~s", [rebar_utils:indent(1), Source]),
+    ?DEBUG("~sSkipped ~s", [rebar_utils:indent(1), filename:basename(Source)]),
     ok;
 compile_handler({Error, Source}, [Config | _Rest]) ->
     NewSource = format_error_source(Source, Config),

--- a/src/rebar_compiler.erl
+++ b/src/rebar_compiler.erl
@@ -272,7 +272,7 @@ do_compile(CompilerMod, Source, Outs, Config, Opts) ->
             ?ERROR("Compiling ~ts failed", [NewSource]),
             maybe_report(Error),
             ?DEBUG("Compilation failed: ~p", [Error]),
-            ?FAIL
+            ?ABORT
     end.
 
 do_compile_and_track(CompilerMod, Source, Outs, Config, Opts) ->
@@ -292,7 +292,7 @@ do_compile_and_track(CompilerMod, Source, Outs, Config, Opts) ->
             ?ERROR("Compiling ~ts failed", [NewSource]),
             maybe_report(Error),
             ?DEBUG("Compilation failed: ~p", [Error]),
-            ?FAIL
+            ?ABORT
     end.
 
 store_artifacts(_G, []) ->
@@ -341,7 +341,7 @@ compile_handler({Error, Source}, [Config | _Rest]) ->
     NewSource = format_error_source(Source, Config),
     ?ERROR("Compiling ~ts failed", [NewSource]),
     maybe_report(Error),
-    ?FAIL.
+    ?ABORT.
 
 clean_(CompilerMod, AppInfo, _Label) ->
     #{src_dirs := SrcDirs,

--- a/src/rebar_compiler_dag.erl
+++ b/src/rebar_compiler_dag.erl
@@ -134,7 +134,7 @@ finalise_populate_sources(G, InDirs, Waiting) ->
         {'DOWN', _MRef, process, Pid, Reason} ->
             {_Status, Source} = maps:get(Pid, Waiting),
             ?ERROR("Failed to get dependencies for ~s~n~p", [Source, Reason]),
-            ?FAIL
+            ?ABORT
     end.
 
 %% @doc this function scans all the source files found and looks into

--- a/src/rebar_compiler_epp.erl
+++ b/src/rebar_compiler_epp.erl
@@ -145,7 +145,7 @@ list_directory(Dir, Cache) ->
                         {Cache, []}, DirFiles),
                     {NewFs#{Dir => Files}, Files};
                 {error, Reason} ->
-                    ?DEBUG("Failed to list ~s, ~p", [Dir, Reason]),
+                    ?DIAGNOSTIC("Failed to list ~s, ~p", [Dir, Reason]),
                     {Cache, []}
             end
     end.

--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -48,8 +48,8 @@ needed_files(Graph, FoundFiles, _, AppInfo) ->
     EbinDir = rebar_app_info:ebin_dir(AppInfo),
     RebarOpts = rebar_app_info:opts(AppInfo),
     ErlOpts = rebar_opts:erl_opts(RebarOpts),
-    ?DEBUG("erlopts ~p", [ErlOpts]),
-    ?DEBUG("files to compile ~p", [FoundFiles]),
+    ?DEBUG("compile options: {erl_opts, ~p}.", [ErlOpts]),
+    ?DEBUG("files to analyze ~p", [FoundFiles]),
 
     %% Make sure that the ebin dir is on the path
     ok = rebar_file_utils:ensure_dir(EbinDir),

--- a/src/rebar_compiler_mib.erl
+++ b/src/rebar_compiler_mib.erl
@@ -91,7 +91,7 @@ compile(Source, OutDirs, _, Opts) ->
             rebar_file_utils:mv(HrlFilename, HrlOut),
             ok;
         {error, compilation_failed} ->
-            ?FAIL
+            ?ABORT
     end.
 
 clean(MibFiles, AppInfo) ->

--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -92,7 +92,8 @@ process_command(State, Command) ->
     Namespace = rebar_state:namespace(State),
     TargetProviders = providers:get_target_providers(Command, Providers, Namespace),
     CommandProvider = providers:get_provider(Command, Providers, Namespace),
-    ?DEBUG("Expanded command sequence to be run: ~p", [TargetProviders]),
+    ?DEBUG("Expanded command sequence to be run: ~w",
+           [[friendly_provider(P) || P <- TargetProviders]]),
     case CommandProvider of
         not_found when Command =/= do ->
             case Namespace of
@@ -136,7 +137,7 @@ process_command(State, Command) ->
 do([], State) ->
     {ok, State};
 do([ProviderName | Rest], State) ->
-    ?DEBUG("Provider: ~p", [ProviderName]),
+    ?DEBUG("Running provider: ~p", [friendly_provider(ProviderName)]),
     %% Special providers like 'as', 'do' or some hooks may be passed
     %% as a tuple {Namespace, Name}, otherwise not. Handle them
     %% on a per-need basis.
@@ -176,3 +177,8 @@ format_error({bad_provider_namespace, {Namespace, Name}}) ->
     io_lib:format("Undefined command ~ts in namespace ~ts", [Name, Namespace]);
 format_error({bad_provider_namespace, Name}) ->
     io_lib:format("Undefined command ~ts", [Name]).
+
+%% @private help display a friendlier sequence of provider names by
+%% omitting the default namespace if it's not there
+friendly_provider({default, P}) -> P;
+friendly_provider(P) -> P.

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -620,7 +620,7 @@ compile_mib(AppInfo) ->
                 rebar_file_utils:mv(HrlFilename, AppInclude),
                 ok;
             {error, compilation_failed} ->
-                ?FAIL
+                ?ABORT
         end
     end.
 

--- a/src/rebar_fetch.erl
+++ b/src/rebar_fetch.erl
@@ -59,7 +59,7 @@ download_source_(AppInfo, State) ->
             code:del_path(filename:absname(filename:join(AppDir1, "ebin"))),
             FetchDir = rebar_app_info:fetch_dir(AppInfo),
             ok = rebar_file_utils:rm_rf(filename:absname(FetchDir)),
-            ?DEBUG("Moving checkout ~p to ~p", [TmpDir, filename:absname(FetchDir)]),
+            ?DIAGNOSTIC("Moving checkout ~p to ~p", [TmpDir, filename:absname(FetchDir)]),
             rebar_file_utils:mv(TmpDir, filename:absname(FetchDir));
         Error ->
             Error

--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -366,7 +366,7 @@ delete_each([File | Rest]) ->
             delete_each(Rest);
         {error, Reason} ->
             ?ERROR("Failed to delete file ~ts: ~p\n", [File, Reason]),
-            ?FAIL
+            ?ABORT
     end.
 
 %% @doc backwards compat layer to pre-utf8 support

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -369,12 +369,12 @@ parse_tags(Dir) ->
 
 git_clone_options() ->
     Option = case os:getenv("REBAR_GIT_CLONE_OPTIONS") of
-        false -> "" ;       %% env var not set
-        Opt ->              %% env var set to empty or others
+        false ->
+            "" ;
+        Opt ->
+            ?DEBUG("Git Clone Options: ~p",[Opt]),
             Opt
     end,
-
-    ?DEBUG("Git clone Option = ~p",[Option]),
     Option.
 
 check_type_support() ->

--- a/src/rebar_hooks.erl
+++ b/src/rebar_hooks.erl
@@ -12,19 +12,33 @@
                    atom() | {atom(), atom()} | string(),
                    [providers:t()], rebar_app_info:t(), rebar_state:t()) -> rebar_app_info:t().
 run_all_hooks(Dir, Type, Command, Providers, AppInfo, State) ->
+    ?DEBUG("Running hooks for ~p in app ~ts (~ts) with configuration:",
+           [Command, rebar_app_info:name(AppInfo), Dir]),
     State1 = rebar_state:current_app(State, AppInfo),
     State2 = run_provider_hooks(Dir, Type, Command, Providers, rebar_app_info:opts(AppInfo), State1),
     run_hooks(Dir, Type, Command, rebar_app_info:opts(AppInfo), State1),
     rebar_state:current_app(State2).
 
 run_all_hooks(Dir, Type, Command, Providers, State) ->
+    ?DEBUG("Running hooks for ~p with configuration:", [Command]),
     run_provider_hooks(Dir, Type, Command, Providers, rebar_state:opts(State), State),
     run_hooks(Dir, Type, Command, rebar_state:opts(State), State).
 
 run_project_and_app_hooks(Dir, Type, Command, Providers, State) ->
     ProjectApps = rebar_state:project_apps(State),
+    ?DEBUG("Running app-specific hooks", []),
     [rebar_hooks:run_all_hooks(Dir, Type, Command, Providers, AppInfo, State) || AppInfo <- ProjectApps],
+    ?DEBUG("Running project-wide hooks", []),
     run_all_hooks(Dir, Type, Command, Providers, State).
+
+format_error({bad_provider, Type, Command, {Name, Namespace}}) ->
+    io_lib:format("Unable to run ~ts hooks for '~p', command '~p' in namespace '~p' not found.", [Type, Command, Namespace, Name]);
+format_error({bad_provider, Type, Command, Name}) ->
+    io_lib:format("Unable to run ~ts hooks for '~p', command '~p' not found.", [Type, Command, Name]).
+
+%%%%%%%%%%%%%%%
+%%% PRIVATE %%%
+%%%%%%%%%%%%%%%
 
 run_provider_hooks(Dir, Type, Command, Providers, Opts, State) ->
     case rebar_opts:get(Opts, provider_hooks, []) of
@@ -40,11 +54,14 @@ run_provider_hooks_(_Dir, _Type, _Command, _Providers, [], State) ->
 run_provider_hooks_(Dir, Type, Command, Providers, TypeHooks, State) ->
     case proplists:get_all_values(Command, TypeHooks) of
         [] ->
+            ?DEBUG("\t{provider_hooks, []}.", []),
             State;
         HookProviders ->
             rebar_paths:set_paths([plugins], State),
             Providers1 = rebar_state:providers(State),
             State1 = rebar_state:providers(rebar_state:dir(State, Dir), Providers++Providers1),
+            ?DEBUG("\t{provider_hooks, [{~p, ~p}]}.",
+                   [Type, HookProviders]),
             case rebar_core:do(HookProviders, State1) of
                 {error, ProviderName} ->
                     ?DEBUG(format_error({bad_provider, Type, Command, ProviderName}), []),
@@ -55,11 +72,6 @@ run_provider_hooks_(Dir, Type, Command, Providers, TypeHooks, State) ->
             end
     end.
 
-format_error({bad_provider, Type, Command, {Name, Namespace}}) ->
-    io_lib:format("Unable to run ~ts hooks for '~p', command '~p' in namespace '~p' not found.", [Type, Command, Namespace, Name]);
-format_error({bad_provider, Type, Command, Name}) ->
-    io_lib:format("Unable to run ~ts hooks for '~p', command '~p' not found.", [Type, Command, Name]).
-
 run_hooks(Dir, pre, Command, Opts, State) ->
     run_hooks(Dir, pre_hooks, Command, Opts, State);
 run_hooks(Dir, post, Command, Opts, State) ->
@@ -67,17 +79,21 @@ run_hooks(Dir, post, Command, Opts, State) ->
 run_hooks(Dir, Type, Command, Opts, State) ->
     case rebar_opts:get(Opts, Type, []) of
         [] ->
-            ?DEBUG("run_hooks(~p, ~p, ~p) -> no hooks defined\n", [Dir, Type, Command]),
+            ?DEBUG("\t{~p, []}.", [Type]),
+            ?DIAGNOSTIC("run_hooks(~p, ~p, ~p) -> no hooks defined\n", [Dir, Type, Command]),
             ok;
         Hooks ->
             Env = rebar_env:create_env(State, Opts),
-            lists:foreach(fun({_, C, _}=Hook) when C =:= Command ->
-                                  apply_hook(Dir, Env, Hook);
-                             ({C, _}=Hook) when C =:= Command ->
-                                  apply_hook(Dir, Env, Hook);
-                             (_) ->
-                                  continue
-                          end, Hooks)
+            CommandHooks = lists:filter(
+                fun({_, C, _}) when C =:= Command -> true;
+                   ({C, _}) when C =:= Command -> true;
+                   (_) -> false
+                end,
+                Hooks
+            ),
+            ?DEBUG("\t{~p, ~p}.",
+                   [Type, CommandHooks]),
+            lists:foreach(fun(Hook) -> apply_hook(Dir, Env, Hook) end, CommandHooks)
     end.
 
 apply_hook(Dir, Env, {Arch, Command, Hook}) ->

--- a/src/rebar_parallel.erl
+++ b/src/rebar_parallel.erl
@@ -34,7 +34,7 @@ parallel_dispatch(Targets, Pids, Handler, Args) ->
             parallel_dispatch(Targets, NewPids, Handler, Args);
         {'DOWN', _Mref, _, _Pid, Info} ->
             ?ERROR("Task failed: ~p", [Info]),
-            ?FAIL;
+            ?ABORT;
         {result, Result} ->
             case Handler(Result, Args) of
                 ok ->

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -220,10 +220,10 @@ cached_download(TmpDir, CachePath, Pkg={pkg, Name, Vsn, _OldHash, _Hash, RepoCon
     CDN = maybe_default_cdn(State),
     case request(RepoConfig#{repo_url => CDN}, Name, Vsn, ETag) of
         {ok, cached} ->
-            ?INFO("Version cached at ~ts is up to date, reusing it", [CachePath]),
+            ?DEBUG("Version cached at ~ts is up to date, reusing it", [CachePath]),
             serve_from_cache(TmpDir, CachePath, Pkg);
         {ok, Body, NewETag} ->
-            ?INFO("Downloaded package, caching at ~ts", [CachePath]),
+            ?DEBUG("Downloaded package, caching at ~ts", [CachePath]),
             maybe_store_etag_in_cache(UpdateETag, ETagPath, NewETag),
             serve_from_download(TmpDir, CachePath, Pkg, Body);
         error when ETag =/= <<>> ->
@@ -236,7 +236,7 @@ cached_download(TmpDir, CachePath, Pkg={pkg, Name, Vsn, _OldHash, _Hash, RepoCon
 
 maybe_default_cdn(State) ->
     CDN = rebar_state:get(State, rebar_packages_cdn, ?DEFAULT_CDN),
-	rebar_utils:to_binary(CDN).
+    rebar_utils:to_binary(CDN).
 
 -spec serve_from_cache(TmpDir, CachePath, Pkg) -> Res when
       TmpDir :: file:name(),

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -378,6 +378,7 @@ copy_app_dirs(AppInfo, OldAppDir, AppDir) ->
                 true ->
                     OutEbin = filename:join([AppDir, "ebin"]),
                     filelib:ensure_dir(filename:join([OutEbin, "dummy.beam"])),
+                    ?DEBUG("Copying existing files from ~ts to ~ts", [EbinDir, OutEbin]),
                     rebar_file_utils:cp_r(filelib:wildcard(filename:join([EbinDir, "*"])), OutEbin);
                 false ->
                     ok

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -382,7 +382,7 @@ symlink_dep(State, From, To) ->
         ok ->
             RelativeFrom = make_relative_to_root(State, From),
             RelativeTo = make_relative_to_root(State, To),
-            ?INFO("Linking ~ts to ~ts", [RelativeFrom, RelativeTo]),
+            ?DEBUG("Linking ~ts to ~ts", [RelativeFrom, RelativeTo]),
             ok;
         exists ->
             ok

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -429,7 +429,8 @@ warn_skip_deps(AppInfo, State) ->
                 false -> ok
             end;
         true ->
-            ?ERROR(Msg, Args), ?FAIL
+            ?ERROR(Msg, Args),
+            ?ABORT
     end.
 
 not_needs_compile(App) ->

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -510,7 +510,7 @@ create_logic_providers(ProviderModules, State0) ->
         ?WITH_STACKTRACE(C,T,S)
             ?DEBUG("~p: ~p ~p", [C, T, S]),
             ?CRASHDUMP("~p: ~p~n~p~n~n~p", [C, T, S, State0]),
-            throw({error, "Failed creating providers. Run with DEBUG=1 for stacktrace or consult rebar3.crashdump."})
+            throw({error, "Failed creating providers. Run with DIAGNOSTIC=1 for stacktrace or consult rebar3.crashdump."})
     end.
 
 to_list(#state_t{} = State) ->

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -150,7 +150,7 @@ wordsize() ->
 sh_send(Command0, String, Options0) ->
     ?INFO("sh_send info:\n\tcwd: ~p\n\tcmd: ~ts < ~ts\n",
           [rebar_dir:get_cwd(), Command0, String]),
-    ?DEBUG("\topts: ~p\n", [Options0]),
+    ?DIAGNOSTIC("\topts: ~p\n", [Options0]),
 
     DefaultOptions = [use_stdout, abort_on_error],
     Options = [expand_sh_flag(V)
@@ -177,8 +177,8 @@ sh_send(Command0, String, Options0) ->
 %% Val = string() | false
 %%
 sh(Command0, Options0) ->
-    ?DEBUG("sh info:\n\tcwd: ~p\n\tcmd: ~ts\n", [rebar_dir:get_cwd(), Command0]),
-    ?DEBUG("\topts: ~p\n", [Options0]),
+    ?DIAGNOSTIC("sh info:\n\tcwd: ~p\n\tcmd: ~ts\n", [rebar_dir:get_cwd(), Command0]),
+    ?DIAGNOSTIC("\topts: ~p\n", [Options0]),
 
     DefaultOptions = [{use_stdout, false}, debug_and_abort_on_error],
     Options = [expand_sh_flag(V)
@@ -190,7 +190,7 @@ sh(Command0, Options0) ->
     Command = lists:flatten(patch_on_windows(Command0, proplists:get_value(env, Options0, []))),
     PortSettings = proplists:get_all_values(port_settings, Options) ++
         [exit_status, {line, 16384}, use_stdio, stderr_to_stdout, hide, eof, binary],
-    ?DEBUG("Port Cmd: ~ts\nPort Opts: ~p\n", [Command, PortSettings]),
+    ?DIAGNOSTIC("Port Cmd: ~ts\nPort Opts: ~p\n", [Command, PortSettings]),
     Port = open_port({spawn, Command}, PortSettings),
 
     try


### PR DESCRIPTION
This is a progressive rework of https://github.com/erlang/rebar3/pull/2009. I'm hoping to drive a major improvement in usability by directly tying some behaviours to the config value that impacts things, we could get some discoverability out of it on top of friendlier debugging output.

Currently the following commits are part of the PR:
- Introduce Diagnostic Mode (82cc665):
  ?DIAGNOSTIC mode is intended to be used for rebar3 maintainers to debug
and understand issues. It shows all the things and all the data and
works with the assumption that people has intent to use the source code
to debug things. An equivalent call is added to `rebar_api`.
  
  ?DEBUG mode is promoted to user-oriented debugging, based on the idea
that what they care about is figuring out their interactions with the
tool. A major improvement in usability would be to directly tie the user
config to the interpreted config (ie merged profiles) to clearly hint at
seen rebar3’s behaviour.  If the debug output can show that and even tie
some behaviours to the config value that impacts things, we could get
some discoverability out of it too, something missing from declarative
tools like this.
- Rename ?FAIL to ?ABORT (4b91521):
  Just cleaning up old legacy stuff from when macros couldn't have multiple arities
- friendlier debug mode in rebar_core (0698e3b):
  omits the default namespace when displaying providers
- move shell commands debug to diagnostic (2fab8cd):
  All the super verbose information about shell commands and their parsing is unlikely to be useful
  to users so I'm moving that stuff to DIAGNOSTIC mode instead of DEBUG. 
- rename DEBUG to DIAGNOSTIC in crashdump messages (66d30dc):
  To make it clear that we want the full dump when people submit issues or might want to look at crash information
- Reworking app discovery and dep fetching verbosity (683b48c):
  I'm moving stuff that is an implementation detail (caching packages, setting up symlinks) to lower log
  levels to focus on what the user actually has an ability to impact.
  
  This commit also has an example of showing the `src_dirs` and `lib_dirs` config values as understood
  by the app discovery task in DEBUG mode to let the user know they can impact things 
- Rework debug/diagnostic logs for compile tasks (38638aa):
  This should cover most common things, including hooks.
  What this commit specifically does is change some less useful messages for more
  contextualized ones, including tying specific configurations to actions
  taking place. This is particularly visible in hooks, and hopefully
  provides some amount of discoverability.
  
  Also of note:
  - ebin/ directory copying is called explicitly when done since people
    have issues with that
  - paths for compiled files are made relative since the analysis list
    shows the full paths already
  - hooks are a bit more verbose but also more useful.

I'm hoping we could merge this and then keep the work going for specific providers at a later point, and possibly tweak these base cases before driving the principles further out.

------
## Output

This section shows comparative output between Rebar3 in the mainline development branch and this pull request

### Current Main Branch

<details>
<summary>
Click to unfurl

```
λ rebar3 → master* → DEBUG=1 rebar3 escriptize
===> Load global config file /home/ferd/.config/rebar3/rebar.config
===> 23.0 satisfies the requirement for minimum OTP version 18
===> Expanded command sequence to be run: [{default,app_discovery},
                                                  {default,install_deps},
                                                  {default,lock},
                                                  {default,compile},
                                                  {default,escriptize}]
===> Provider: {default,app_discovery}
===> Provider: {default,install_deps}
===> Verifying dependencies...
===> Fetching bbmustache v1.10.0
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/bbmustache-1.10.0.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/bbmustache

===> 	opts: [{use_stdout,false},abort_on_error]

...
```

</summary>

```
λ rebar3 → master* → DEBUG=1 rebar3 escriptize
===> Load global config file /home/ferd/.config/rebar3/rebar.config
===> 23.0 satisfies the requirement for minimum OTP version 18
===> Expanded command sequence to be run: [{default,app_discovery},
                                                  {default,install_deps},
                                                  {default,lock},
                                                  {default,compile},
                                                  {default,escriptize}]
===> Provider: {default,app_discovery}
===> Provider: {default,install_deps}
===> Verifying dependencies...
===> Fetching bbmustache v1.10.0
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/bbmustache-1.10.0.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/bbmustache

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/bbmustache
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Moving checkout "/tmp/.tmp_dir434103762473" to "/home/ferd/code/self/rebar3/_build/default/lib/bbmustache"
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: mv /tmp/.tmp_dir434103762473 /home/ferd/code/self/rebar3/_build/default/lib/bbmustache

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: mv /tmp/.tmp_dir434103762473 /home/ferd/code/self/rebar3/_build/default/lib/bbmustache
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Fetching certifi v2.5.2
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/certifi-2.5.2.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/certifi

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/certifi
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Moving checkout "/tmp/.tmp_dir972869531509" to "/home/ferd/code/self/rebar3/_build/default/lib/certifi"
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: mv /tmp/.tmp_dir972869531509 /home/ferd/code/self/rebar3/_build/default/lib/certifi

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: mv /tmp/.tmp_dir972869531509 /home/ferd/code/self/rebar3/_build/default/lib/certifi
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Fetching cf v0.3.1
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/cf-0.3.1.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/cf

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/cf
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Moving checkout "/tmp/.tmp_dir501872965832" to "/home/ferd/code/self/rebar3/_build/default/lib/cf"
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: mv /tmp/.tmp_dir501872965832 /home/ferd/code/self/rebar3/_build/default/lib/cf

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: mv /tmp/.tmp_dir501872965832 /home/ferd/code/self/rebar3/_build/default/lib/cf
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Fetching cth_readable v1.4.8
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/cth_readable-1.4.8.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/cth_readable

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/cth_readable
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Moving checkout "/tmp/.tmp_dir997526267448" to "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable"
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: mv /tmp/.tmp_dir997526267448 /home/ferd/code/self/rebar3/_build/default/lib/cth_readable

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: mv /tmp/.tmp_dir997526267448 /home/ferd/code/self/rebar3/_build/default/lib/cth_readable
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Evaluating config script "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/rebar.config.script"
===> Fetching erlware_commons v1.3.1
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/erlware_commons-1.3.1.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Moving checkout "/tmp/.tmp_dir145527999183" to "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons"
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: mv /tmp/.tmp_dir145527999183 /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: mv /tmp/.tmp_dir145527999183 /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Evaluating config script "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/rebar.config.script"
===> Fetching eunit_formatters v0.5.0
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/eunit_formatters-0.5.0.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Moving checkout "/tmp/.tmp_dir780308483392" to "/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters"
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: mv /tmp/.tmp_dir780308483392 /home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: mv /tmp/.tmp_dir780308483392 /home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Fetching getopt v1.0.1
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/getopt-1.0.1.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/getopt

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/getopt
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Moving checkout "/tmp/.tmp_dir553319190160" to "/home/ferd/code/self/rebar3/_build/default/lib/getopt"
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: mv /tmp/.tmp_dir553319190160 /home/ferd/code/self/rebar3/_build/default/lib/getopt

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: mv /tmp/.tmp_dir553319190160 /home/ferd/code/self/rebar3/_build/default/lib/getopt
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Fetching parse_trans v3.3.0
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/parse_trans-3.3.0.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/parse_trans

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/parse_trans
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Moving checkout "/tmp/.tmp_dir554851497950" to "/home/ferd/code/self/rebar3/_build/default/lib/parse_trans"
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: mv /tmp/.tmp_dir554851497950 /home/ferd/code/self/rebar3/_build/default/lib/parse_trans

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: mv /tmp/.tmp_dir554851497950 /home/ferd/code/self/rebar3/_build/default/lib/parse_trans
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Fetching providers v1.8.1
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/providers-1.8.1.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/providers

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/providers
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Moving checkout "/tmp/.tmp_dir198691146289" to "/home/ferd/code/self/rebar3/_build/default/lib/providers"
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: mv /tmp/.tmp_dir198691146289 /home/ferd/code/self/rebar3/_build/default/lib/providers

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: mv /tmp/.tmp_dir198691146289 /home/ferd/code/self/rebar3/_build/default/lib/providers
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Fetching relx v4.0.2
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/relx-4.0.2.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/relx

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/relx
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Moving checkout "/tmp/.tmp_dir100334530701" to "/home/ferd/code/self/rebar3/_build/default/lib/relx"
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: mv /tmp/.tmp_dir100334530701 /home/ferd/code/self/rebar3/_build/default/lib/relx

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: mv /tmp/.tmp_dir100334530701 /home/ferd/code/self/rebar3/_build/default/lib/relx
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Fetching ssl_verify_fun v1.1.6
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/ssl_verify_fun-1.1.6.tar is up to date, reusing it
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: rm -rf /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Moving checkout "/tmp/.tmp_dir862714793027" to "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun"
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: mv /tmp/.tmp_dir862714793027 /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun

===> 	opts: [{use_stdout,false},abort_on_error]

===> Port Cmd: mv /tmp/.tmp_dir862714793027 /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun
Port Opts: [exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> Provider: {default,lock}
===> Provider: {default,compile}
===> Compile (apps)
===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/getopt", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/providers", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cf", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/bbmustache", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/relx", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cth_readable", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/parse_trans", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/certifi", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/getopt", pre_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/providers", pre_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cf", pre_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons", pre_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/bbmustache", pre_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/relx", pre_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters", pre_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cth_readable", pre_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/parse_trans", pre_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/certifi", pre_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun", pre_hooks, erlc_compile) -> no hooks defined

===> Analyzing applications...
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/bbmustache/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/certifi/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cf/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/bbmustache/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/certifi/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cf/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/bbmustache/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/certifi/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cf/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/getopt/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/relx/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/bbmustache/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/certifi/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cf/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/getopt/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/relx/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/bbmustache/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/certifi/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cf/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/getopt/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/relx/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/bbmustache/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/certifi/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cf/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/getopt/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/bbmustache/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/certifi/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cf/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/_build/default/lib/getopt/include, enoent
===> Compiling bbmustache
===> erlopts [debug_info,
                     {d,namespaced_types},
                     warnings_as_errors,warn_export_all,warn_untyped_record]
===> files to compile ["/home/ferd/code/self/rebar3/_build/default/lib/bbmustache/src/bbmustache.erl"]
===> Starting 1 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/bbmustache/src/bbmustache.erl
===> Compiling cf
===> erlopts [debug_info]
===> files to compile ["/home/ferd/code/self/rebar3/_build/default/lib/cf/src/cf.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cf/src/cf_term.erl"]
===> Starting 2 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/cf/src/cf.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/cf/src/cf_term.erl
===> Compiling cth_readable
===> erlopts [debug_info]
===> files to compile ["/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_failonly.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_helpers.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_compact_shell.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_transform.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_nosasl.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_lager_backend.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_shell.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cthr.erl"]
===> Starting 2 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_transform.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_nosasl.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_lager_backend.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_compact_shell.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_failonly.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cthr.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_shell.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_helpers.erl
===> Compiling erlware_commons
===> erlopts [{d,namespaced_types},
                     {d,have_callback_support},
                     {d,rand_module},
                     {d,unicode_str},
                     debug_info,warnings_as_errors]
===> files to compile ["/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_gb_trees.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_orddict.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_talk.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_vsn.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_semver.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_semver_parser.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_lists.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_file.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_cmd_log.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_dictionary.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_rbdict.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_plists.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_cnv.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_git_vsn.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_dict.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_assoc_list.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_compile.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_date.erl"]
===>      Compiled ec_dictionary.erl
===>      Compiled ec_vsn.erl
===> Starting 2 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_lists.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_rbdict.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_gb_trees.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_semver.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_assoc_list.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_cnv.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_talk.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_file.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_git_vsn.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_plists.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_semver_parser.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_dict.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_cmd_log.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_orddict.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_compile.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_date.erl
===> Compiling eunit_formatters
===> erlopts [debug_info,{d,namespaced_dicts}]
===> files to compile ["/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters/src/eunit_progress.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters/src/binomial_heap.erl"]
===> Starting 2 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters/src/binomial_heap.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters/src/eunit_progress.erl
===> Compiling getopt
===> erlopts [warn_unused_vars,warn_export_all,warn_shadow_vars,
                     warn_unused_import,warn_unused_function,warn_bif_clash,
                     warn_unused_record,warn_deprecated_function,
                     warn_obsolete_guard,strict_validation,warn_export_vars,
                     warn_exported_vars,warn_missing_spec,warn_untyped_record,
                     debug_info,
                     {d,unicode_str}]
===> files to compile ["/home/ferd/code/self/rebar3/_build/default/lib/getopt/src/getopt.erl"]
===> Starting 1 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/getopt/src/getopt.erl
===> Compiling providers
===> erlopts [debug_info]
===> files to compile ["/home/ferd/code/self/rebar3/_build/default/lib/providers/src/providers.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/providers/src/provider.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/providers/src/providers_topo.erl"]
===> Starting 2 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/providers/src/provider.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/providers/src/providers_topo.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/providers/src/providers.erl
===> Compiling relx
===> erlopts [{d,'RLX_LOG',rebar_log},
                     debug_info,warnings_as_errors,inline]
===> files to compile ["/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_relup.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_string.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_assemble.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_release.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/relx.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_log.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_state.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_resolve.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_config.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_file_utils.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_app_info.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_util.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_overlay.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_tar.erl"]
===> Starting 2 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/relx.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_tar.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_state.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_release.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_util.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_app_info.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_overlay.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_file_utils.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_log.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_string.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_config.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_relup.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_resolve.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_assemble.erl
===> Compiling ssl_verify_fun
===> erlopts [debug_info]
===> files to compile ["/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_pk.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_fun_encodings.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_string.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_fun_cert_helpers.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_util.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_hostname.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_fingerprint.erl"]
===> Starting 2 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_util.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_fun_encodings.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_hostname.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_pk.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_string.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_fingerprint.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_fun_cert_helpers.erl
===> Compiling parse_trans
===> erlopts [debug_info]
===> files to compile ["/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/parse_trans_pp.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/exprecs.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/parse_trans.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/ct_expand.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/parse_trans_mod.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/parse_trans_codegen.erl"]
===>      Compiled parse_trans.erl
===>      Compiled parse_trans_pp.erl
===>      Compiled parse_trans_codegen.erl
===>      Compiled ct_expand.erl
===> Starting 2 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/parse_trans_mod.erl
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/exprecs.erl
===> Compiling certifi
===> erlopts [debug_info,deterministic,{d,'OTP_20_AND_ABOVE'}]
===> files to compile ["/home/ferd/code/self/rebar3/_build/default/lib/certifi/src/certifi.erl"]
===> Starting 1 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/_build/default/lib/certifi/src/certifi.erl
===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/getopt", post_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/providers", post_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cf", post_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons", post_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/bbmustache", post_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/relx", post_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters", post_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cth_readable", post_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/parse_trans", post_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/certifi", post_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun", post_hooks, erlc_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/getopt", pre_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/providers", pre_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cf", pre_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons", pre_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/bbmustache", pre_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/relx", pre_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters", pre_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cth_readable", pre_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/parse_trans", pre_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/certifi", pre_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun", pre_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/getopt", post_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/providers", post_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cf", post_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons", post_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/bbmustache", post_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/relx", post_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters", post_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cth_readable", post_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/parse_trans", post_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/certifi", post_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun", post_hooks, app_compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/getopt", post_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/providers", post_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cf", post_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons", post_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/bbmustache", post_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/relx", post_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters", post_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/cth_readable", post_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/parse_trans", post_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/certifi", post_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun", post_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3", pre_hooks, compile) -> no hooks defined

===> Compile (project_apps)
===> run_hooks("/home/ferd/code/self/rebar3", pre_hooks, compile) -> no hooks defined

===> run_hooks("/home/ferd/code/self/rebar3", pre_hooks, erlc_compile) -> no hooks defined

===> Analyzing applications...
===> Failed to list /home/ferd/code/self/rebar3/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/include, enoent
===> Failed to list /home/ferd/code/self/rebar3/include, enoent
===> Compiling rebar
===> erlopts [debug_info,
                     {d,rand_only},
                     {d,unicode_str},
                     {d,filelib_find_source},
                     warnings_as_errors]
===> files to compile ["/home/ferd/code/self/rebar3/src/r3_hex_api_package_owner.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_app_discovery.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_bare_compile.erl",
                              "/home/ferd/code/self/rebar3/src/cth_retry.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_common_test.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_string.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_shell.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_repos.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_packages.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_resource.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_resource_v2.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_dir.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_uri.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_fetch.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_alias.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_tarball.erl",
                              "/home/ferd/code/self/rebar3/src/r3_safe_erl_term.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_yrl.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_config.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_pb_signed.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_local_install.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_api.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_pb_package.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_paths.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_api_package.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_local_upgrade.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_file_utils.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_path.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_unlock.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_dialyzer_format.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_git_subdir_resource.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_api_release.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_deps_tree.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_erl_tar.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_dist_utils.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_report.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_clean.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_edoc.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_xrl.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_agent.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_pb_versions.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_hg_resource.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_compile.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_git_resource.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_plugins.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_dialyzer.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_relx.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_lock.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_base_compiler.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_escriptize.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_plugins_upgrade.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_api_key.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_mib.erl",
                              "/home/ferd/code/self/rebar3/src/rebar3.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_install_deps.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_state.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_release.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_api_user.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_help.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_erl.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_otp_app.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_deps.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_new.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_env.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_app_discover.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_hooks.erl",
                              "/home/ferd/code/self/rebar3/src/r3.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_http.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_http_httpc.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_dag.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_get_deps.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_pkg_resource.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_cover.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_tar.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_eunit.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_plugins.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_state.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_xref.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_core.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_hex_repos.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_epp.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_templater.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_core.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_erlc_compiler.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_digraph.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_filename.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_version.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_do.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_utils.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_pb_names.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_as.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_user.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_parallel.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_repo.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_packages.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_registry.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_update.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_relup.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_opts.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_log.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_api.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_upgrade.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_app_info.erl",
                              "/home/ferd/code/self/rebar3/src/cth_fail_fast.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_app_utils.erl"]
===>      Compiled rebar_resource_v2.erl
===>      Compiled rebar_compiler.erl
===>      Compiled r3_hex_http.erl
===> Starting 2 worker(s)
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_relx.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_edoc.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_state.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_pb_versions.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_safe_erl_term.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_fetch.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_compiler_yrl.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_compiler_mib.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_git_resource.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_compiler_erl.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_release.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_opts.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_parallel.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_do.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_api_package.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_update.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_filename.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_tarball.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_uri.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_shell.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_repo.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_registry.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_relup.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_hg_resource.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_api_key.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_help.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_api.erl
===>      Compiled /home/ferd/code/self/rebar3/src/cth_retry.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_hex_repos.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_clean.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_repos.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_otp_app.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_deps_tree.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_dialyzer.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_common_test.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_packages.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_xref.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_agent.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_git_subdir_resource.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_dialyzer_format.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_packages.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_digraph.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_compiler_epp.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_paths.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_compile.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_app_discovery.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_string.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_unlock.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_templater.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_cover.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_env.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_new.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_config.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_local_install.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_install_deps.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_path.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_compiler_xrl.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_core.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_dist_utils.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_user.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_state.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_report.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_api_user.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_lock.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_plugins_upgrade.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_plugins.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_pb_package.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_http_httpc.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_utils.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_api_package_owner.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_bare_compile.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_compiler_dag.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_app_discover.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_alias.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_hooks.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_upgrade.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_tar.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_eunit.erl
===>      Compiled /home/ferd/code/self/rebar3/src/cth_fail_fast.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_base_compiler.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_app_utils.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_app_info.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_resource.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_erlc_compiler.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_file_utils.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_core.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar3.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_log.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_deps.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_api_release.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_api.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_erl_tar.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_version.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_pkg_resource.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_pb_names.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_dir.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_local_upgrade.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_get_deps.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_plugins.erl
===>      Compiled /home/ferd/code/self/rebar3/src/r3_hex_pb_signed.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_as.erl
===>      Compiled /home/ferd/code/self/rebar3/src/rebar_prv_escriptize.erl
===> run_hooks("/home/ferd/code/self/rebar3", pre_hooks, app_compile) -> no hooks defined

===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: git log -n 1 --pretty=format:"%h
" 

===> 	opts: [{use_stdout,false},
                       return_on_error,
                       {cd,"/home/ferd/code/self/rebar3"}]

===> Port Cmd: git log -n 1 --pretty=format:"%h
" 
Port Opts: [{cd,"/home/ferd/code/self/rebar3"},
            exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: git -c color.ui=false log --oneline --no-walk --tags --decorate

===> 	opts: [{use_stdout,false},
                       return_on_error,
                       {cd,"/home/ferd/code/self/rebar3"}]

===> Port Cmd: git -c color.ui=false log --oneline --no-walk --tags --decorate
Port Opts: [{cd,"/home/ferd/code/self/rebar3"},
            exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: git describe --tags --abbrev=0

===> 	opts: [{use_stdout,false},
                       return_on_error,
                       {cd,"/home/ferd/code/self/rebar3"}]

===> Port Cmd: git describe --tags --abbrev=0
Port Opts: [{cd,"/home/ferd/code/self/rebar3"},
            exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: git rev-list HEAD

===> 	opts: [{use_stdout,false},
                       {cd,"/home/ferd/code/self/rebar3"},
                       {debug_abort_on_error,
                           "Getting rev-list of git dependency failed in /home/ferd/code/self/rebar3"}]

===> Port Cmd: git rev-list HEAD
Port Opts: [{cd,"/home/ferd/code/self/rebar3"},
            exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]

===> run_hooks("/home/ferd/code/self/rebar3", post_hooks, compile) -> no hooks defined

===> Provider: {default,escriptize}
===> run_hooks("/home/ferd/code/self/rebar3", pre_hooks, escriptize) -> no hooks defined

===> Building escript for rebar...
===> Creating escript file /home/ferd/code/self/rebar3/_build/default/bin/rebar3
===> processing <<"rebar">>
===> new deps of <<"rebar">> found to be [<<"getopt">>,
                                                 <<"erlware_commons">>,
                                                 <<"providers">>,
                                                 <<"bbmustache">>,
                                                 <<"ssl_verify_fun">>,
                                                 <<"certifi">>,
                                                 <<"cth_readable">>,
                                                 <<"relx">>,<<"cf">>,
                                                 <<"eunit_formatters">>]
===> processing <<"getopt">>
===> new deps of <<"getopt">> found to be []
===> processing <<"erlware_commons">>
===> new deps of <<"erlware_commons">> found to be []
===> processing <<"providers">>
===> new deps of <<"providers">> found to be []
===> processing <<"bbmustache">>
===> new deps of <<"bbmustache">> found to be []
===> processing <<"ssl_verify_fun">>
===> new deps of <<"ssl_verify_fun">> found to be []
===> processing <<"certifi">>
===> new deps of <<"certifi">> found to be []
===> processing <<"cth_readable">>
===> new deps of <<"cth_readable">> found to be []
===> processing <<"relx">>
===> new deps of <<"relx">> found to be []
===> processing <<"cf">>
===> new deps of <<"cf">> found to be []
===> processing <<"eunit_formatters">>
===> new deps of <<"eunit_formatters">> found to be []
===> sh info:
	cwd: "/home/ferd/code/self/rebar3"
	cmd: cp "$REBAR_BUILD_DIR/bin/rebar3" ./rebar3

===> 	opts: [use_stdout,
                       {cd,"/home/ferd/code/self/rebar3"},
                       {env,[{"REBAR_DEPS_DIR",
                              "/home/ferd/code/self/rebar3/_build/default/lib"},
                             {"REBAR_BUILD_DIR",
                              "/home/ferd/code/self/rebar3/_build/default"},
                             {"REBAR_ROOT_DIR",
                              "/home/ferd/code/self/rebar3/."},
                             {"REBAR_CHECKOUTS_DIR",
                              "/home/ferd/code/self/rebar3/_checkouts"},
                             {"REBAR_CHECKOUTS_OUT_DIR",
                              "/home/ferd/code/self/rebar3/_build/default/checkouts"},
                             {"REBAR_PLUGINS_DIR",
                              "/home/ferd/code/self/rebar3/_build/default/plugins"},
                             {"REBAR_GLOBAL_CONFIG_DIR",
                              "/home/ferd/.config/rebar3"},
                             {"REBAR_GLOBAL_CACHE_DIR",
                              "/home/ferd/.cache/rebar3"},
                             {"REBAR_TEMPLATE_DIR",
                              "/home/ferd/.config/rebar3/templates"},
                             {"REBAR_APP_DIRS",
                              "/home/ferd/code/self/rebar3/_build/default/apps/*:/home/ferd/code/self/rebar3/_build/default/lib/*:/home/ferd/code/self/rebar3/_build/default/."},
                             {"REBAR_SRC_DIRS",[]},
                             {"ERLANG_ERTS_VER","11.0"},
                             {"ERLANG_ROOT_DIR","/home/ferd/bin/erls/23.0"},
                             {"ERL","/home/ferd/bin/erls/23.0/bin/erl"},
                             {"ERLC","/home/ferd/bin/erls/23.0/bin/erlc"},
                             {"ERLANG_ARCH","64"},
                             {"ERLANG_TARGET",
                              "23.0-x86_64-unknown-linux-gnu-64"},
                             {"ERLANG_LIB_DIR_erl_interface",
                              "/home/ferd/bin/erls/23.0/lib/erl_interface-4.0"},
                             {"ERLANG_LIB_VER_erl_interface","4.0"}]},
                       {abort_on_error,"Hook for escriptize failed!\n"}]

===> Port Cmd: cp "$REBAR_BUILD_DIR/bin/rebar3" ./rebar3
Port Opts: [{cd,"/home/ferd/code/self/rebar3"},
            {env,[{"REBAR_DEPS_DIR",
                   "/home/ferd/code/self/rebar3/_build/default/lib"},
                  {"REBAR_BUILD_DIR",
                   "/home/ferd/code/self/rebar3/_build/default"},
                  {"REBAR_ROOT_DIR","/home/ferd/code/self/rebar3/."},
                  {"REBAR_CHECKOUTS_DIR",
                   "/home/ferd/code/self/rebar3/_checkouts"},
                  {"REBAR_CHECKOUTS_OUT_DIR",
                   "/home/ferd/code/self/rebar3/_build/default/checkouts"},
                  {"REBAR_PLUGINS_DIR",
                   "/home/ferd/code/self/rebar3/_build/default/plugins"},
                  {"REBAR_GLOBAL_CONFIG_DIR","/home/ferd/.config/rebar3"},
                  {"REBAR_GLOBAL_CACHE_DIR","/home/ferd/.cache/rebar3"},
                  {"REBAR_TEMPLATE_DIR","/home/ferd/.config/rebar3/templates"},
                  {"REBAR_APP_DIRS",
                   "/home/ferd/code/self/rebar3/_build/default/apps/*:/home/ferd/code/self/rebar3/_build/default/lib/*:/home/ferd/code/self/rebar3/_build/default/."},
                  {"REBAR_SRC_DIRS",[]},
                  {"ERLANG_ERTS_VER","11.0"},
                  {"ERLANG_ROOT_DIR","/home/ferd/bin/erls/23.0"},
                  {"ERL","/home/ferd/bin/erls/23.0/bin/erl"},
                  {"ERLC","/home/ferd/bin/erls/23.0/bin/erlc"},
                  {"ERLANG_ARCH","64"},
                  {"ERLANG_TARGET","23.0-x86_64-unknown-linux-gnu-64"},
                  {"ERLANG_LIB_DIR_erl_interface",
                   "/home/ferd/bin/erls/23.0/lib/erl_interface-4.0"},
                  {"ERLANG_LIB_VER_erl_interface","4.0"}]},
            exit_status,
            {line,16384},
            use_stdio,stderr_to_stdout,hide,eof,binary]
```

</details>

### This Pull Request

<details>
<summary>
Click to unfurl

```
λ rebar3 → diagnostic-debug-modes* → DEBUG=1 rebar3 escriptize
===> Load global config file /home/ferd/.config/rebar3/rebar.config
===> 23.0 satisfies the requirement for minimum OTP version 18
===> Expanded command sequence to be run: [app_discovery,install_deps,lock,compile,escriptize]
===> Running provider: app_discovery
===> Found top-level apps: [rebar]
	using config: [{src_dirs,["src"]},{lib_dirs,["apps/*","lib/*","."]}]
===> Running provider: install_deps
===> Verifying dependencies...
===> Fetching bbmustache v1.10.0
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/bbmustache-1.10.0.tar is up to date, reusing it                                                                                  
```

</summary>

```
λ rebar3 → diagnostic-debug-modes* → DEBUG=1 rebar3 escriptize                                                                                                                                                               
===> Load global config file /home/ferd/.config/rebar3/rebar.config
===> 23.0 satisfies the requirement for minimum OTP version 18
===> Expanded command sequence to be run: [app_discovery,install_deps,lock,compile,escriptize]
===> Running provider: app_discovery
===> Found top-level apps: [rebar]
	using config: [{src_dirs,["src"]},{lib_dirs,["apps/*","lib/*","."]}]
===> Running provider: install_deps
===> Verifying dependencies...
===> Fetching bbmustache v1.10.0
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/bbmustache-1.10.0.tar is up to date, reusing it
===> Fetching certifi v2.5.2
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/certifi-2.5.2.tar is up to date, reusing it
===> Fetching cf v0.3.1
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/cf-0.3.1.tar is up to date, reusing it
===> Fetching cth_readable v1.4.8
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/cth_readable-1.4.8.tar is up to date, reusing it
===> Evaluating config script "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/rebar.config.script"
===> Fetching erlware_commons v1.3.1
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/erlware_commons-1.3.1.tar is up to date, reusing it
===> Evaluating config script "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/rebar.config.script"
===> Fetching eunit_formatters v0.5.0
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/eunit_formatters-0.5.0.tar is up to date, reusing it
===> Fetching getopt v1.0.1
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/getopt-1.0.1.tar is up to date, reusing it
===> Fetching parse_trans v3.3.0
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/parse_trans-3.3.0.tar is up to date, reusing it
===> Fetching providers v1.8.1
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/providers-1.8.1.tar is up to date, reusing it
===> Fetching relx v4.0.2
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/relx-4.0.2.tar is up to date, reusing it
===> Fetching ssl_verify_fun v1.1.6
===> Version cached at /home/ferd/.cache/rebar3/hex/hexpm/packages/ssl_verify_fun-1.1.6.tar is up to date, reusing it
===> Running provider: lock
===> Running provider: compile
===> Compile (apps)
===> Running hooks for compile in app getopt (/home/ferd/code/self/rebar3/_build/default/lib/getopt) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for compile in app providers (/home/ferd/code/self/rebar3/_build/default/lib/providers) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for compile in app cf (/home/ferd/code/self/rebar3/_build/default/lib/cf) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for compile in app erlware_commons (/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for compile in app bbmustache (/home/ferd/code/self/rebar3/_build/default/lib/bbmustache) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for compile in app relx (/home/ferd/code/self/rebar3/_build/default/lib/relx) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for compile in app eunit_formatters (/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for compile in app cth_readable (/home/ferd/code/self/rebar3/_build/default/lib/cth_readable) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for compile in app parse_trans (/home/ferd/code/self/rebar3/_build/default/lib/parse_trans) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for compile in app certifi (/home/ferd/code/self/rebar3/_build/default/lib/certifi) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for compile in app ssl_verify_fun (/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app getopt (/home/ferd/code/self/rebar3/_build/default/lib/getopt) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app providers (/home/ferd/code/self/rebar3/_build/default/lib/providers) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app cf (/home/ferd/code/self/rebar3/_build/default/lib/cf) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app erlware_commons (/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app bbmustache (/home/ferd/code/self/rebar3/_build/default/lib/bbmustache) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app relx (/home/ferd/code/self/rebar3/_build/default/lib/relx) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app eunit_formatters (/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app cth_readable (/home/ferd/code/self/rebar3/_build/default/lib/cth_readable) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app parse_trans (/home/ferd/code/self/rebar3/_build/default/lib/parse_trans) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app certifi (/home/ferd/code/self/rebar3/_build/default/lib/certifi) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app ssl_verify_fun (/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun) with configuration:
===> 	{pre_hooks, []}.
===> Analyzing applications...
===> Compiling bbmustache
===> compile options: {erl_opts, [debug_info,
                                         {d,namespaced_types},
                                         warnings_as_errors,warn_export_all,
                                         warn_untyped_record]}.
===> files to analyze ["/home/ferd/code/self/rebar3/_build/default/lib/bbmustache/src/bbmustache.erl"]
===> Starting 1 worker(s)
===>      Compiled bbmustache.erl
===> Compiling cf
===> compile options: {erl_opts, [debug_info]}.
===> files to analyze ["/home/ferd/code/self/rebar3/_build/default/lib/cf/src/cf.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cf/src/cf_term.erl"]
===> Starting 2 worker(s)
===>      Compiled cf.erl
===>      Compiled cf_term.erl
===> Compiling cth_readable
===> compile options: {erl_opts, [debug_info]}.
===> files to analyze ["/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_failonly.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_helpers.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_compact_shell.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_transform.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_nosasl.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_lager_backend.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cth_readable_shell.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/cth_readable/src/cthr.erl"]
===> Starting 2 worker(s)
===>      Compiled cth_readable_transform.erl
===>      Compiled cth_readable_nosasl.erl
===>      Compiled cth_readable_lager_backend.erl
===>      Compiled cth_readable_compact_shell.erl
===>      Compiled cth_readable_failonly.erl
===>      Compiled cthr.erl
===>      Compiled cth_readable_shell.erl
===>      Compiled cth_readable_helpers.erl
===> Compiling erlware_commons
===> compile options: {erl_opts, [{d,namespaced_types},
                                         {d,have_callback_support},
                                         {d,rand_module},
                                         {d,unicode_str},
                                         debug_info,warnings_as_errors]}.
===> files to analyze ["/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_gb_trees.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_orddict.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_talk.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_vsn.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_semver.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_semver_parser.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_lists.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_file.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_cmd_log.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_dictionary.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_rbdict.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_plists.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_cnv.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_git_vsn.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_dict.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_assoc_list.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_compile.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons/src/ec_date.erl"]
===>      Compiled ec_dictionary.erl
===>      Compiled ec_vsn.erl
===> Starting 2 worker(s)
===>      Compiled ec_lists.erl
===>      Compiled ec_rbdict.erl
===>      Compiled ec_gb_trees.erl
===>      Compiled ec_semver.erl
===>      Compiled ec_assoc_list.erl
===>      Compiled ec_cnv.erl
===>      Compiled ec_talk.erl
===>      Compiled ec_file.erl
===>      Compiled ec_git_vsn.erl
===>      Compiled ec_plists.erl
===>      Compiled ec_semver_parser.erl
===>      Compiled ec_dict.erl
===>      Compiled ec_cmd_log.erl
===>      Compiled ec_orddict.erl
===>      Compiled ec_compile.erl
===>      Compiled ec_date.erl
===> Compiling eunit_formatters
===> compile options: {erl_opts, [debug_info,{d,namespaced_dicts}]}.
===> files to analyze ["/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters/src/eunit_progress.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters/src/binomial_heap.erl"]
===> Starting 2 worker(s)
===>      Compiled binomial_heap.erl
===>      Compiled eunit_progress.erl
===> Compiling getopt
===> compile options: {erl_opts, [warn_unused_vars,warn_export_all,
                                         warn_shadow_vars,warn_unused_import,
                                         warn_unused_function,warn_bif_clash,
                                         warn_unused_record,
                                         warn_deprecated_function,
                                         warn_obsolete_guard,
                                         strict_validation,warn_export_vars,
                                         warn_exported_vars,warn_missing_spec,
                                         warn_untyped_record,debug_info,
                                         {d,unicode_str}]}.
===> files to analyze ["/home/ferd/code/self/rebar3/_build/default/lib/getopt/src/getopt.erl"]
===> Starting 1 worker(s)
===>      Compiled getopt.erl
===> Compiling providers
===> compile options: {erl_opts, [debug_info]}.
===> files to analyze ["/home/ferd/code/self/rebar3/_build/default/lib/providers/src/providers.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/providers/src/provider.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/providers/src/providers_topo.erl"]
===> Starting 2 worker(s)
===>      Compiled provider.erl
===>      Compiled providers_topo.erl
===>      Compiled providers.erl
===> Compiling relx
===> compile options: {erl_opts, [{d,'RLX_LOG',rebar_log},
                                         debug_info,warnings_as_errors,inline]}.
===> files to analyze ["/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_relup.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_string.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_assemble.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_release.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/relx.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_log.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_state.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_resolve.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_config.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_file_utils.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_app_info.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_util.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_overlay.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/relx/src/rlx_tar.erl"]
===> Starting 2 worker(s)
===>      Compiled relx.erl
===>      Compiled rlx_tar.erl
===>      Compiled rlx_state.erl
===>      Compiled rlx_release.erl
===>      Compiled rlx_util.erl
===>      Compiled rlx_app_info.erl
===>      Compiled rlx_overlay.erl
===>      Compiled rlx_file_utils.erl
===>      Compiled rlx_log.erl
===>      Compiled rlx_string.erl
===>      Compiled rlx_relup.erl
===>      Compiled rlx_config.erl
===>      Compiled rlx_resolve.erl
===>      Compiled rlx_assemble.erl
===> Compiling ssl_verify_fun
===> compile options: {erl_opts, [debug_info]}.
===> files to analyze ["/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_pk.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_fun_encodings.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_string.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_fun_cert_helpers.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_util.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_hostname.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun/src/ssl_verify_fingerprint.erl"]
===> Starting 2 worker(s)
===>      Compiled ssl_verify_util.erl
===>      Compiled ssl_verify_fun_encodings.erl
===>      Compiled ssl_verify_string.erl
===>      Compiled ssl_verify_hostname.erl
===>      Compiled ssl_verify_pk.erl
===>      Compiled ssl_verify_fun_cert_helpers.erl
===>      Compiled ssl_verify_fingerprint.erl
===> Compiling parse_trans
===> compile options: {erl_opts, [debug_info]}.
===> files to analyze ["/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/parse_trans_pp.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/exprecs.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/parse_trans.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/ct_expand.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/parse_trans_mod.erl",
                              "/home/ferd/code/self/rebar3/_build/default/lib/parse_trans/src/parse_trans_codegen.erl"]
===>      Compiled parse_trans.erl
===>      Compiled parse_trans_pp.erl
===>      Compiled parse_trans_codegen.erl
===>      Compiled ct_expand.erl
===> Starting 2 worker(s)
===>      Compiled parse_trans_mod.erl
===>      Compiled exprecs.erl
===> Compiling certifi
===> compile options: {erl_opts, [debug_info,deterministic,
                                         {d,'OTP_20_AND_ABOVE'}]}.
===> files to analyze ["/home/ferd/code/self/rebar3/_build/default/lib/certifi/src/certifi.erl"]
===> Starting 1 worker(s)
===>      Compiled certifi.erl
===> Running hooks for erlc_compile in app getopt (/home/ferd/code/self/rebar3/_build/default/lib/getopt) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for erlc_compile in app providers (/home/ferd/code/self/rebar3/_build/default/lib/providers) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for erlc_compile in app cf (/home/ferd/code/self/rebar3/_build/default/lib/cf) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for erlc_compile in app erlware_commons (/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for erlc_compile in app bbmustache (/home/ferd/code/self/rebar3/_build/default/lib/bbmustache) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for erlc_compile in app relx (/home/ferd/code/self/rebar3/_build/default/lib/relx) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for erlc_compile in app eunit_formatters (/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for erlc_compile in app cth_readable (/home/ferd/code/self/rebar3/_build/default/lib/cth_readable) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for erlc_compile in app parse_trans (/home/ferd/code/self/rebar3/_build/default/lib/parse_trans) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for erlc_compile in app certifi (/home/ferd/code/self/rebar3/_build/default/lib/certifi) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for erlc_compile in app ssl_verify_fun (/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app getopt (/home/ferd/code/self/rebar3/_build/default/lib/getopt) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app providers (/home/ferd/code/self/rebar3/_build/default/lib/providers) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app cf (/home/ferd/code/self/rebar3/_build/default/lib/cf) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app erlware_commons (/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app bbmustache (/home/ferd/code/self/rebar3/_build/default/lib/bbmustache) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app relx (/home/ferd/code/self/rebar3/_build/default/lib/relx) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app eunit_formatters (/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app cth_readable (/home/ferd/code/self/rebar3/_build/default/lib/cth_readable) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app parse_trans (/home/ferd/code/self/rebar3/_build/default/lib/parse_trans) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app certifi (/home/ferd/code/self/rebar3/_build/default/lib/certifi) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app ssl_verify_fun (/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app getopt (/home/ferd/code/self/rebar3/_build/default/lib/getopt) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app providers (/home/ferd/code/self/rebar3/_build/default/lib/providers) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app cf (/home/ferd/code/self/rebar3/_build/default/lib/cf) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app erlware_commons (/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app bbmustache (/home/ferd/code/self/rebar3/_build/default/lib/bbmustache) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app relx (/home/ferd/code/self/rebar3/_build/default/lib/relx) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app eunit_formatters (/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app cth_readable (/home/ferd/code/self/rebar3/_build/default/lib/cth_readable) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app parse_trans (/home/ferd/code/self/rebar3/_build/default/lib/parse_trans) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app certifi (/home/ferd/code/self/rebar3/_build/default/lib/certifi) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app ssl_verify_fun (/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app getopt (/home/ferd/code/self/rebar3/_build/default/lib/getopt) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app providers (/home/ferd/code/self/rebar3/_build/default/lib/providers) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app cf (/home/ferd/code/self/rebar3/_build/default/lib/cf) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app erlware_commons (/home/ferd/code/self/rebar3/_build/default/lib/erlware_commons) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app bbmustache (/home/ferd/code/self/rebar3/_build/default/lib/bbmustache) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app relx (/home/ferd/code/self/rebar3/_build/default/lib/relx) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app eunit_formatters (/home/ferd/code/self/rebar3/_build/default/lib/eunit_formatters) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app cth_readable (/home/ferd/code/self/rebar3/_build/default/lib/cth_readable) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app parse_trans (/home/ferd/code/self/rebar3/_build/default/lib/parse_trans) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app certifi (/home/ferd/code/self/rebar3/_build/default/lib/certifi) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app ssl_verify_fun (/home/ferd/code/self/rebar3/_build/default/lib/ssl_verify_fun) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile with configuration:
===> 	{pre_hooks, []}.
===> Compile (project_apps)
===> Running hooks for compile in app rebar (/home/ferd/code/self/rebar3) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for erlc_compile in app rebar (/home/ferd/code/self/rebar3) with configuration:
===> 	{pre_hooks, []}.
===> Analyzing applications...
===> Compiling rebar
===> compile options: {erl_opts, [debug_info,
                                         {d,rand_only},
                                         {d,unicode_str},
                                         {d,filelib_find_source},
                                         warnings_as_errors]}.
===> files to analyze ["/home/ferd/code/self/rebar3/src/r3_hex_api_package_owner.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_app_discovery.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_bare_compile.erl",
                              "/home/ferd/code/self/rebar3/src/cth_retry.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_common_test.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_string.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_shell.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_repos.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_packages.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_resource.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_resource_v2.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_dir.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_uri.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_fetch.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_alias.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_tarball.erl",
                              "/home/ferd/code/self/rebar3/src/r3_safe_erl_term.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_yrl.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_config.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_pb_signed.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_local_install.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_api.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_pb_package.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_paths.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_api_package.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_local_upgrade.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_file_utils.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_path.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_unlock.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_dialyzer_format.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_git_subdir_resource.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_api_release.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_deps_tree.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_erl_tar.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_dist_utils.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_report.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_clean.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_edoc.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_xrl.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_agent.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_pb_versions.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_hg_resource.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_compile.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_git_resource.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_plugins.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_dialyzer.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_relx.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_lock.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_base_compiler.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_escriptize.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_plugins_upgrade.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_api_key.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_mib.erl",
                              "/home/ferd/code/self/rebar3/src/rebar3.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_install_deps.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_state.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_release.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_api_user.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_help.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_erl.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_otp_app.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_deps.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_new.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_env.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_app_discover.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_hooks.erl",
                              "/home/ferd/code/self/rebar3/src/r3.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_http.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_http_httpc.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_dag.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_get_deps.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_pkg_resource.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_cover.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_tar.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_eunit.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_plugins.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_state.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_xref.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_core.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_hex_repos.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler_epp.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_templater.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_core.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_erlc_compiler.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_digraph.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_filename.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_version.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_do.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_utils.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_pb_names.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_as.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_user.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_parallel.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_repo.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_packages.erl",
                              "/home/ferd/code/self/rebar3/src/r3_hex_registry.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_update.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_relup.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_opts.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_compiler.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_log.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_api.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_prv_upgrade.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_app_info.erl",
                              "/home/ferd/code/self/rebar3/src/cth_fail_fast.erl",
                              "/home/ferd/code/self/rebar3/src/rebar_app_utils.erl"]
===>      Compiled rebar_resource_v2.erl
===>      Compiled rebar_compiler.erl
===>      Compiled r3_hex_http.erl
===> Starting 2 worker(s)
===>      Compiled rebar_relx.erl
===>      Compiled rebar_prv_edoc.erl
===>      Compiled rebar_prv_state.erl
===>      Compiled r3_hex_pb_versions.erl
===>      Compiled rebar_fetch.erl
===>      Compiled r3_safe_erl_term.erl
===>      Compiled r3.erl
===>      Compiled rebar_compiler_yrl.erl
===>      Compiled rebar_compiler_mib.erl
===>      Compiled rebar_git_resource.erl
===>      Compiled rebar_compiler_erl.erl
===>      Compiled rebar_opts.erl
===>      Compiled rebar_prv_release.erl
===>      Compiled rebar_parallel.erl
===>      Compiled rebar_prv_do.erl
===>      Compiled r3_hex_api_package.erl
===>      Compiled rebar_prv_update.erl
===>      Compiled r3_hex_filename.erl
===>      Compiled r3_hex_tarball.erl
===>      Compiled rebar_uri.erl
===>      Compiled rebar_prv_shell.erl
===>      Compiled r3_hex_repo.erl
===>      Compiled r3_hex_registry.erl
===>      Compiled rebar_prv_relup.erl
===>      Compiled rebar_prv_help.erl
===>      Compiled r3_hex_api_key.erl
===>      Compiled rebar_hg_resource.erl
===>      Compiled rebar_api.erl
===>      Compiled cth_retry.erl
===>      Compiled rebar_hex_repos.erl
===>      Compiled rebar_prv_clean.erl
===>      Compiled rebar_prv_repos.erl
===>      Compiled rebar_otp_app.erl
===>      Compiled rebar_prv_deps_tree.erl
===>      Compiled rebar_prv_common_test.erl
===>      Compiled rebar_prv_packages.erl
===>      Compiled rebar_prv_xref.erl
===>      Compiled rebar_prv_dialyzer.erl
===>      Compiled rebar_agent.erl
===>      Compiled rebar_git_subdir_resource.erl
===>      Compiled rebar_dialyzer_format.erl
===>      Compiled rebar_packages.erl
===>      Compiled rebar_digraph.erl
===>      Compiled rebar_compiler_epp.erl
===>      Compiled rebar_paths.erl
===>      Compiled rebar_string.erl
===>      Compiled rebar_prv_app_discovery.erl
===>      Compiled rebar_prv_compile.erl
===>      Compiled rebar_prv_unlock.erl
===>      Compiled rebar_templater.erl
===>      Compiled rebar_env.erl
===>      Compiled rebar_prv_cover.erl
===>      Compiled rebar_config.erl
===>      Compiled rebar_prv_new.erl
===>      Compiled rebar_prv_local_install.erl
===>      Compiled rebar_prv_install_deps.erl
===>      Compiled rebar_user.erl
===>      Compiled rebar_compiler_xrl.erl
===>      Compiled r3_hex_core.erl
===>      Compiled rebar_prv_path.erl
===>      Compiled rebar_dist_utils.erl
===>      Compiled rebar_state.erl
===>      Compiled rebar_prv_report.erl
===>      Compiled r3_hex_api_user.erl
===>      Compiled rebar_prv_lock.erl
===>      Compiled rebar_prv_plugins_upgrade.erl
===>      Compiled rebar_prv_plugins.erl
===>      Compiled r3_hex_pb_package.erl
===>      Compiled r3_hex_http_httpc.erl
===>      Compiled rebar_utils.erl
===>      Compiled rebar_compiler_dag.erl
===>      Compiled r3_hex_api_package_owner.erl
===>      Compiled rebar_prv_bare_compile.erl
===>      Compiled rebar_prv_alias.erl
===>      Compiled rebar_app_discover.erl
===>      Compiled rebar_hooks.erl
===>      Compiled rebar_prv_eunit.erl
===>      Compiled rebar_prv_tar.erl
===>      Compiled rebar_prv_upgrade.erl
===>      Compiled cth_fail_fast.erl
===>      Compiled rebar_base_compiler.erl
===>      Compiled rebar_app_utils.erl
===>      Compiled rebar_app_info.erl
===>      Compiled rebar_resource.erl
===>      Compiled rebar_erlc_compiler.erl
===>      Compiled rebar_file_utils.erl
===>      Compiled rebar_core.erl
===>      Compiled rebar3.erl
===>      Compiled rebar_log.erl
===>      Compiled rebar_prv_deps.erl
===>      Compiled r3_hex_api_release.erl
===>      Compiled r3_hex_api.erl
===>      Compiled r3_hex_pb_names.erl
===>      Compiled rebar_prv_version.erl
===>      Compiled rebar_pkg_resource.erl
===>      Compiled r3_hex_erl_tar.erl
===>      Compiled rebar_dir.erl
===>      Compiled rebar_prv_local_upgrade.erl
===>      Compiled rebar_prv_get_deps.erl
===>      Compiled rebar_plugins.erl
===>      Compiled rebar_prv_as.erl
===>      Compiled r3_hex_pb_signed.erl
===>      Compiled rebar_prv_escriptize.erl
===> Running hooks for erlc_compile in app rebar (/home/ferd/code/self/rebar3) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for app_compile in app rebar (/home/ferd/code/self/rebar3) with configuration:
===> 	{pre_hooks, []}.
===> Running hooks for app_compile in app rebar (/home/ferd/code/self/rebar3) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile in app rebar (/home/ferd/code/self/rebar3) with configuration:
===> 	{post_hooks, []}.
===> Running hooks for compile with configuration:
===> 	{post_hooks, []}.
===> Running provider: escriptize
===> Running hooks for escriptize in app rebar (/home/ferd/code/self/rebar3) with configuration:
===> 	{pre_hooks, []}.
===> Building escript for rebar...
===> Creating escript file /home/ferd/code/self/rebar3/_build/default/bin/rebar3
===> processing <<"rebar">>
===> new deps of <<"rebar">> found to be [<<"getopt">>,
                                                 <<"erlware_commons">>,
                                                 <<"providers">>,
                                                 <<"bbmustache">>,
                                                 <<"ssl_verify_fun">>,
                                                 <<"certifi">>,
                                                 <<"cth_readable">>,
                                                 <<"relx">>,<<"cf">>,
                                                 <<"eunit_formatters">>]
===> processing <<"getopt">>
===> new deps of <<"getopt">> found to be []
===> processing <<"erlware_commons">>
===> new deps of <<"erlware_commons">> found to be []
===> processing <<"providers">>
===> new deps of <<"providers">> found to be []
===> processing <<"bbmustache">>
===> new deps of <<"bbmustache">> found to be []
===> processing <<"ssl_verify_fun">>
===> new deps of <<"ssl_verify_fun">> found to be []
===> processing <<"certifi">>
===> new deps of <<"certifi">> found to be []
===> processing <<"cth_readable">>
===> new deps of <<"cth_readable">> found to be []
===> processing <<"relx">>
===> new deps of <<"relx">> found to be []
===> processing <<"cf">>
===> new deps of <<"cf">> found to be []
===> processing <<"eunit_formatters">>
===> new deps of <<"eunit_formatters">> found to be []
===> Running hooks for escriptize in app rebar (/home/ferd/code/self/rebar3) with configuration:
===> 	{post_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)",
                               escriptize,
                               "cp \"$REBAR_BUILD_DIR/bin/rebar3\" ./rebar3"},
                              {"win32",escriptize,
                               "robocopy \"%REBAR_BUILD_DIR%/bin/\" ./ rebar3* /njs /njh /nfl /ndl & exit /b 0"}]}.

```

</details>