### PR TITLE
Use rebar_packages_cdn for fetching package resource

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -134,6 +134,7 @@ run_aux(State, RawArgs) ->
     %% Maybe change the default hex CDN
     HexCDN = case os:getenv("HEX_CDN") of
                  false -> ?DEFAULT_CDN;
+                 [] -> ?DEFAULT_CDN;
                  CDN -> CDN
              end,
     State2 = rebar_state:set(State1, rebar_packages_cdn, HexCDN),

--- a/src/rebar_hex_repos.erl
+++ b/src/rebar_hex_repos.erl
@@ -34,7 +34,7 @@ from_state(BaseConfig, State) ->
     %% add base config entries that are specific to use by rebar3 and not overridable
     Repos1 = merge_with_base_and_auth(Repos, BaseConfig, Auth),
     %% merge organizations parent repo options into each oraganization repo
-    update_organizations(Repos1).
+    update_organizations(maybe_override_default_repo_url(Repos1, State)).
 
 -spec get_repo_config(unicode:unicode_binary(), rebar_state:t() | [repo()])
                      -> {ok, repo()} | error.
@@ -101,6 +101,15 @@ update_organizations(Repos) ->
                                                 filename:join("repos", rebar_utils:to_list(RepoName))),
                       %% still let the organization config override this constructed repo url
                       maps:merge(Parent#{repo_url => rebar_utils:to_binary(ParentRepoUrl)}, Repo);
+                 (Repo) ->
+                      Repo
+              end, Repos).
+
+maybe_override_default_repo_url(Repos, State) ->
+    lists:map(fun(Repo=#{repo_name := ?PUBLIC_HEX_REPO}) ->
+                      Repo#{repo_url => rebar_state:default_hex_repo_url_override(State)};
+                 (Repo=#{name := ?PUBLIC_HEX_REPO}) ->
+                      Repo#{repo_url => rebar_state:default_hex_repo_url_override(State)};
                  (Repo) ->
                       Repo
               end, Repos).

--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -244,6 +244,7 @@ parse_checksum(Checksum) ->
 update_package(Name, RepoConfig=#{name := Repo}, State) ->
     ?MODULE:verify_table(State),
     CDN = rebar_state:maybe_default_cdn(State),
+    ?DEBUG("Getting package ~ts resource from repo ~ts", [Name, CDN]),
     try r3_hex_repo:get_package(get_package_repo_config(RepoConfig#{repo_url => CDN}), Name) of
         {ok, {200, _Headers, Releases}} ->
             _ = insert_releases(Name, Releases, Repo, ?PACKAGE_TABLE),

--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -243,7 +243,8 @@ parse_checksum(Checksum) ->
 
 update_package(Name, RepoConfig=#{name := Repo}, State) ->
     ?MODULE:verify_table(State),
-    try r3_hex_repo:get_package(get_package_repo_config(RepoConfig), Name) of
+    CDN = rebar_state:maybe_default_cdn(State),
+    try r3_hex_repo:get_package(get_package_repo_config(RepoConfig#{repo_url => CDN}), Name) of
         {ok, {200, _Headers, Releases}} ->
             _ = insert_releases(Name, Releases, Repo, ?PACKAGE_TABLE),
             {ok, RegistryDir} = rebar_packages:registry_dir(State),

--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -243,7 +243,8 @@ parse_checksum(Checksum) ->
 
 update_package(Name, RepoConfig=#{name := Repo}, State) ->
     ?MODULE:verify_table(State),
-    ?DEBUG("Getting package ~ts resource from repo ~ts", [Name, maps:get(repo_url, RepoConfig, undefined)]),
+    ?DEBUG("Getting definition for package ~ts from repo ~ts via repo_url ~ts",
+           [Name, maps:get(name, RepoConfig, undefined), maps:get(repo_url, RepoConfig, undefined)]),
     try r3_hex_repo:get_package(get_package_repo_config(RepoConfig), Name) of
         {ok, {200, _Headers, Releases}} ->
             _ = insert_releases(Name, Releases, Repo, ?PACKAGE_TABLE),

--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -243,9 +243,8 @@ parse_checksum(Checksum) ->
 
 update_package(Name, RepoConfig=#{name := Repo}, State) ->
     ?MODULE:verify_table(State),
-    CDN = rebar_state:maybe_default_cdn(State),
-    ?DEBUG("Getting package ~ts resource from repo ~ts", [Name, CDN]),
-    try r3_hex_repo:get_package(get_package_repo_config(RepoConfig#{repo_url => CDN}), Name) of
+    ?DEBUG("Getting package ~ts resource from repo ~ts", [Name, maps:get(repo_url, RepoConfig, undefined)]),
+    try r3_hex_repo:get_package(get_package_repo_config(RepoConfig), Name) of
         {ok, {200, _Headers, Releases}} ->
             _ = insert_releases(Name, Releases, Repo, ?PACKAGE_TABLE),
             {ok, RegistryDir} = rebar_packages:registry_dir(State),

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -212,7 +212,7 @@ store_etag_in_cache(Path, ETag) ->
            | {bad_registry_checksum, integer(), integer()} | {error, _}.
 cached_download(TmpDir, CachePath, Pkg={pkg, Name, Vsn, _OldHash, _Hash, RepoConfig}, State, ETag,
                 ETagPath, UpdateETag) ->
-    CDN = maybe_default_cdn(State),
+    CDN = rebar_state:maybe_default_cdn(State),
     case request(RepoConfig#{repo_url => CDN}, Name, Vsn, ETag) of
         {ok, cached} ->
             ?DEBUG("Version cached at ~ts is up to date, reusing it", [CachePath]),
@@ -228,10 +228,6 @@ cached_download(TmpDir, CachePath, Pkg={pkg, Name, Vsn, _OldHash, _Hash, RepoCon
         error ->
             {fetch_fail, Name, Vsn}
     end.
-
-maybe_default_cdn(State) ->
-    CDN = rebar_state:get(State, rebar_packages_cdn, ?DEFAULT_CDN),
-    rebar_utils:to_binary(CDN).
 
 -spec serve_from_cache(TmpDir, CachePath, Pkg) -> Res when
       TmpDir :: file:name(),

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -213,12 +213,13 @@ store_etag_in_cache(Path, ETag) ->
 cached_download(TmpDir, CachePath, Pkg={pkg, Name, Vsn, _OldHash, _Hash, RepoConfig}, State, ETag,
                 ETagPath, UpdateETag) ->
     CDN = rebar_state:maybe_default_cdn(State),
+    ?DEBUG("Downloading package ~ts from repo ~ts", [Name, CDN]),
     case request(RepoConfig#{repo_url => CDN}, Name, Vsn, ETag) of
         {ok, cached} ->
             ?DEBUG("Version cached at ~ts is up to date, reusing it", [CachePath]),
             serve_from_cache(TmpDir, CachePath, Pkg);
         {ok, Body, NewETag} ->
-            ?DEBUG("Downloaded package from repo ~ts, caching at ~ts", [CDN, CachePath]),
+            ?DEBUG("Downloaded package ~ts, caching at ~ts", [Name, CachePath]),
             maybe_store_etag_in_cache(UpdateETag, ETagPath, NewETag),
             serve_from_download(TmpDir, CachePath, Pkg, Body);
         error when ETag =/= <<>> ->

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -212,8 +212,8 @@ store_etag_in_cache(Path, ETag) ->
            | {bad_registry_checksum, integer(), integer()} | {error, _}.
 cached_download(TmpDir, CachePath, Pkg={pkg, Name, Vsn, _OldHash, _Hash, RepoConfig}, _State, ETag,
                 ETagPath, UpdateETag) ->
-    RepoUrl = maps:get(repo_url, RepoConfig, undefined),
-    ?DEBUG("Downloading package ~ts from repo ~ts", [Name, RepoUrl]),
+    ?DEBUG("Making request to get package ~ts tarball from repo ~ts via repo_url ~ts",
+           [Name, maps:get(name, RepoConfig, undefined), maps:get(repo_url, RepoConfig, undefined)]),
     case request(RepoConfig, Name, Vsn, ETag) of
         {ok, cached} ->
             ?DEBUG("Version cached at ~ts is up to date, reusing it", [CachePath]),

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -210,11 +210,11 @@ store_etag_in_cache(Path, ETag) ->
       UpdateETag :: boolean(),
       Res :: ok | {unexpected_hash, integer(), integer()} | {fetch_fail, binary(), binary()}
            | {bad_registry_checksum, integer(), integer()} | {error, _}.
-cached_download(TmpDir, CachePath, Pkg={pkg, Name, Vsn, _OldHash, _Hash, RepoConfig}, State, ETag,
+cached_download(TmpDir, CachePath, Pkg={pkg, Name, Vsn, _OldHash, _Hash, RepoConfig}, _State, ETag,
                 ETagPath, UpdateETag) ->
-    CDN = rebar_state:maybe_default_cdn(State),
-    ?DEBUG("Downloading package ~ts from repo ~ts", [Name, CDN]),
-    case request(RepoConfig#{repo_url => CDN}, Name, Vsn, ETag) of
+    RepoUrl = maps:get(repo_url, RepoConfig, undefined),
+    ?DEBUG("Downloading package ~ts from repo ~ts", [Name, RepoUrl]),
+    case request(RepoConfig, Name, Vsn, ETag) of
         {ok, cached} ->
             ?DEBUG("Version cached at ~ts is up to date, reusing it", [CachePath]),
             serve_from_cache(TmpDir, CachePath, Pkg);

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -35,6 +35,8 @@
          all_checkout_deps/1,
          namespace/1, namespace/2,
 
+         maybe_default_cdn/1,
+
          deps_names/1,
 
          to_list/1,
@@ -491,6 +493,11 @@ add_provider(State=#state_t{providers=Providers, allow_provider_overrides=false}
         false ->
             State#state_t{providers=[Provider | Providers]}
     end.
+
+-spec maybe_default_cdn(t()) -> binary().
+maybe_default_cdn(State) ->
+    CDN = rebar_state:get(State, rebar_packages_cdn, ?DEFAULT_CDN),
+    rebar_utils:to_binary(CDN).
 
 -dialyzer({no_match, create_logic_providers/2}). % we want to be permissive with providers:new/2
 create_logic_providers(ProviderModules, State0) ->

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -35,7 +35,7 @@
          all_checkout_deps/1,
          namespace/1, namespace/2,
 
-         maybe_default_cdn/1,
+         default_hex_repo_url_override/1,
 
          deps_names/1,
 
@@ -494,8 +494,8 @@ add_provider(State=#state_t{providers=Providers, allow_provider_overrides=false}
             State#state_t{providers=[Provider | Providers]}
     end.
 
--spec maybe_default_cdn(t()) -> binary().
-maybe_default_cdn(State) ->
+-spec default_hex_repo_url_override(t()) -> binary().
+default_hex_repo_url_override(State) ->
     CDN = rebar_state:get(State, rebar_packages_cdn, ?DEFAULT_CDN),
     rebar_utils:to_binary(CDN).
 


### PR DESCRIPTION
Not only `r3_hex_repo:get_tarball` need to use `rebar_packages_cdn`, but also all the other exported functions from `r3_hex_repo`.

Since only `get_package` and `get_tarball` are used, I apply cdn option with them but the rests.

Maybe this should be a config option inside the vender hex_core.