### PR TITLE
Make rebar3 templates check for name clashes

### DIFF
--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -196,6 +196,21 @@ maybe_warn_about_name(Vars) ->
             ok
     end.
 
+maybe_warn_about_name_clash(File) ->
+    case filename:extension(File) of
+        ".erl" ->
+            Module0 = re:replace(filename:basename(File), "\.erl", "", [{return, list}]),
+            Module = list_to_atom(Module0),
+            try Module:module_info() of
+                _ -> ?WARN("The module definition of '~ts' in file ~ts "
+                           "will clash with an existing Erlang module.",
+                           [Module, File])
+            catch
+                _:_ -> ok
+            end;
+        _ -> ok
+    end.
+
 validate_atom(Str) ->
     case io_lib:fread("~a", unicode:characters_to_list(Str)) of
         {ok, [Atom], ""} ->
@@ -258,6 +273,7 @@ execute_template([{template, From, To} | Terms], Files, {Template, Type, Cwd}, V
     In = expand_path(From, Vars),
     Out = expand_path(To, Vars),
     Tpl = load_file(Files, Type, filename:join(Cwd, In)),
+    maybe_warn_about_name_clash(Out),
     case write_file(Out, render(Tpl, Vars), Force) of
         ok ->
             ok;

--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -199,7 +199,7 @@ maybe_warn_about_name(Vars) ->
 maybe_warn_about_name_clash(File) ->
     case filename:extension(File) of
         ".erl" ->
-            Module0 = re:replace(filename:basename(File), "\.erl", "", [{return, list}]),
+            Module0 = re:replace(filename:basename(File), "\\.erl$", "", [{return, list}]),
             Module = list_to_atom(Module0),
             try Module:module_info() of
                 _ -> ?WARN("The module definition of '~ts' in file ~ts "


### PR DESCRIPTION
This commit changes rebar3 to check for name clashes of the
modules created from its templates with existing Erlang modules
to produce a non-blocking warning for each clashing module.

It does so by checking if any of the modules that will be created
is already defined in the path and, to do so, reimplements the function
`code:all_available/0` when rebar3 is used with a version of Erlang/OTP
older than 23.0, as said function was added in that release.

Should close #1386.