### PR TITLE
Sanitize repo configuration in DEBUG output

### DIFF
--- a/src/rebar_hex_repos.erl
+++ b/src/rebar_hex_repos.erl
@@ -27,7 +27,9 @@
                   repo_key => binary(),
                   repo_public_key => binary(),
                   repo_verify => binary(),
-                  repo_verify_origin => binary()}.
+                  repo_verify_origin => binary(),
+                  mirror_of => _ % legacy field getting stripped
+                 }.
 
 from_state(BaseConfig, State) ->
     HexConfig = rebar_state:get(State, hex, []),
@@ -55,10 +57,11 @@ get_repo_config(RepoName, State) ->
 
 -spec anon_repo_config(repo()) ->
     #{api_url := _, name := _, repo_name => _, repo_organization => _,
-      repo_url := _, repo_verify => _, repo_verify_origin => _}.
+      repo_url := _, repo_verify => _, repo_verify_origin => _,
+      mirror_of => _}.
 anon_repo_config(Map) ->
     maps:with([name, repo_name, api_url, repo_url, repo_organization,
-               repo_verify, repo_verify_origin], Map).
+               mirror_of, repo_verify, repo_verify_origin], Map).
 
 -spec format_repo(repo()) -> unicode:chardata().
 format_repo(RepoConfig) ->

--- a/src/rebar_hex_repos.erl
+++ b/src/rebar_hex_repos.erl
@@ -5,7 +5,10 @@
          auth_config/1,
          remove_from_auth_config/2,
          update_auth_config/2,
-         format_error/1]).
+         format_error/1,
+         anon_repo_config/1,
+         format_repo/1
+        ]).
 
 -ifdef(TEST).
 %% exported for test purposes
@@ -49,6 +52,25 @@ get_repo_config(RepoName, State) ->
     Resources = rebar_state:resources(State),
     #{repos := Repos} = rebar_resource_v2:find_resource_state(pkg, Resources),
     get_repo_config(RepoName, Repos).
