### PR TITLE
Attempt to add checkout location to rebar3 path

### DIFF
--- a/src/rebar_prv_path.erl
+++ b/src/rebar_prv_path.erl
@@ -81,11 +81,14 @@ lib_dir(State)  -> io_lib:format("~ts", [rebar_dir:deps_dir(State)]).
 rel_dir(State)  -> io_lib:format("~ts/rel", [rebar_dir:base_dir(State)]).
 
 ebin_dirs(Apps, State) ->
-    lists:map(fun(App) -> io_lib:format("~ts/~ts/ebin", [rebar_dir:deps_dir(State), App]) end, Apps).
+    lists:flatmap(fun(App) -> [io_lib:format("~ts/~ts/ebin", [rebar_dir:checkouts_out_dir(State), App]),
+                               io_lib:format("~ts/~ts/ebin", [rebar_dir:deps_dir(State), App]) ] end, Apps).
 priv_dirs(Apps, State) ->
-    lists:map(fun(App) -> io_lib:format("~ts/~ts/priv", [rebar_dir:deps_dir(State), App]) end, Apps).
+    lists:flatmap(fun(App) -> [io_lib:format("~ts/~ts/priv", [rebar_dir:checkouts_out_dir(State), App]),
+                               io_lib:format("~ts/~ts/priv", [rebar_dir:deps_dir(State), App]) ] end, Apps).
 src_dirs(Apps, State) ->
-    lists:map(fun(App) -> io_lib:format("~ts/~ts/src", [rebar_dir:deps_dir(State), App]) end, Apps).
+    lists:flatmap(fun(App) -> [io_lib:format("~ts/~ts/src", [rebar_dir:checkouts_out_dir(State), App]),
+                               io_lib:format("~ts/~ts/src", [rebar_dir:deps_dir(State), App]) ] end, Apps).
 
 print_paths_if_exist(Paths, State) ->
     {RawOpts, _} = rebar_state:command_parsed_args(State),


### PR DESCRIPTION
A first bash for conversation regarding issue #2420 

My initial thought was "I'll just do what rebar3 shell does", but that of course doesn't work because that would make everything very slow indeed, so instead I just add the calculated checkouts dir to the list that then gets filtered by an 'dir exists' clause.

As it stands, that would  mean that priv/src would be to the symlinks back to _checkouts, so maybe they'd  just be better off using checkouts_dir which would  do that for us..