### PR TITLE
Add regression test for dep override infinite loop

### DIFF
--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -1780,7 +1780,10 @@ override_del_pkg_deps(Config) ->
         {deps, TopDeps},
         {overrides, [
             {del, some_dep, [
-                {deps, [other_dep]}
+                {deps, [other_dep]},
+                %% regression: a non-existing option deletion
+                %% could trigger an infinite loop
+                {provider_hooks, [{post, [{compile, xref}]}]}
             ]}
         ]}
     ],


### PR DESCRIPTION
Completes the fix presented in #2381

Uses an existing test to simply inject the regression.