### PR TITLE
Run pkg updates on plugin upgrades

### DIFF
--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -60,12 +60,7 @@ lock(AppInfo, _) ->
       Res :: boolean().
 needs_update(AppInfo, _) ->
     {pkg, _Name, Vsn, _OldHash, _Hash, _} = rebar_app_info:source(AppInfo),
-    case rebar_utils:to_binary(rebar_app_info:original_vsn(AppInfo)) =:= rebar_utils:to_binary(Vsn) of
-        true ->
-            false;
-        false ->
-            true
-    end.
+    rebar_utils:to_binary(rebar_app_info:original_vsn(AppInfo)) =/= rebar_utils:to_binary(Vsn).
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/src/rebar_prv_plugins_upgrade.erl
+++ b/src/rebar_prv_plugins_upgrade.erl
@@ -62,6 +62,7 @@ upgrade(Plugin, State) ->
             ?PRV_ERROR({not_found, Plugin});
         {ok, P, Profile} ->
             State1 = rebar_state:set(State, deps_dir, ?DEFAULT_PLUGINS_DIR),
+            maybe_update_pkg(P, State1),
             {Apps, State2} = rebar_prv_install_deps:handle_deps_as_profile(Profile, State1, [P], true),
 
             {no_cycle, Sorted} = rebar_prv_install_deps:find_cycles(Apps),
@@ -92,3 +93,29 @@ find_plugin(Plugin, Profiles, State) ->
 build_plugin(ToBuild, State) ->
     Providers = rebar_state:providers(State),
     rebar_prv_compile:compile(State, Providers, ToBuild, plugins).
+
+maybe_update_pkg(Name, State) ->
+    try rebar_app_utils:parse_dep(root, ?DEFAULT_PLUGINS_DIR, Name, State, [], 0) of
+        AppInfo ->
+            Source = rebar_app_info:source(AppInfo),
+            case element(1, Source) of
+                pkg ->
+                    Resources = rebar_state:resources(State),
+                    #{repos := RepoConfigs} = rebar_resource_v2:find_resource_state(pkg, Resources),
+                    PkgName = element(2, Source),
+                    [update_package(PkgName, RepoConfig, State) || RepoConfig <- RepoConfigs];
+                _ ->
+                    skip
+            end
+    catch
+        throw:?PRV_ERROR({parse_dep, _}) ->
+            skip
+    end.
+
+update_package(Name, RepoConfig, State) ->
+    case rebar_packages:update_package(Name, RepoConfig, State) of
+        fail ->
+            ?WARN("Failed to fetch updates for package ~ts from repo ~ts", [Name, maps:get(name, RepoConfig)]);
+        _ ->
+            ok
+    end.


### PR DESCRIPTION
Upgrading dependencies already checked for package updates before running
the upgrade task. Plugins didn't have that mechanism in place and that
made upgrading plugins over hex trickier since users could be stuck a
long time without running an update manually.

This fix mostly readapts existing dep code to the context of plugins to
look them up one at a time and run the update as part of the upgrade.