### PR TITLE
Fix DAG resolving for recursive directories

### DIFF
--- a/src/rebar_compiler_dag.erl
+++ b/src/rebar_compiler_dag.erl
@@ -244,8 +244,8 @@ compile_order(G, AppDefs, SrcExt, ArtifactExt) ->
     %% Build a digraph for following topo-sort, and populate
     %%  FileToApp map as a side effect for caching
     AppDAG = digraph:new([acyclic]), % ignore cycles and hope it works
-    IsHeaderFile = 
-        fun(File) -> 
+    IsHeaderFile =
+        fun(File) ->
             Ext = filename:extension(File),
             (Ext =/= SrcExt) andalso (Ext =/= ArtifactExt)
         end,

--- a/src/rebar_compiler_epp.erl
+++ b/src/rebar_compiler_epp.erl
@@ -126,12 +126,12 @@ list_directory(Dir, Cache) ->
                     %% create a full list of *.erl files under Dir.
                     {NewFs, Files} = lists:foldl(
                         fun (File, {DirCache, Files} = Acc) ->
-                            %% recurse into subdirs
                             FullName = filename:join(Dir, File),
                             case filelib:is_dir(FullName) of
                                 true ->
-                                    {UpdFs, MoreFiles} = list_directory(FullName, DirCache),
-                                    {UpdFs, MoreFiles ++ Files};
+                                    %% We assume the include paths carry all recursive directories
+                                    %% so we don't need this resolution to be recursive.
+                                    Acc;
                                 false ->
                                     %% ignore all but *.erl files
                                     case filename:extension(File) =:= ".erl" of


### PR DESCRIPTION
This fixes https://github.com/erlang/rebar3/issues/2534

While fixing the bug reported above, as explained in https://github.com/erlang/rebar3/issues/2534#issuecomment-820393110
I found out that the DAG preparation took in include paths that were
explicit, and did not resolve them properly (and therefore silently
failed to track updates). On the other hand, the compiler worked fine,
which highlighted a difference between options passed to EPP via the
compiler, and those we pass internally when building the DAG.

I fixed this, which in turn caused problems with test cases for
recursive parse transforms; the reason being that modules were being
resolved as source files under `_build/`, which turned out to be due to
the EPP resolver we wrote that would go recursive in all directories to
find files. So when the top-level directory for an app was passed in
(which is needed for include files in legacy cases), it accidentally
would find build modules before the rest.

This was fixed by removing recursivity in EPP, which in turn broke the
behaviour recursive lookup in the DAG; this required going back to the
`rebar_compiler_erl` module's paths and sending in explicit lookup paths
for includes (which are also in a set used for behaviours and parse
transforms!)

So here we are:

1. Take the recursive lookup out of EPP (which is used only for erl
   files anyway)
2. Move the path expansion around that to be done in the compiler
   behaviour's context function instead since it's required for include
   files as well (EPP won't cover these)
3. Ensure that path expansion in the context function also respects the
   rebar.config recursion options for the erlang compiler, which will
   prevent potential clashes around subdirectories with conflicting (or
   optionally-built) files
4. Adding a test for the new case

This is one interesting case of tests partially saving our asses, once
more.  They're slow but they're good.

CC @max-au since this touches fun code y'all needed, but I expect no breakage.