### PR TITLE
Give more flexibility to del dep by name in overrides

### DIFF
--- a/src/rebar_opts.erl
+++ b/src/rebar_opts.erl
@@ -166,16 +166,25 @@ override_opt(Opts1, Opts2) ->
 
 %% @private
 del_dep(OldValue, [Value]) when is_atom(Value) ->
-    NewValue = lists:keydelete(atom_to_binary(Value, utf8), 1, OldValue),
+    NewValue = del_dep_by_name(Value, OldValue),
     del_dep(NewValue, OldValue, [Value]);
 del_dep(OldValue, [{Value, _Version, _Source}]) ->
-    NewValue = lists:keydelete(atom_to_binary(Value, utf8), 1, OldValue),
+    NewValue = del_dep_by_name(Value, OldValue),
     del_dep(NewValue, OldValue, [{Value, _Version, _Source}]);
 del_dep(OldValue, [Value]) ->
     del_dep(OldValue, OldValue, [Value]);
 del_dep(OldValue, [Value|Values]) ->
     NewValue = del_dep(del_dep(OldValue, [Value]), OldValue, [Value]),
     del_dep(NewValue, Values).
+
+del_dep_by_name(Name, Deps) ->
+    DepName = rebar_utils:to_binary(Name),
+    lists:filter(fun(Dep) -> dep_name(Dep) /= DepName end, Deps).
+
+dep_name(Dep) when is_tuple(Dep) ->
+    rebar_utils:to_binary(element(1, Dep));
+dep_name(Dep) ->
+    rebar_utils:to_binary(Dep).
 
 %% @private
 %% If the initial deletion did not work remove it as always

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -1742,7 +1742,8 @@ override_del_deps(Config) ->
                                                                      {"dep_b", "0.0.1", []},
                                                                      {"dep_c", "0.0.1", []}]},
                                               {"other_dep", "0.0.1", [{"dep_c", "0.0.1", []},
-                                                                      {"dep_d", "0.0.1", []}]}]),
+                                                                      {"dep_d", "0.0.1", []},
+                                                                      {"dep_e", "0.0.1", []}]}]),
     TopDeps = rebar_test_utils:top_level_deps(Deps),
 
     DepA = {dep_a, "0.0.1", {git, "https://example.org/user/dep_a.git", {tag, "0.0.1"}}},
@@ -1759,7 +1760,7 @@ override_del_deps(Config) ->
                 {deps, [DepA, DepB]}
             ]},
             {del, [
-                {deps, [DepC]}
+                {deps, [DepC, dep_e]}
             ]}
         ]}
     ],
@@ -1771,6 +1772,7 @@ override_del_deps(Config) ->
               {dep_not_exist, "dep_a"},
               {dep_not_exist, "dep_b"},
               {dep_not_exist, "dep_c"},
+              {dep_not_exist, "dep_e"},
               {dep, "dep_d"}]}
     ).
 


### PR DESCRIPTION
Following #2287.

This patch allows deleting other dep's dependency by name with overrides for lockless deps where dep names in `Opts` are usually atoms.
