### PR TITLE
fix logger reset for the shell plugin

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -171,8 +171,8 @@ maybe_remove_logger() ->
 
 maybe_reset_logger(ignore) ->
     ok;
-maybe_reset_logger({restart, #{module := Mod, config := Cfg}}) ->
-    logger:add_handler(default, Mod, Cfg).
+maybe_reset_logger({restart, Config = #{module := Mod}}) ->
+    logger:add_handler(default, Mod, Config).
 
 kill_old_user() ->
     OldUser = whereis(user),


### PR DESCRIPTION
The shell plugin has to reset the logger by fetching its configuration and
re-applying it later. In the current state, `maybe_reset_logger/1` will only
re-apply part of the configuration (the `config` key), which does not include
other settings such as filters and formatters.

The effect can be demonstrated by adding filters or formatters to `~/.erlang`
and running rebar3 shell on any project (without any --config argument, this
one reload the logger env; updating the kernel/logger environment in
`~/.erlang` fixes it).

For example:
```erlang
logger:set_handler_config(default, #{formatter => {logger_formatter,
                                                   #{template => ["> ", msg, "\n"]}}}).
```

This patch makes sure the default handler is re-created with its entire
original configuration.