### PR TITLE
Modify algorithm to decide compilation order between apps to resolve header dependencies

### DIFF
--- a/src/rebar_compiler.erl
+++ b/src/rebar_compiler.erl
@@ -68,7 +68,7 @@ analyze_all({Compiler, G}, Apps) ->
     AppPaths = [{rebar_app_info:name(AppInfo),
                  rebar_utils:to_list(rebar_app_info:dir(AppInfo)) ++ [Sep]}
                 || AppInfo <- Apps],
-    AppNames = rebar_compiler_dag:compile_order(G, AppPaths),
+    AppNames = rebar_compiler_dag:compile_order(G, AppPaths, SrcExt, OutExt),
     {Contexts, sort_apps(AppNames, Apps)}.
 
 %% @doc same as analyze_all/2, but over extra_src_apps,

--- a/test/rebar_compiler_dag_SUITE.erl
+++ b/test/rebar_compiler_dag_SUITE.erl
@@ -110,6 +110,9 @@ project() ->
          "-export([parse_transform/2]).\n"
          "parse_transform(Forms, _Opts) -> Forms.\n"},
         {"src/app3_resolve.hrl",
+         "-behaviour(app2).\n"
+         "-export([cb/0]).\n"
+         "cb() -> {}.\n"
          "%% this file should be found"}
      ]}
     ].
@@ -273,7 +276,7 @@ propagate_behaviour(Config) ->
         {"/include/app1_b.hrl", S3},
         {"/src/app2.erl", S5},
         {"/include/app2.hrl", S4},
-        {"/src/app3.erl", S4},
+        {"/src/app3.erl", S5},
         {"/src/app3_resolve.hrl", S1}
     ],
     matches(Matches, FileStamps),
@@ -300,7 +303,7 @@ propagate_app1_ptrans(Config) ->
         {"/include/app1_b.hrl", S3},
         {"/src/app2.erl", S5},
         {"/include/app2.hrl", S4},
-        {"/src/app3.erl", S4},
+        {"/src/app3.erl", S5},
         {"/src/app3_resolve.hrl", S1}
     ],
     matches(Matches, FileStamps),
@@ -463,4 +466,3 @@ next_second() ->
     Ms = (trunc(Now / 1000)*1000 + 1000) - Now,
     %% add a 50ms for jitter since the exact amount sometimes causes failures
     timer:sleep(max(Ms+50, 1000)).
-

--- a/test/rebar_compiler_dag_SUITE.erl
+++ b/test/rebar_compiler_dag_SUITE.erl
@@ -171,7 +171,7 @@ app_sort(Config) ->
     ?assertEqual([lists:nth(2, AppNames),
                   lists:nth(3, AppNames),
                   lists:nth(1, AppNames)],
-                 rebar_compiler_dag:compile_order(G, AppPaths)),
+                 rebar_compiler_dag:compile_order(G, AppPaths, ".erl", ".beam")),
     ok.
 
 propagate_include_app1a() ->


### PR DESCRIPTION
The change does not consider a dependency on an .hrl file from one app to another as an ordering dependency between the two apps. Instead it resolves all the .hrl dependencies completely and uses the resolved dependencies instead. This means that it's much less likely that there are circular dependencies between apps for compiler ordering meaning that the ordering is much more likely to be correct even for projects which have circular .hrl dependencies.

The change I made to the tests was to add a dependency from a .hrl in app3 to a source file in app2.

More discussion about this change in https://github.com/erlang/rebar3/discussions/2465