### PR TITLE
set explicit encoding when reading and writing hex config

### DIFF
--- a/src/rebar_hex_repos.erl
+++ b/src/rebar_hex_repos.erl
@@ -163,5 +163,6 @@ update_auth_config(Updates, State) ->
     Config = auth_config(State),
     AuthConfigFile = auth_config_file(State),
     ok = filelib:ensure_dir(AuthConfigFile),
-    NewConfig = iolist_to_binary([io_lib:print(maps:merge(Config, Updates)) | ".\n"]),
-    ok = file:write_file(AuthConfigFile, NewConfig).
+    NewConfig = iolist_to_binary(["%% coding: utf-8", io_lib:nl(),
+                                  io_lib:print(maps:merge(Config, Updates)), ".", io_lib:nl()]),
+    ok = file:write_file(AuthConfigFile, NewConfig, [{encoding, utf8}]).

--- a/test/rebar_pkg_repos_SUITE.erl
+++ b/test/rebar_pkg_repos_SUITE.erl
@@ -9,7 +9,8 @@
 
 all() ->
     [default_repo, repo_merging, repo_replacing,
-     auth_merging, auth_config_errors, organization_merging, {group, resolve_version}].
+     auth_read_write_read, auth_merging, auth_config_errors, organization_merging,
+     {group, resolve_version}].
 
 groups() ->
     [{resolve_version, [use_first_repo_match, use_exact_with_hash, fail_repo_update,
@@ -270,6 +271,11 @@ auth_config_errors(_Config) ->
     ?assertEqual(undefined, maps:get(read_key, UpdatedRepo2, undefined)),
     ?assertEqual(undefined, maps:get(write_key, DefaultRepo, undefined)),
     ok.
+
+auth_read_write_read(_Config) ->
+    State = rebar_state:new([]),
+    rebar_hex_repos:update_auth_config(#{"foo" => <<200>>}, State),
+    rebar_hex_repos:update_auth_config(#{"foo" => <<200>>}, State).
 
 organization_merging(_Config) ->
     Repo1 = #{name => <<"hexpm:repo-1">>,


### PR DESCRIPTION
(fixes tsloughter/rebar3_hex#184)

The issue was that the bytes were written "as is" on disk, while Erlang source files are expected to be utf8 (and no longer latin1) by default since Erlang/OTP 17.0 (as per https://erlang.org/doc/reference_manual/character_set.html)
e.g. byte <<200>> (0xC8) is not valid utf8, but was written as is, causing `file:consult` to raise an encoding error.

It is preferable not to rely on default behavior, and specify an encoding both at write and read time.
This PR specifies utf8 (probably more future-proof than latin1) when calling `file:write_file` and adds the encoding at the top of the file for future reads via `file:consult` (as per https://erlang.org/doc/reference_manual/character_set.html#source-file-encoding).

The test writes to the actual config at the moment. How should I stub it out, knowing that it should still use `file:file_write` and `file:consult` and have the same semantics? Maybe an in-memory file, etc

cc @starbelly @ferd 