### PR TITLE
rebar_compiler: fix DAG and speed-up analysis for large repositories

### DIFF
--- a/src/rebar_compiler.erl
+++ b/src/rebar_compiler.erl
@@ -64,8 +64,9 @@ analyze_all({Compiler, G}, Apps) ->
     rebar_compiler_dag:populate_deps(G, SrcExt, OutExt),
     rebar_compiler_dag:propagate_stamps(G),
 
+    [$a, Sep, $b] = filename:join("a", "b"),
     AppPaths = [{rebar_app_info:name(AppInfo),
-                 rebar_utils:to_list(rebar_app_info:dir(AppInfo))}
+                 rebar_utils:to_list(rebar_app_info:dir(AppInfo)) ++ [Sep]}
                 || AppInfo <- Apps],
     AppNames = rebar_compiler_dag:compile_order(G, AppPaths),
     {Contexts, sort_apps(AppNames, Apps)}.
@@ -205,7 +206,7 @@ prepare_compiler_env(Compiler, Apps) ->
             EbinDir = rebar_utils:to_list(rebar_app_info:ebin_dir(AppInfo)),
             %% Make sure that outdir is on the path
             ok = rebar_file_utils:ensure_dir(EbinDir),
-            true = code:add_patha(filename:absname(EbinDir))
+            true = code:add_pathz(filename:absname(EbinDir))
         end,
         Apps
     ),

--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -53,7 +53,9 @@ needed_files(Graph, FoundFiles, _, AppInfo) ->
 
     %% Make sure that the ebin dir is on the path
     ok = rebar_file_utils:ensure_dir(EbinDir),
-    true = code:add_patha(filename:absname(EbinDir)),
+    %% this is only needed to provide behaviours/parse_transforms for
+    %%  applications that will be compiled next
+    true = code:add_pathz(filename:absname(EbinDir)),
 
     {ParseTransforms, Rest} = split_source_files(FoundFiles, ErlOpts),
     NeededErlFiles = case needed_files(Graph, ErlOpts, RebarOpts, OutDir, EbinDir, ParseTransforms) of

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -167,7 +167,11 @@ prepare_project_app(_State, _Providers, AppInfo) ->
     copy_app_dirs(AppInfo,
                   rebar_app_info:dir(AppInfo),
                   rebar_app_info:out_dir(AppInfo)),
-    code:add_pathsa([rebar_app_info:ebin_dir(AppInfo)]),
+    %% application code path must be added to the source
+    %%  otherwise code_server will remember 'lib_dir' for
+    %%  this application, and all `-include_lib` directives
+    %%  will actually go into _build/profile/lib/...
+    code:add_pathsz([rebar_app_info:dir(AppInfo)]),
     AppInfo.
 
 prepare_compile(State, Providers, AppInfo) ->


### PR DESCRIPTION
This patch fixes incorrect behaviour of rebar_compiler_epp that
finds dependencies in _build/test/lib/... folder when rebar3 is run with
test profile. It is caused by code:lib_dir() pointing to _build
directory (when ebin is added to code path). Problem originates in
OTP that expects "include" and "ebin" directories being next to each other,
but rebar3 separates build artifacts and include files.

This patch also significantly speeds up analisys, caching file-to-application
mapping and avoiding repeated lookup for the very same gen_server/...