### PR TITLE
Patch `rebar_base_compiler` to handle extensions with no leading dot

### DIFF
--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -96,9 +96,17 @@ run(Config, FirstFiles, SourceDir, SourceExt, TargetDir, TargetExt,
       TargetDir :: file:filename(),
       SourceExt :: string(),
       TargetExt :: string().
-run(Config, FirstFiles, SourceDir, SourceExt, TargetDir, TargetExt,
+run(Config, FirstFiles, SourceDir, SourceExt0, TargetDir, TargetExt,
     Compile3Fn, Opts) ->
-    %% Convert simple extension to proper regex
+    %% Convert simple extension to proper regex.
+    %% If the extension has a leading dot (e.g.: `.peg')
+    %% we escape it.
+    %% Otherwise, if the extension doesn't have a leading dot
+    %% we add it ourselves (e.g.: `peg' -> `.peg')
+    SourceExt = case SourceExt0 of
+        [$.|_Ext] -> SourceExt0;
+        _ -> [$.] ++ SourceExt0
+    end,
     SourceExtRe = "^(?!\\._).*\\" ++ SourceExt ++ [$$],
 
     Recursive = proplists:get_value(recursive, Opts, true),


### PR DESCRIPTION
Closes #2378.