### PR TITLE
More path juggling fixes

### DIFF
--- a/src/rebar_compiler.erl
+++ b/src/rebar_compiler.erl
@@ -201,15 +201,24 @@ sort_apps(Names, Apps) ->
             {_, App} <- [lists:keyfind(Name, 1, NamedApps)]].
 
 prepare_compiler_env(Compiler, Apps) ->
+    RebarLibs = [rebar_utils:to_binary(Atom)
+                 || {ok, RebarApps} <- [application:get_key(rebar, applications)],
+                    Atom <- RebarApps],
     lists:foreach(
         fun(AppInfo) ->
             EbinDir = rebar_utils:to_list(rebar_app_info:ebin_dir(AppInfo)),
             %% Make sure that outdir is on the path
             ok = rebar_file_utils:ensure_dir(EbinDir),
+            %% We use code:add_pathz for better caching speed when
+            %% dealing with overall projects and deps under profiles,
+            %% but for correctness' sake, we also have to
             %% use code:add_patha to go above rebar3's own dependencies
             %% when they clash to avoid overtaking the project's
             %% path for includes and priv/
-            true = code:add_patha(filename:absname(EbinDir))
+            case lists:member(rebar_app_info:name(AppInfo), RebarLibs) of
+                true -> true = code:add_patha(filename:absname(EbinDir));
+                false -> true = code:add_pathz(filename:absname(EbinDir))
+            end
         end,
         Apps
     ),

--- a/src/rebar_compiler.erl
+++ b/src/rebar_compiler.erl
@@ -206,7 +206,10 @@ prepare_compiler_env(Compiler, Apps) ->
             EbinDir = rebar_utils:to_list(rebar_app_info:ebin_dir(AppInfo)),
             %% Make sure that outdir is on the path
             ok = rebar_file_utils:ensure_dir(EbinDir),
-            true = code:add_pathz(filename:absname(EbinDir))
+            %% use code:add_patha to go above rebar3's own dependencies
+            %% when they clash to avoid overtaking the project's
+            %% path for includes and priv/
+            true = code:add_patha(filename:absname(EbinDir))
         end,
         Apps
     ),

--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -51,12 +51,6 @@ needed_files(Graph, FoundFiles, _, AppInfo) ->
     ?DEBUG("compile options: {erl_opts, ~p}.", [ErlOpts]),
     ?DEBUG("files to analyze ~p", [FoundFiles]),
 
-    %% Make sure that the ebin dir is on the path
-    ok = rebar_file_utils:ensure_dir(EbinDir),
-    %% this is only needed to provide behaviours/parse_transforms for
-    %%  applications that will be compiled next
-    true = code:add_pathz(filename:absname(EbinDir)),
-
     {ParseTransforms, Rest} = split_source_files(FoundFiles, ErlOpts),
     NeededErlFiles = case needed_files(Graph, ErlOpts, RebarOpts, OutDir, EbinDir, ParseTransforms) of
                          [] ->


### PR DESCRIPTION
The first commit omits some code path additions that aren't required.

The rest address additional issues have been reported where path juggling clashed between rebar3 dependencies and projects' own dependencies, particularly on the first build where the path is added for the first time to a project.

The fix _is_ to make the code path use `code:add_patha/1` to make it go above rebar3's in-memory deps.

However, when building with profiles, using `code:add_patha/1` lowers some resolving cache speed to resolve apps and paths, which is why @max-au had replaced it with `code:add_pathz/1`. In order to see if build speeds could be preserved, the third commit adds a conditional check where the performance fix is maintained when apps are _not_ part of the rebar3 dependency tree as well.

This would need additional benchmarking on large projects (nudge nudge @max-au ) to see if this is an acceptable tradeoff.