### PR TITLE
Catch and report missing escript dependency

### DIFF
--- a/test/rebar_escriptize_SUITE.erl
+++ b/test/rebar_escriptize_SUITE.erl
@@ -7,6 +7,7 @@
          all/0,
          escriptize_with_name/1,
          escriptize_with_bad_name/1,
+         escriptize_with_bad_dep/1,
          build_and_clean_app/1,
          escriptize_with_ebin_subdir/1]).
 
@@ -31,6 +32,7 @@ all() ->
      build_and_clean_app,
      escriptize_with_name,
      escriptize_with_bad_name,
+     escriptize_with_bad_dep,
      escriptize_with_ebin_subdir
     ].
 
@@ -61,6 +63,15 @@ escriptize_with_bad_name(Config) ->
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
     rebar_test_utils:run_and_check(Config, [{escript_main_app, boogers}], ["escriptize"],
                                    {error,{rebar_prv_escriptize, {bad_name, boogers}}}).
+
+escriptize_with_bad_dep(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib, boogers]),
+    rebar_test_utils:run_and_check(Config, [{escript_main_app, Name}], ["escriptize"],
+                                   {error,{rebar_prv_escriptize, {bad_app, boogers}}}).
 
 escriptize_with_ebin_subdir(Config) ->
     AppDir = ?config(apps, Config),


### PR DESCRIPTION
Otherwise we end up in a situation where we get a hard crash.
Fixes https://github.com/erlang/rebar3/issues/2520