### PR TITLE
pass no_spawn_compiler_process to compile:file/2

### DIFF
--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -270,6 +270,7 @@ effects_code_generation(Option) ->
         verbose -> false;
         {cwd,_} -> false;
         {outdir, _} -> false;
+        no_spawn_compiler_process -> false;
         _ -> true
     end.
 

--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -129,7 +129,7 @@ dependencies(Source, _SourceDir, Dirs, DepOpts) ->
     end.
 
 compile(Source, [{_, OutDir}], Config, ErlOpts) ->
-    case compile:file(Source, [{outdir, OutDir} | ErlOpts]) of
+    case compile:file(Source, [{outdir, OutDir}, no_spawn_compiler_process | ErlOpts]) of
         {ok, _Mod} ->
             ok;
         {ok, _Mod, []} ->
@@ -145,7 +145,7 @@ compile(Source, [{_, OutDir}], Config, ErlOpts) ->
 
 compile_and_track(Source, [{Ext, OutDir}], Config, ErlOpts) ->
     rebar_compiler_epp:flush(),
-    BuildOpts = [{outdir, OutDir} | ErlOpts],
+    BuildOpts = [{outdir, OutDir}, no_spawn_compiler_process | ErlOpts],
     Target = target_base(OutDir, Source) ++ Ext,
     {ok, CompileVsn} = application:get_key(compiler, vsn),
     AllOpts = case erlang:function_exported(compile, env_compiler_options, 0) of

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -564,7 +564,8 @@ internal_erl_compile(Opts, Dir, Module, OutDir, ErlOpts, RebarOpts) ->
     ok = filelib:ensure_dir(Target),
     PrivIncludes = [{i, filename:join(Dir, Src)}
                     || Src <- rebar_dir:all_src_dirs(RebarOpts, ["src"], [])],
-    AllOpts = [{outdir, filename:dirname(Target)}] ++ ErlOpts ++ PrivIncludes ++
+    AllOpts = [{outdir, filename:dirname(Target)}, no_spawn_compiler_process]
+              ++ ErlOpts ++ PrivIncludes ++
               [{i, filename:join(Dir, "include")}, {i, Dir}, return],
     case compile:file(Module, AllOpts) of
         {ok, _Mod} ->


### PR DESCRIPTION
rebar3 handles its own worker processes for compilation so having compile:file spawn additional processes is a waste.

I thought we already did this. Maybe there is a reason we shouldn't that I forgot?