### PR TITLE
Increase OTP 24 readiness + move to OTP 20 min.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,14 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [19, 20, 21, 22, 23]
+        otp_version: [20, 21, 22, 23, 24]
         os: [ubuntu-latest]
 
     container:
       image: erlang:${{ matrix.otp_version }}
 
     env:
-      LATEST_OTP_RELEASE: 23
+      LATEST_OTP_RELEASE: 24
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: gleam-lang/setup-erlang@master
       with:
-        otp-version: 19.3.6.13
+        otp-version: 21.3.8.17
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: gleam-lang/setup-erlang@master
       with:
-        otp-version: 19.3.6.13
+        otp-version: 21.3.8.17
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY --from=builder /root/rebar3/_build/prod/bin/rebar3 .
 
 # and install it
 RUN HOME=/opt ./rebar3 local install \
+    && rm -f /usr/local/bin/rebar3 \
     && ln /opt/.cache/rebar3/bin/rebar3 /usr/local/bin/rebar3 \
     && rm -rf rebar3
 

--- a/bootstrap
+++ b/bootstrap
@@ -662,11 +662,8 @@ format_error(AbsSource, Extra, {Mod, Desc}) ->
 
 additional_defines() ->
     [{d, D} || {Re, D} <- [{"^[0-9]+", namespaced_types},
-                           {"^18", no_maps_update_with},
-                           {"^R1[4|5]", deprecated_crypto},
-                           {"^2", unicode_str},
-                           {"^(R|1|20)", fun_stacktrace},
-                           {"^((1[8|9])|2)", rand_module}],
+                           {"^(20)", fun_stacktrace},
+                           {"^(2)", rand_module}],
                is_otp_release(Re)].
 
 is_otp_release(ArchRegex) ->

--- a/rebar.config
+++ b/rebar.config
@@ -32,12 +32,9 @@
 
 {overrides, [{add, relx, [{erl_opts, [{d, 'RLX_LOG', rebar_log}]}]}]}.
 
-{erl_opts, [{platform_define, "^(19|2)", rand_only},
-            {platform_define, "^18", no_maps_update_with},
-            {platform_define, "^2", unicode_str},
+{erl_opts, [warnings_as_errors,
             {platform_define, "^(2[1-9])|(20\\\\.3)", filelib_find_source},
-            {platform_define, "^(R|1|20)", fun_stacktrace},
-            warnings_as_errors
+            {platform_define, "^(20)", fun_stacktrace}
            ]}.
 
 {edoc_opts, [preprocess]}.

--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -25,7 +25,7 @@
             {platform_define, "(linux|freebsd)", 'BACKLOG', 128},
             {platform_define, "R13", 'old_inets'}]}.
 
-{minimum_otp_vsn, "19.3"}.
+{minimum_otp_vsn, "21.0"}.
 
 %% MIB Options?
 {mib_opts, []}.

--- a/src/rebar_string.erl
+++ b/src/rebar_string.erl
@@ -8,8 +8,6 @@
 %% Util exports
 -export([consult/1]).
 
--ifdef(unicode_str).
-
 %% string:join/2 copy; string:join/2 is getting obsoleted
 %% and replaced by lists:join/2, but lists:join/2 is too new
 %% for version support (only appeared in 19.0) so it cannot be
@@ -31,27 +29,6 @@ chr(S, C) when is_integer(C) -> chr(S, C, 1).
 chr([C|_Cs], C, I) -> I;
 chr([_|Cs], C, I) -> chr(Cs, C, I+1);
 chr([], _C, _I) -> 0.
--else.
-
-join(Strings, Separator) -> string:join(Strings, Separator).
-split(Str, SearchPattern) when is_list(Str) -> string:split(Str, SearchPattern);
-split(Str, SearchPattern) when is_binary(Str) -> binary:split(Str, SearchPattern).
-lexemes(Str, SepList) -> string:tokens(Str, SepList).
-trim(Str) when is_list(Str) ->
-    re:replace(Str, "\\s+", "", [global, {return, list}]);
-trim(Str) when is_binary(Str) ->
-    list_to_binary(trim(binary_to_list(Str))).
-trim(Str, Direction, [Char]) ->
-    Dir = case Direction of
-              both -> both;
-              leading -> left;
-              trailing -> right
-          end,
-    string:strip(Str, Dir, Char).
-uppercase(Str) -> string:to_upper(Str).
-lowercase(Str) -> string:to_lower(Str).
-chr(Str, Char) -> string:chr(Str, Char).
--endif.
 
 %% @doc
 %% Given a string or binary, parse it into a list of terms, ala file:consult/1

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -8,13 +8,6 @@
 -export([create_random_name/1, create_random_vsn/0, write_src_file/2,
          random_element/1]).
 
-%% Pick the right random module
--ifdef(rand_only).
--define(random, rand).
--else.
--define(random, random).
--endif.
-
 %%%%%%%%%%%%%%
 %%% Public %%%
 %%%%%%%%%%%%%%
@@ -162,25 +155,13 @@ create_config(_AppDir, ConfFilename, Contents) ->
 
 %% @doc Util to create a random variation of a given name.
 create_random_name(Name) ->
-    random_seed(),
-    Name ++ erlang:integer_to_list(?random:uniform(1000000)).
+    Name ++ erlang:integer_to_list(rand:uniform(1000000)).
 
 %% @doc Util to create a random variation of a given version.
 create_random_vsn() ->
-    random_seed(),
-    lists:flatten([erlang:integer_to_list(?random:uniform(100)),
-                   ".", erlang:integer_to_list(?random:uniform(100)),
-                   ".", erlang:integer_to_list(?random:uniform(100))]).
-
--ifdef(rand_only).
-random_seed() ->
-    %% the rand module self-seeds
-    ok.
--else.
-random_seed() ->
-    <<A:32, B:32, C:32>> = crypto:rand_bytes(12),
-    random:seed({A,B,C}).
--endif.
+    lists:flatten([erlang:integer_to_list(rand:uniform(100)),
+                   ".", erlang:integer_to_list(rand:uniform(100)),
+                   ".", erlang:integer_to_list(rand:uniform(100))]).
 
 expand_deps(_, []) -> [];
 expand_deps(git_subdir, [{Name, Deps} | Rest]) ->
@@ -552,5 +533,5 @@ package_app(AppDir, DestDir, PkgName, PkgVsn) ->
     {Checksum1, E}.
 
 random_element(Repos) ->
-    Index = ?random:uniform(length(Repos)),
+    Index = rand:uniform(length(Repos)),
     lists:nth(Index, Repos).

--- a/vendor_hex_core.sh
+++ b/vendor_hex_core.sh
@@ -10,7 +10,7 @@ REBAR3_TOP=$(pwd)
 export REBAR3_TOP
 pushd "$1"
 touch proto/* # force re-generation of protobuf elements
-TARGET_ERLANG_VERSION=19
+TARGET_ERLANG_VERSION=20
 export TARGET_ERLANG_VERSION
 rebar3 as dev compile
 ./vendor.sh src r3_


### PR DESCRIPTION
What this pulls in:
* https://github.com/uwiger/parse_trans/pull/41
* https://github.com/uwiger/parse_trans/pull/42
* https://github.com/uwiger/parse_trans/pull/43

After I saw that a bump was required, I decided to adapt to min. OTP ~21~(now) 20

- [x] don't merge until you decide to up min. to OTP 20
- [x] potentially tweak TARGET_ERLANG_VERSION
- [x] bump `erlware_commons` (after something like https://github.com/erlware/erlware_commons/pull/152 happens)
- [x] tweak `bootstrap` to adapt to these changes too