### PR TITLE
Common test: make group paths work for --group "[g1,g2],g3" option

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -177,7 +177,7 @@ transform_opts([{dir, Dirs}|Rest], Acc) ->
 transform_opts([{suite, Suites}|Rest], Acc) ->
     transform_opts(Rest, [{suite, split_string(Suites)}|Acc]);
 transform_opts([{group, Groups}|Rest], Acc) ->
-    transform_opts(Rest, [{group, split_string(Groups)}|Acc]);
+    transform_opts(Rest, [{group, transform_group(Groups)}|Acc]);
 transform_opts([{testcase, Cases}|Rest], Acc) ->
     transform_opts(Rest, [{testcase, split_string(Cases)}|Acc]);
 transform_opts([{config, Configs}|Rest], Acc) ->
@@ -223,6 +223,17 @@ transform_retry(Opts, State) ->
 
 split_string(String) ->
     rebar_string:lexemes(String, [$,]).
+
+transform_group(String) ->
+    case rebar_string:consult([$[, String, $], $.]) of
+        [Terms] when is_list(Terms) ->
+            Terms;
+        Terms when is_list(Terms) ->
+            Terms;
+        {error, _} ->
+            %% try a normal string split
+            split_string(String)
+    end.
 
 cfgopts(State) ->
     case rebar_state:get(State, ct_opts, []) of

--- a/test/rebar_ct_SUITE.erl
+++ b/test/rebar_ct_SUITE.erl
@@ -1601,6 +1601,15 @@ cmd_vs_cfg_opts(Config) ->
     false = lists:keymember(group, 1, TestOpts2),
     false = lists:keymember(testcase, 1, TestOpts2),
 
+    {ok, GetOptResult3} = getopt:parse(GetOptSpec, ["--group","[g1,g2],g3"]),
+    State3 = rebar_state:command_parsed_args(State, GetOptResult3),
+    {ok, TestOpts3} = rebar_prv_common_test:prepare_tests(State3),
+    true = lists:member({group, [[g1,g2],g3]}, TestOpts3),
+    false = lists:keymember(suite, 1, TestOpts3),
+    false = lists:keymember(spec, 1, TestOpts3),
+    false = lists:keymember(dir, 1, TestOpts3),
+    false = lists:keymember(testcase, 1, TestOpts3),
+
     ok.
 
 single_testspec_in_ct_opts(Config) ->


### PR DESCRIPTION
The common_test application accepts for the group option groups
or path of groups. This adds support for specifying grou paths in
the form "g1.g2.g3".

refs #2444 