### PR TITLE
Add support for relx config file

### DIFF
--- a/src/rebar_relx.erl
+++ b/src/rebar_relx.erl
@@ -75,7 +75,8 @@ read_relx_config(State, Options) ->
     ConfigFile = proplists:get_value(config, Options, []),
     case ConfigFile of
         "" ->
-            case {rebar_state:get(State, relx, []), file:consult("relx.config")} of
+            ConfigPath = filename:join([rebar_dir:root_dir(State), "relx.config"]),
+            case {rebar_state:get(State, relx, []), file:consult(ConfigPath)} of
                 {[], {ok, Config}} ->
                     ?DEBUG("Configuring releases with relx.config", []),
                     Config;

--- a/src/rebar_relx.erl
+++ b/src/rebar_relx.erl
@@ -77,21 +77,23 @@ read_relx_config(State, Options) ->
         "" ->
             case {rebar_state:get(State, relx, []), file:consult("relx.config")} of
                 {[], {ok, Config}} ->
-                    ?DEBUG("Using relx.config", []),
+                    ?DEBUG("Configuring releases with relx.config", []),
                     Config;
                 {Config, {error, enoent}} ->
-                    ?DEBUG("Using relx config from rebar.config", []),
+                    ?DEBUG("Configuring releases the {relx, ...} entry"
+                           " from rebar.config", []),
                     Config;
                 {_, {error, Reason}} ->
                     erlang:error(?PRV_ERROR({config_file, "relx.config", Reason}));
                 {RebarConfig, {ok, _RelxConfig}} ->
-                    ?WARN("Found conflicting relx configs, using rebar.config", []),
+                    ?WARN("Found conflicting relx configs, configuring releases"
+                          " with rebar.config", []),
                     RebarConfig
             end;
         ConfigFile ->
             case file:consult(ConfigFile) of
                 {ok, Config} ->
-                    ?DEBUG("Using relx config file: ~p", [ConfigFile]),
+                    ?DEBUG("Configuring releases with: ~ts", [ConfigFile]),
                     Config;
                 {error, Reason} ->
                     erlang:error(?PRV_ERROR({config_file, ConfigFile, Reason}))
@@ -106,7 +108,7 @@ format_error(unknown_vsn) ->
 format_error(all_relup) ->
     "Option --all can not be applied to `relup` command";
 format_error({config_file, Filename, Error}) ->
-    io_lib:format("Failed to read config file ~s: ~p", [Filename, Error]);
+    io_lib:format("Failed to read config file ~ts: ~p", [Filename, Error]);
 format_error(Error) ->
     io_lib:format("~p", [Error]).
 

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -431,6 +431,7 @@ check_results(AppDir, Expected, ProfileRun) ->
                         end,
                     DevMode = lists:all(IsSymLinkFun, RelLibs),
                     ?assertEqual(ExpectedDevMode, DevMode),
+                    ?assert(ec_file:exists(filename:join([ReleaseDir, Name, "releases", Vsn]))),
 
                     %% throws not_found if it doesn't exist
                     ok


### PR DESCRIPTION
This PR adds support for reading the relx configuration from a file when generating a release.
Rebar will continue to use the `rebar.config` relx section as the preferred source of truth, but if there is no such section it will use the configuration from default file `relx.config`.
However if the `--config` flag specifies a configuration file it will be preferred over of the configuration from `rebar.config` or `relx.config`.

I've added a test that should cover these different scenarios.