### PR TITLE
Fix spec for download callback

### DIFF
--- a/src/rebar_resource_v2.erl
+++ b/src/rebar_resource_v2.erl
@@ -30,7 +30,7 @@
 
 -callback init(type(), rebar_state:t()) -> {ok, resource()}.
 -callback lock(rebar_app_info:t(), resource_state()) -> source().
--callback download(file:filename_all(), rebar_app_info:t(), resource_state(), rebar_state:t()) ->
+-callback download(file:filename_all(), rebar_app_info:t(), rebar_state:t(), resource_state()) ->
     ok | {error, any()}.
 -callback needs_update(rebar_app_info:t(), resource_state()) -> boolean().
 -callback make_vsn(rebar_app_info:t(), resource_state()) ->


### PR DESCRIPTION
Unless I understand the code wrong, the custom state always comes last in resource_run.