### PR TITLE
Add rebar_hex_repos:remove_from_auth_config/2

### DIFF
--- a/src/rebar_hex_repos.erl
+++ b/src/rebar_hex_repos.erl
@@ -3,6 +3,7 @@
 -export([from_state/2,
          get_repo_config/2,
          auth_config/1,
+         remove_from_auth_config/2,
          update_auth_config/2,
          format_error/1]).
 
@@ -158,11 +159,19 @@ auth_config(State) ->
             ?ABORT("Error found in repos auth config (~ts) at line ~ts", [AuthFile, Reason])
     end.
 
+-spec remove_from_auth_config(term(), rebar_state:t()) -> ok.
+remove_from_auth_config(Key, State) ->
+    Updated = maps:remove(Key, auth_config(State)),
+    write_auth_config(Updated, State).
+
 -spec update_auth_config(map(), rebar_state:t()) -> ok.
 update_auth_config(Updates, State) ->
-    Config = auth_config(State),
+    Updated = maps:merge(auth_config(State), Updates),
+    write_auth_config(Updated, State).
+
+write_auth_config(Config, State) ->
     AuthConfigFile = auth_config_file(State),
     ok = filelib:ensure_dir(AuthConfigFile),
     NewConfig = iolist_to_binary(["%% coding: utf-8", io_lib:nl(),
-                                  io_lib:print(maps:merge(Config, Updates)), ".", io_lib:nl()]),
+                                  io_lib:print(Config), ".", io_lib:nl()]),
     ok = file:write_file(AuthConfigFile, NewConfig, [{encoding, utf8}]).


### PR DESCRIPTION
 - add function that allows the complete removal of an entry from auth
 config

 - add test for rebar_hex_repos:remove_from_auth_config/2

 - update test/rebar_pkg_repos_SUITE:auth_read_write_read/1 to use mocks so
 we don't append to actual hex.config files