### PR TITLE
Remove verbosity option that was taken out in relx 4.x

### DIFF
--- a/src/rebar_relx.erl
+++ b/src/rebar_relx.erl
@@ -190,8 +190,6 @@ opt_spec_list() ->
       "Print usage"},
      {lib_dir, $l, "lib-dir", string,
       "Additional dir that should be searched for OTP Apps"},
-     {log_level, $V, "verbose", {integer, 2},
-      "Verbosity level, maybe between 0 and 3"},
      {dev_mode, $d, "dev-mode", boolean,
       "Symlink the applications and configuration into the release instead of copying"},
      {include_erts, $i, "include-erts", string,


### PR DESCRIPTION
[Fix #1880]

From what I could gather these options were taken/copied from `relx` 3.x then `verbose`/`log_level` was removed from `relx` but the option stayed documented in `rebar3`.