### PR TITLE
Fix `plugins upgrade` for non-tuple specification

### DIFF
--- a/src/rebar_prv_plugins.erl
+++ b/src/rebar_prv_plugins.erl
@@ -64,7 +64,7 @@ list_local_plugins(State) ->
                             fun (LocalPluginDef) ->
                                 rebar_utils:to_atom(
                                     if is_tuple(LocalPluginDef) -> element(1, LocalPluginDef);
-                                       LocalPluginDef -> LocalPluginDef
+                                       true -> LocalPluginDef
                                     end
                                 )
                             end,

--- a/test/rebar_plugins_SUITE.erl
+++ b/test/rebar_plugins_SUITE.erl
@@ -217,6 +217,11 @@ upgrade(Config) ->
     rebar_test_utils:run_and_check(
         Config, RConf, ["plugins", "upgrade", PkgName],
         {ok, [{app, Name, valid}, {file, PluginBeam}, {plugin, PkgName, <<"0.1.3">>}]}
+     ),
+
+    rebar_test_utils:run_and_check(
+        Config, RConf, ["plugins", "upgrade"],
+        {ok, [{app, Name, valid}, {file, PluginBeam}, {plugin, PkgName}]}
      ).
 
 upgrade_project_plugin(Config) ->


### PR DESCRIPTION
Fixes https://github.com/erlang/rebar3/issues/2440#issuecomment-823051052, as introduced by https://github.com/erlang/rebar3/commit/10404ab802415e9b515250a496f4726c367407ed#diff-8ea8ad4be21eabc13455daec52b69545db813e2e08597683d9a4f6c0fce7b187R67.

I'm trying to come up with a test.