### PR TITLE
Support pre-fetched deps for nix.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -20,8 +20,10 @@ main(_) ->
     %% cause weird failures when compilers get modified between releases.
     rm_rf("_build/prod"),
     %% The same pattern happens with default/ as well, particularly when
-    %% developig new things.
-    rm_rf("_build/default"),
+    %% developing new things. 
+    %% Keep other deps in default/lib for build environments like Nix
+    %% where internet access is disabled that deps are not downloadable.
+    rm_rf("_build/default/lib/rebar"),
 
     %% We fetch a few deps from hex for boostraping,
     %% so we must compile r3_safe_erl_term.xrl which


### PR DESCRIPTION
Downloading dependencies during build is not possible in some environments like nix.
Nix pre-download all the deps into `_build/default/lib` and disable internet access during build.

So, `_build/default/lib` shouldn't be deleted at startup.

