### PR TITLE
Have "rebar3 plugins upgrade" work without specifying plugin name

### DIFF
--- a/src/rebar_prv_plugins.erl
+++ b/src/rebar_prv_plugins.erl
@@ -4,7 +4,8 @@
 
 -export([init/1,
          do/1,
-         format_error/1]).
+         format_error/1,
+         list_local_plugins/1]).
 
 -include("rebar.hrl").
 -include_lib("providers/include/providers.hrl").
@@ -41,8 +42,7 @@ do(State) ->
 
     RebarOpts = rebar_state:opts(State),
     SrcDirs = rebar_dir:src_dirs(RebarOpts, ["src"]),
-    Plugins = rebar_state:get(State, plugins, []),
-    ProjectPlugins = rebar_state:get(State, project_plugins, []),
+    {LocalPluginsDefs, _} = list_local_plugins(State),
     PluginsDirs = filelib:wildcard(filename:join(rebar_dir:plugins_dir(State), "*")),
 
     %% use `checkouts_dir' and not `checkouts_out_dir'. Since we use `all' in `find_apps'
@@ -50,12 +50,24 @@ do(State) ->
     %% because the user removing from `_checkouts/' doesn't cause removal of the output
     CheckoutsDirs = filelib:wildcard(filename:join(rebar_dir:checkouts_dir(State), "*")),
     Apps = rebar_app_discover:find_apps(CheckoutsDirs++PluginsDirs, SrcDirs, all, State),
-    display_plugins("Local plugins", Apps, Plugins ++ ProjectPlugins),
+    display_plugins("Local plugins", Apps, LocalPluginsDefs),
     {ok, State}.
 
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
+
+list_local_plugins(State) ->
+    LocalPluginsDefs = rebar_state:get(State, plugins, [])
+                       ++ rebar_state:get(State, project_plugins, []),
+    LocalPluginsNames = lists:map(
+                            fun (LocalPluginDef) ->
+                                if is_atom(LocalPluginDef) -> LocalPluginDef;
+                                   is_tuple(LocalPluginDef) -> element(1, LocalPluginDef)
+                               end
+                            end,
+                            LocalPluginsDefs),
+    {LocalPluginsDefs, LocalPluginsNames}.
 
 display_plugins(_Header, _Apps, []) ->
     ok;

--- a/src/rebar_prv_plugins.erl
+++ b/src/rebar_prv_plugins.erl
@@ -62,9 +62,11 @@ list_local_plugins(State) ->
                        ++ rebar_state:get(State, project_plugins, []),
     LocalPluginsNames = lists:map(
                             fun (LocalPluginDef) ->
-                                if is_atom(LocalPluginDef) -> LocalPluginDef;
-                                   is_tuple(LocalPluginDef) -> element(1, LocalPluginDef)
-                               end
+                                rebar_utils:to_atom(
+                                    if is_tuple(LocalPluginDef) -> element(1, LocalPluginDef);
+                                       LocalPluginDef -> LocalPluginDef
+                                    end
+                                )
                             end,
                             LocalPluginsDefs),
     {LocalPluginsDefs, LocalPluginsNames}.

--- a/src/rebar_prv_plugins_upgrade.erl
+++ b/src/rebar_prv_plugins_upgrade.erl
@@ -35,14 +35,18 @@ do(State) ->
     {Args, _} = rebar_state:command_parsed_args(State),
     case proplists:get_value(plugin, Args, none) of
         none ->
-            ?PRV_ERROR(no_plugin_arg);
+            {_, LocalPluginsNames} = rebar_prv_plugins:list_local_plugins(State),
+            lists:foldl(
+                fun (LocalPluginName, {ok, StateAcc}) ->
+                    upgrade(atom_to_list(LocalPluginName), StateAcc)
+                end,
+                {ok, State},
+                LocalPluginsNames);
         Plugin ->
             upgrade(Plugin, State)
     end.
 
 -spec format_error(any()) -> iolist().
-format_error(no_plugin_arg) ->
-    io_lib:format("Must give an installed plugin to upgrade as an argument", []);
 format_error({not_found, Plugin}) ->
     io_lib:format("Plugin to upgrade not found: ~ts", [Plugin]);
 format_error(Reason) ->

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -58,6 +58,7 @@
          deps_to_binary/1,
          to_binary/1,
          to_list/1,
+         to_atom/1,
          tup_dedup/1,
          tup_umerge/2,
          tup_sort/1,
@@ -269,6 +270,10 @@ to_list(A) when is_atom(A) -> atom_to_list(A);
 to_list(B) when is_binary(B) -> unicode:characters_to_list(B);
 to_list(I) when is_integer(I) -> integer_to_list(I);
 to_list(Str) -> unicode:characters_to_list(Str).
+
+to_atom(B) when is_binary(B) -> binary_to_atom(B, utf8);
+to_atom(Str) when is_list(Str) -> list_to_atom(Str);
+to_atom(A) when is_atom(A) -> A.
 
 tup_dedup(List) ->
     tup_dedup_(tup_sort(List)).


### PR DESCRIPTION
Closes #2491.

As per the doc.s and a validation (over Slack), about the expected behaviour, this pull request aims at having `rebar3 plugins upgrade` (no target plugin) work.

- [ ] take https://github.com/erlang/rebar3/pull/2521#discussion_r603258207 into account
- [ ] make sure `as Profile plugins upgrade` is taken into account (crashing in this pull request)