### PR TITLE
Erlang/OTP 24 (master) compatibility for ./bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -156,7 +156,7 @@ set_httpc_options(_, []) ->
     ok;
 
 set_httpc_options(Scheme, Proxy) ->
-    {ok, {_, UserInfo, Host, Port, _, _}} = http_uri:parse(Proxy),
+    #{userinfo := UserInfo, host := Host, port := Port} = uri_string:parse(Proxy),
     httpc:set_options([{Scheme, {{Host, Port}, []}}], rebar),
     proxy_ipfamily(Host, inet:gethostbyname(Host)),
     set_proxy_auth(UserInfo).
@@ -721,7 +721,7 @@ set_proxy_auth(UserInfo) ->
     [Username, Password] = re:split(UserInfo, ":",
                                     [{return, list}, {parts,2}, unicode]),
     %% password may contain url encoded characters, need to decode them first
-    put(proxy_auth, [{proxy_auth, {Username, http_uri:decode(Password)}}]).
+    put(proxy_auth, [{proxy_auth, {Username, uri_string:percent_decode(Password)}}]).
 
 get_proxy_auth() ->
     case get(proxy_auth) of

--- a/bootstrap
+++ b/bootstrap
@@ -156,7 +156,7 @@ set_httpc_options(_, []) ->
     ok;
 
 set_httpc_options(Scheme, Proxy) ->
-    #{userinfo := UserInfo, host := Host, port := Port} = uri_string:parse(Proxy),
+    #{userinfo := UserInfo, host := Host, port := Port} = rebar_uri:parse(Proxy),
     httpc:set_options([{Scheme, {{Host, Port}, []}}], rebar),
     proxy_ipfamily(Host, inet:gethostbyname(Host)),
     set_proxy_auth(UserInfo).
@@ -721,7 +721,7 @@ set_proxy_auth(UserInfo) ->
     [Username, Password] = re:split(UserInfo, ":",
                                     [{return, list}, {parts,2}, unicode]),
     %% password may contain url encoded characters, need to decode them first
-    put(proxy_auth, [{proxy_auth, {Username, uri_string:percent_decode(Password)}}]).
+    put(proxy_auth, [{proxy_auth, {Username, rebar_uri:percent_decode(Password)}}]).
 
 get_proxy_auth() ->
     case get(proxy_auth) of

--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -8,6 +8,7 @@
   {registered, []},
   {applications, [kernel,
                   stdlib,
+                  %% note: will be filtered out by rebar_prv_escriptize on Erlang/OTP 24+
                   hipe,
                   sasl,
                   compiler,


### PR DESCRIPTION
Replaces (deprecated in OTP 24) `http_uri` calls with `uri_string`.

Note that some dependencies need other warnings to be addressed for bootstrap to succeed:

 * https://github.com/erlware/erlware_commons/pull/146
 * https://github.com/uwiger/parse_trans/pull/41

As far as I can tell, this addresses #2436, at least for now.