### PR TITLE
Fix compile issue on windows when language is not english

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -163,13 +163,17 @@ win32_mklink_ok({error,{1,"Cannot create a file when that file already exists.\n
     % File or dir is already in place; find if it is already a symlink (true) or
     % if it is a directory (copy-required; false)
     is_symlink(Target);
-win32_mklink_ok(_, _) ->
-    false.
+win32_mklink_ok(_, Target) ->
+    is_symlink(Target).
 
 %% @private
 is_symlink(Filename) ->
-    {ok, Info} = file:read_link_info(Filename),
-    Info#file_info.type == symlink.
+    case file:read_link_info(Filename) of
+        {ok, Info} ->
+            Info#file_info.type == symlink;
+        _ ->
+            false
+    end.
 
 %% @private
 %% drops the last 'node' of the filename, presumably the last dir such as 'src'

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -675,12 +675,20 @@ debug_and_abort(Command, {Rc, Output}) ->
           "~ts", [Command, Rc, Output]),
     throw(rebar_abort).
 
+port_line_to_list(Line) ->
+    case unicode:characters_to_list(Line) of
+        LineList when is_list(LineList) ->
+            LineList;
+        _ ->
+            binary_to_list(Line)
+    end.
+
 sh_loop(Port, Fun, Acc) ->
     receive
         {Port, {data, {eol, Line}}} ->
-            sh_loop(Port, Fun, Fun(unicode:characters_to_list(Line) ++ "\n", Acc));
+            sh_loop(Port, Fun, Fun(port_line_to_list(Line) ++ "\n", Acc));
         {Port, {data, {noeol, Line}}} ->
-            sh_loop(Port, Fun, Fun(unicode:characters_to_list(Line), Acc));
+            sh_loop(Port, Fun, Fun(port_line_to_list(Line), Acc));
         {Port, eof} ->
             Data = lists:flatten(lists:reverse(Acc)),
             receive


### PR DESCRIPTION
Fixes #2371 
when match file link result, if output match ok fail, then recheck link target, if target is is link file already do nothing.
fix match error in `rebar_util:sh_loop`.