### PR TITLE
Print actural download repo in DEBUG output

### DIFF
--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -218,7 +218,7 @@ cached_download(TmpDir, CachePath, Pkg={pkg, Name, Vsn, _OldHash, _Hash, RepoCon
             ?DEBUG("Version cached at ~ts is up to date, reusing it", [CachePath]),
             serve_from_cache(TmpDir, CachePath, Pkg);
         {ok, Body, NewETag} ->
-            ?DEBUG("Downloaded package, caching at ~ts", [CachePath]),
+            ?DEBUG("Downloaded package from repo ~ts, caching at ~ts", [CDN, CachePath]),
             maybe_store_etag_in_cache(UpdateETag, ETagPath, NewETag),
             serve_from_download(TmpDir, CachePath, Pkg, Body);
         error when ETag =/= <<>> ->


### PR DESCRIPTION
The original debug output prints the `repo_url` from the pkg RepoConfig, which is not the actual URI to fetch from, maybe using a HEX_CDN, or a private repo URL like erlang/rebar3#2346. 

This patch prevents confusing and benefits for debuging.