+
+-spec anon_repo_config(repo()) ->
+    #{api_url := _, name := _, repo_name => _, repo_organization => _,
+      repo_url := _, repo_verify => _, repo_verify_origin => _}.
+anon_repo_config(Map) ->
+    maps:with([name, repo_name, api_url, repo_url, repo_organization,
+               repo_verify, repo_verify_origin], Map).
+
+-spec format_repo(repo()) -> unicode:chardata().
+format_repo(RepoConfig) ->
+    Name = maps:get(name, RepoConfig, undefined),
+    case get({?MODULE, format_repo, Name}) of
+        undefined ->
+            put({?MODULE, format_repo, Name}, true),
+            Anon = anon_repo_config(RepoConfig),
+            io_lib:format("~ts (~p)", [Name, Anon]);
+        true ->
+            io_lib:format("~ts", [Name])
+    end.
 
 merge_with_base_and_auth(Repos, BaseConfig, Auth) ->
     [maps:merge(maps:merge(Repo, BaseConfig),

--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -243,8 +243,8 @@ parse_checksum(Checksum) ->
 
 update_package(Name, RepoConfig=#{name := Repo}, State) ->
     ?MODULE:verify_table(State),
-    ?DEBUG("Getting definition for package ~ts from repo ~ts via repo_url ~ts",
-           [Name, maps:get(name, RepoConfig, undefined), maps:get(repo_url, RepoConfig, undefined)]),
+    ?DEBUG("Getting definition for package ~ts from repo ~ts",
+           [Name, rebar_hex_repos:format_repo(RepoConfig)]),
     try r3_hex_repo:get_package(get_package_repo_config(RepoConfig), Name) of
         {ok, {200, _Headers, Releases}} ->
             _ = insert_releases(Name, Releases, Repo, ?PACKAGE_TABLE),

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -296,6 +296,4 @@ maybe_store_etag_in_cache(true = _UpdateETag, Path, ETag) ->
 
 anon({pkg, PkgName, PkgVsn, OldHash, Hash, RepoConfig}) ->
     {pkg, PkgName, PkgVsn, OldHash, Hash,
-     rebar_hex_repos:anon_repo_config(RepoConfig)};
-anon(Package) ->
-    Package.
+     rebar_hex_repos:anon_repo_config(RepoConfig)}.

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -212,8 +212,8 @@ store_etag_in_cache(Path, ETag) ->
            | {bad_registry_checksum, integer(), integer()} | {error, _}.
 cached_download(TmpDir, CachePath, Pkg={pkg, Name, Vsn, _OldHash, _Hash, RepoConfig}, _State, ETag,
                 ETagPath, UpdateETag) ->
-    ?DEBUG("Making request to get package ~ts tarball from repo ~ts via repo_url ~ts",
-           [Name, maps:get(name, RepoConfig, undefined), maps:get(repo_url, RepoConfig, undefined)]),
+    ?DEBUG("Making request to get package ~ts from repo ~ts",
+           [Name, rebar_hex_repos:format_repo(RepoConfig)]),
     case request(RepoConfig, Name, Vsn, ETag) of
         {ok, cached} ->
             ?DEBUG("Version cached at ~ts is up to date, reusing it", [CachePath]),
@@ -280,7 +280,7 @@ maybe_old_registry_checksum(Hash) -> list_to_integer(binary_to_list(Hash), 16).
       Binary :: binary(),
       Res :: ok | {error,_}.
 serve_from_download(TmpDir, CachePath, Package, Binary) ->
-    ?DEBUG("Writing ~p to cache at ~ts", [Package, CachePath]),
+    ?DEBUG("Writing ~p to cache at ~ts", [catch anon(Package), CachePath]),
     file:write_file(CachePath, Binary),
     serve_from_memory(TmpDir, Binary, Package).
 
@@ -293,3 +293,9 @@ maybe_store_etag_in_cache(false = _UpdateETag, _Path, _ETag) ->
     ok;
 maybe_store_etag_in_cache(true = _UpdateETag, Path, ETag) ->
     store_etag_in_cache(Path, ETag).
+
+anon({pkg, PkgName, PkgVsn, OldHash, Hash, RepoConfig}) ->
+    {pkg, PkgName, PkgVsn, OldHash, Hash,
+     rebar_hex_repos:anon_repo_config(RepoConfig)};
+anon(Package) ->
+    Package.


### PR DESCRIPTION
A few issues exist in the current code:

1. the DEBUG information for a brand new package when no index cache is
   present outputs private hex keys
2. recently merged branches had debug output I Felt could be cleaner (see https://github.com/erlang/rebar3/pull/2479)

This commits fixes both by adding helper function to the rebar_hex_repos
module whose role is to anonimize the information and also provide a
stringified version of each repo config for debugging purposes.

The new output should look something like:

    ===> Verifying dependencies...
    ...
    ===> Getting definition for package hex_core from repo hexpm (#{api_url => <<"https://hex.pm/api">>,name => <<"hexpm">>,
             repo_name => <<"hexpm">>,repo_organization => undefined,
             repo_url => <<"https://repo.hex.pm">>,repo_verify => true,
             repo_verify_origin => true})
    ===> Getting definition for package verl from repo hexpm
    ===> Compile (apps)
    ...
    ===> Running provider: install_deps
    ===> Verifying dependencies...
    ===> Getting definition for package bbmustache from repo hexpm
    ===> Getting definition for package certifi from repo hexpm
    ===> Getting definition for package cf from repo hexpm
    ...
    ===> Fetching relx v4.3.0
    ===> Making request to get package relx from repo hexpm
    ===> Downloaded package relx, caching at /home/ferd/.cache/rebar3/hex/hexpm/packages/relx-4.3.0.tar
    ===> Writing {pkg,<<"relx">>,<<"4.3.0">>,
                             <<"5BD80A4BC733DD648C68A7AC882BA3922C45EEA2E23D9D207A4BF9F416D1F301">>,
                             <<"738E0949A6FC7D0DE9E4549DC0F73D9B6E05B539E1511BB248590702B3220440">>,
                             #{api_url => <<"https://hex.pm/api">>,
                               name => <<"hexpm">>,repo_name => <<"hexpm">>,
                               repo_organization => undefined,
                               repo_url => <<"https://repo.hex.pm">>,
                               repo_verify => true,repo_verify_origin => true}} to cache at /home/ferd/.cache/rebar3/hex/hexpm/packages/relx-4.3.0.tar
    ===> Running provider: lock
    ===> Running provider: 'get-deps'

This shows the 'hexpm' config being displayed one and then cached across
providers, and the debug message for package writing being simplified to
show the origins and non-private security details