### PR TITLE
create release and upload escript for new tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,34 +1,47 @@
 name: Publish
 
 on:
-  release:
-    types: [published, created, edited]
+  push:
+    tags:
+      - '*'
 
 jobs:
   build:
-    name: Publish escript to release
+    name: Create release and publish escript for every new tag
     runs-on: ubuntu-latest
-
-    container:
-      image: erlang:19
 
     steps:
     - uses: actions/checkout@v2
+
+    - uses: gleam-lang/setup-erlang@v1.0.0
+      with:
+        otp-version: 19.3.6.13
     - name: Compile
       run: ./bootstrap
     - name: CT tests
       run: ./rebar3 ct
 
-    # - name: Upload Release Asset
-    #   id: upload-release-asset
-    #   uses: actions/upload-release-asset@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ github.event.release.upload_url }}
-    #     asset_path: ./rebar3
-    #     asset_name: rebar3
-    #     asset_content_type: application/zip
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./rebar3
+        asset_name: rebar3
+        asset_content_type: application/octet-stream
 
     - name: Configure AWS credentials
       if: "!github.event.release.prerelease"


### PR DESCRIPTION
If this works, from now on creating a tag will result in a github release being created and escript being uploaded to it as an asset. So after tag is created we'll wait for github to create the release and then can edit it to add the changelog info to it.