### PR TITLE
Add useful example constraint

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -25,6 +25,8 @@
             {platform_define, "(linux|freebsd)", 'BACKLOG', 128},
             {platform_define, "R13", 'old_inets'}]}.
 
+{minimum_otp_vsn, "19.3"}.
+
 %% MIB Options?
 {mib_opts, []}.
 %% SNMP mibs to compile first?


### PR DESCRIPTION
I'm not sure if the version choice is OK, but don't expect `rebar3` consumers to copy-paste without thinking about consequences either.