### PR TITLE
add support to configure application resource naming

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -50,7 +50,7 @@
 %% This configuration is intended to let profiles compose with special app
 %% files by prefixing extensions.
 {application_resource_extensions, [
-    ".app.src.script", ".app.src", ".exs"
+    ".app.src.script", ".app.src"
 ]}
 
 %% == Common Test ==

--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -42,6 +42,14 @@
 %% yecc files to compile first
 {yrl_first_files, []}.
 
+%% == Application Discovery ==
+
+%% Extensions for discovering application resource files. Rebar3 discovers
+%% applications by searching for these files. When building the application
+%% information, rebar will use the first discovered files in the list.
+{application_resource_extensions, [
+    "app.src.script", "app.src", "mix.exs"
+]}
 
 %% == Common Test ==
 

--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -47,8 +47,10 @@
 %% Extensions for discovering application resource files. Rebar3 discovers
 %% applications by searching for these files. When building the application
 %% information, rebar will use the first discovered files in the list.
+%% This configuration is intended to let profiles compose with special app
+%% files by prefixing extensions.
 {application_resource_extensions, [
-    "app.src.script", "app.src", "mix.exs"
+    ".app.src.script", ".app.src", ".exs"
 ]}
 
 %% == Common Test ==

--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -31,6 +31,7 @@
 -define(INDEX_FILE, "packages.idx").
 -define(HEX_AUTH_FILE, "hex.config").
 -define(PUBLIC_HEX_REPO, <<"hexpm">>).
+-define(DEFAULT_APP_RESOURCE_EXT, ["app.src.script", "app.src", "mix.exs"]).
 
 %% ignore this function in all modules
 %% not every module that exports it and relies on it being called implements provider

--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -31,7 +31,7 @@
 -define(INDEX_FILE, "packages.idx").
 -define(HEX_AUTH_FILE, "hex.config").
 -define(PUBLIC_HEX_REPO, <<"hexpm">>).
--define(DEFAULT_APP_RESOURCE_EXT, [".app.src.script", ".app.src", ".exs"]).
+-define(DEFAULT_APP_RESOURCE_EXT, [".app.src.script", ".app.src"]).
 
 %% ignore this function in all modules
 %% not every module that exports it and relies on it being called implements provider

--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -31,7 +31,7 @@
 -define(INDEX_FILE, "packages.idx").
 -define(HEX_AUTH_FILE, "hex.config").
 -define(PUBLIC_HEX_REPO, <<"hexpm">>).
--define(DEFAULT_APP_RESOURCE_EXT, ["app.src.script", "app.src", "mix.exs"]).
+-define(DEFAULT_APP_RESOURCE_EXT, [".app.src.script", ".app.src", ".exs"]).
 
 %% ignore this function in all modules
 %% not every module that exports it and relies on it being called implements provider

--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -383,11 +383,11 @@ extension_type([{Pattern, Type} | Rest], Extension) ->
          FlattenedResourceFiles :: [{app_resource_type(), file:filename()}].
 flatten_resource_files(ResourceFiles) ->
     {Flattened, _} =
-        lists:foldr(
+        lists:foldl(
             fun flatten_resource_impl/2,
             {[], []},
             ResourceFiles),
-    Flattened.
+    lists:reverse(Flattened).
 
 flatten_resource_impl({Type, Files}, Acc = {ResAcc, Used}) ->
     NewFiles = [F || F <- Files, not lists:member(F, Used)],

--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -4,15 +4,17 @@
 
 -export([do/2,
          format_error/1,
-         find_unbuilt_apps/1,
-         find_apps/1,
+         find_unbuilt_apps/2,
          find_apps/2,
+         find_apps/3,
          find_apps/4,
-         find_app/2,
-         find_app/3]).
+         find_app/3,
+         find_app/4]).
 
 -include("rebar.hrl").
 -include_lib("providers/include/providers.hrl").
+
+-type app_resource_type() :: app |  app_src | script | mix_exs.
 
 %% @doc from the base directory, find all the applications
 %% at the top level and their dependencies based on the configuration
@@ -219,13 +221,13 @@ reset_hooks(Opts, CurrentProfiles) ->
 %% @private find the directories for all apps, while detecting their source dirs
 %% Returns the app dir with the respective src_dirs for them, in that order,
 %% for every app found.
--spec all_app_dirs([file:name()]) -> [{file:name(), [file:name()]}].
-all_app_dirs(LibDirs) ->
+-spec all_app_dirs([file:name()], rebar_state:t()) -> [{file:name(), [file:name()]}].
+all_app_dirs(LibDirs, State) ->
     lists:flatmap(fun(LibDir) ->
                           case filelib:is_dir(LibDir) of
                               true ->
                                   {_, SrcDirs} = find_config_src(LibDir, ["src"]),
-                                  app_dirs(LibDir, SrcDirs);
+                                  app_dirs(LibDir, SrcDirs, State);
                               false ->
                                   []
                           end
@@ -234,9 +236,9 @@ all_app_dirs(LibDirs) ->
 %% @private find the directories for all apps based on their source dirs
 %% Returns the app dir with the respective src_dirs for them, in that order,
 %% for every app found.
--spec all_app_dirs([file:name()], [file:name()]) -> [{file:name(), [file:name()]}].
-all_app_dirs(LibDirs, SrcDirs) ->
-    lists:flatmap(fun(LibDir) -> app_dirs(LibDir, SrcDirs) end, LibDirs).
+-spec all_app_dirs([file:name()], [file:name()], rebar_state:t()) -> [{file:name(), [file:name()]}].
+all_app_dirs(LibDirs, SrcDirs, State) ->
+    lists:flatmap(fun(LibDir) -> app_dirs(LibDir, SrcDirs, State) end, LibDirs).
 
 %% @private find the directories based on the library directories.
 %% Returns the app dir with the respective src_dirs for them, in that order,
@@ -245,11 +247,11 @@ all_app_dirs(LibDirs, SrcDirs) ->
 %% The function returns the src directories since they might have been
 %% detected in a top-level loop and we want to skip further detection
 %% starting now.
--spec app_dirs([file:name()], [file:name()]) -> [{file:name(), [file:name()]}].
-app_dirs(LibDir, SrcDirs) ->
+-spec app_dirs([file:name()], [file:name()], rebar_state:t()) -> [{file:name(), [file:name()]}].
+app_dirs(LibDir, SrcDirs, State) ->
+    Extensions = rebar_state:get(State, application_resource_extensions, ?DEFAULT_APP_RESOURCE_EXT),
     Paths = lists:append([
-        [filename:join([LibDir, SrcDir, "*.app.src"]),
-         filename:join([LibDir, SrcDir, "*.app.src.script"])]
+        [filename:join([LibDir, SrcDir, "*." ++ Ext]) || Ext <- Extensions ]
         || SrcDir <- SrcDirs
     ]),
     EbinPath = filename:join([LibDir, "ebin", "*.app"]),
@@ -261,26 +263,26 @@ app_dirs(LibDir, SrcDirs) ->
                             end, [], [EbinPath | Paths])).
 
 %% @doc find all apps that haven't been built in a list of directories
--spec find_unbuilt_apps([file:filename_all()]) -> [rebar_app_info:t()].
-find_unbuilt_apps(LibDirs) ->
-    find_apps(LibDirs, invalid).
+-spec find_unbuilt_apps([file:filename_all()], rebar_state:t()) -> [rebar_app_info:t()].
+find_unbuilt_apps(LibDirs, State) ->
+    find_apps(LibDirs, invalid, State).
 
 %% @doc for each directory passed, find all apps that are valid.
 %% Returns all the related app info records.
--spec find_apps([file:filename_all()]) -> [rebar_app_info:t()].
-find_apps(LibDirs) ->
-    find_apps(LibDirs, valid).
+-spec find_apps([file:filename_all()], rebar_state:t()) -> [rebar_app_info:t()].
+find_apps(LibDirs, State) ->
+    find_apps(LibDirs, valid, State).
 
 %% @doc for each directory passed, find all apps according
 %% to the validity rule passed in. Returns all the related
 %% app info records.
--spec find_apps([file:filename_all()], valid | invalid | all) -> [rebar_app_info:t()].
-find_apps(LibDirs, Validate) ->
+-spec find_apps([file:filename_all()], valid | invalid | all, rebar_state:t()) -> [rebar_app_info:t()].
+find_apps(LibDirs, Validate, State) ->
     rebar_utils:filtermap(
       fun({AppDir, AppSrcDirs}) ->
-            find_app(rebar_app_info:new(), AppDir, AppSrcDirs, Validate)
+            find_app(rebar_app_info:new(), AppDir, AppSrcDirs, Validate, State)
       end,
-      all_app_dirs(LibDirs)
+      all_app_dirs(LibDirs, State)
     ).
 
 %% @doc for each directory passed, with the configured source directories,
@@ -292,30 +294,30 @@ find_apps(LibDirs, SrcDirs, Validate, State) ->
       fun({AppDir, AppSrcDirs}) ->
             find_app(rebar_app_info:new(), AppDir, AppSrcDirs, Validate, State)
       end,
-      all_app_dirs(LibDirs, SrcDirs)
+      all_app_dirs(LibDirs, SrcDirs, State)
     ).
 
 %% @doc check that a given app in a directory is there, and whether it's
 %% valid or not based on the second argument. Returns the related
 %% app info record.
--spec find_app(file:filename_all(), valid | invalid | all) -> {true, rebar_app_info:t()} | false.
-find_app(AppDir, Validate) ->
+-spec find_app(file:filename_all(), valid | invalid | all, rebar_state:t()) -> {true, rebar_app_info:t()} | false.
+find_app(AppDir, Validate, State) ->
     {Config, SrcDirs} = find_config_src(AppDir, ["src"]),
     AppInfo = rebar_app_info:update_opts(rebar_app_info:dir(rebar_app_info:new(), AppDir),
                                          dict:new(), Config),
-    find_app_(AppInfo, AppDir, SrcDirs, Validate).
+    find_app_(AppInfo, AppDir, SrcDirs, Validate, State).
 
 %% @doc check that a given app in a directory is there, and whether it's
 %% valid or not based on the second argument. Returns the related
 %% app info record.
--spec find_app(rebar_app_info:t(), file:filename_all(), valid | invalid | all) ->
+-spec find_app(rebar_app_info:t(), file:filename_all(), valid | invalid | all, rebar_state:t()) ->
     {true, rebar_app_info:t()} | false.
-find_app(AppInfo, AppDir, Validate) ->
+find_app(AppInfo, AppDir, Validate, State) ->
     %% if no src dir is passed, figure it out from the app info, with a default
     %% of src/
     AppOpts = rebar_app_info:opts(AppInfo),
     SrcDirs = rebar_dir:src_dirs(AppOpts, ["src"]),
-    find_app_(AppInfo, AppDir, SrcDirs, Validate).
+    find_app_(AppInfo, AppDir, SrcDirs, Validate, State).
 
 %% @doc check that a given app in a directory is there, and whether it's
 %% valid or not based on the second argument. The third argument includes
@@ -333,27 +335,61 @@ find_app(AppInfo, AppDir, SrcDirs, Validate, State) ->
                        Config = rebar_config:consult(AppDir),
                        rebar_app_info:update_opts(AppInfo, rebar_app_info:opts(AppInfo), Config)
                end,
-    find_app_(AppInfo1, AppDir, SrcDirs, Validate).
-
-find_app(AppInfo, AppDir, SrcDirs, Validate) ->
-    Config = rebar_config:consult(AppDir),
-    AppInfo1 = rebar_app_info:update_opts(AppInfo, rebar_app_info:opts(AppInfo), Config),
-    find_app_(AppInfo1, AppDir, SrcDirs, Validate).
+    find_app_(AppInfo1, AppDir, SrcDirs, Validate, State).
 
 -spec find_app_(rebar_app_info:t(), file:filename_all(),
-               [file:filename_all()], valid | invalid | all) ->
+               [file:filename_all()], valid | invalid | all,  rebar_state:t()) ->
     {true, rebar_app_info:t()} | false.
-find_app_(AppInfo, AppDir, SrcDirs, Validate) ->
-    AppFile = filelib:wildcard(filename:join([AppDir, "ebin", "*.app"])),
-    AppSrcFile = lists:append(
-        [filelib:wildcard(filename:join([AppDir, SrcDir, "*.app.src"]))
-         || SrcDir <- SrcDirs]
-    ),
-    AppSrcScriptFile = lists:append(
-        [filelib:wildcard(filename:join([AppDir, SrcDir, "*.app.src.script"]))
-         || SrcDir <- SrcDirs]
-    ),
-    try_handle_app_file(AppInfo, AppFile, AppDir, AppSrcFile, AppSrcScriptFile, Validate).
+find_app_(AppInfo, AppDir, SrcDirs, Validate, State) ->
+    Extensions = rebar_state:get(State, application_resource_extensions, ?DEFAULT_APP_RESOURCE_EXT),
+    ResourceFiles = [
+        {app, filelib:wildcard(filename:join([AppDir, "ebin", "*.app"]))} |
+        [
+        {extension_type(Ext), lists:append([ filelib:wildcard(filename:join([AppDir, SrcDir, "*." ++ Ext]))
+        || SrcDir <- SrcDirs])}
+        || Ext <- Extensions
+    ]],
+    % io:format(user, "conf: ~p~n", [{AppDir, SrcDirs}]),
+    % io:format(user, "Extensions: ~p~n", [Extensions]),
+    % io:format(user, "ResourceFiles: ~p~n", [ResourceFiles]),
+    FlattenedResourceFiles = flatten_resource_files(ResourceFiles),
+    % io:format(user, "FlattenedResourceFiles: ~p~n", [FlattenedResourceFiles]),
+    try_handle_resource_files(AppInfo, AppDir, FlattenedResourceFiles, Validate).
+
+-spec extension_type(string()) -> app_resource_type().
+extension_type(Extension) ->
+    Mapping = [
+        {"app", app},
+        {"src", app_src},
+        {"script", script},
+        {"mix.exs", mix_exs}
+    ],
+    extension_type(Mapping, Extension).
+
+-spec extension_type([{string(), Type}], string()) -> Type
+    when Type :: app_resource_type().
+extension_type([], _) ->
+    %% default to app_src
+    app_src;
+extension_type([{Pattern, Type} | Rest], Extension) ->
+    case lists:suffix(Pattern, Extension) of
+        true ->
+            Type;
+        false ->
+            extension_type(Rest, Extension)
+    end.
+
+-spec flatten_resource_files(ResourceFiles) -> FlattenedResourceFiles
+    when ResourceFiles :: [{app_resource_type(), [file:filename()]}],
+         FlattenedResourceFiles :: [{app_resource_type(), file:filename()}].
+flatten_resource_files(ResourceFiles) ->
+    lists:foldr(
+        fun ({_Type, []}, Acc)      -> Acc;
+            ({Type, [File]}, Acc)   -> [{Type, File} | Acc];
+            ({_Type, Others}, _Acc) -> throw({error, {multiple_app_files, Others}})
+        end,
+        [],
+        ResourceFiles).
 
 %% @doc find the directory that an appfile has
 -spec app_dir(file:filename()) -> file:filename().
@@ -391,32 +427,39 @@ create_app_info(AppInfo, AppDir, AppFile) ->
             throw({error, {?MODULE, Err}}) % wrap this
     end.
 
+
 %% @doc Read in and parse the .app file if it is availabe. Do the same for
 %% the .app.src file if it exists.
--spec try_handle_app_file(AppInfo, AppFile, AppDir, AppSrcFile, AppSrcScriptFile, valid | invalid | all) ->
+-spec try_handle_resource_files(AppInfo, AppDir, ResourceFiles, valid | invalid | all) ->
     {true, AppInfo} | false when
       AppInfo :: rebar_app_info:t(),
-      AppFile :: file:filename(),
       AppDir :: file:filename(),
-      AppSrcFile :: file:filename(),
-      AppSrcScriptFile :: file:filename().
-try_handle_app_file(AppInfo, [], AppDir, [], AppSrcScriptFile, Validate) ->
-    try_handle_app_src_file(AppInfo, [], AppDir, AppSrcScriptFile, Validate);
-try_handle_app_file(AppInfo, [], AppDir, AppSrcFile, _, Validate) ->
-    try_handle_app_src_file(AppInfo, [], AppDir, AppSrcFile, Validate);
-try_handle_app_file(AppInfo0, [File], AppDir, AppSrcFile, _, Validate) ->
+      ResourceFiles :: [{app_resource_type(), file:filename()}].
+try_handle_resource_files(AppInfo, AppDir, [{app, AppFile} | Rest], Validate) ->
+    AppSrcFile = proplists:get_value(app_src, Rest),
+    try_handle_app_file(AppInfo, AppDir, AppFile, AppSrcFile, Validate);
+try_handle_resource_files(AppInfo, AppDir, [{Type, AppSrcFile} | _Rest], Validate)
+    when Type =:= app_src orelse Type =:= script ->
+    try_handle_app_src_file(AppInfo, AppDir, AppSrcFile, Validate);
+try_handle_resource_files(AppInfo, _AppDir, [{mix_exs, _AppSrcFile} | _Rest], _Validate) ->
+    {true, rebar_app_info:project_type(AppInfo, mix)};
+try_handle_resource_files(_AppInfo, _AppDir, [], _Validate) ->
+    false.
+
+
+%% @doc Read in and parse the .app file if it is availabe. Do the same for
+%% the .app.src file if it exists.
+-spec try_handle_app_file(AppInfo, AppDir, File, AppSrcFile, valid | invalid | all) ->
+    {true, AppInfo} | false when
+      AppInfo :: rebar_app_info:t(),
+      AppDir :: file:filename(),
+      File :: file:filename(),
+      AppSrcFile :: file:filename().
+try_handle_app_file(AppInfo0, AppDir, File, AppSrcFile, Validate) ->
     try create_app_info(AppInfo0, AppDir, File) of
         AppInfo ->
             AppInfo1 = rebar_app_info:app_file(AppInfo, File),
-            AppInfo2 = case AppSrcFile of
-                           [F] ->
-                               rebar_app_info:app_file_src(AppInfo1, F);
-                           [] ->
-                               %% Set to undefined in case AppInfo previous had a .app.src
-                               rebar_app_info:app_file_src(AppInfo1, undefined);
-                           Other when is_list(Other) ->
-                               throw({error, {multiple_app_files, Other}})
-                      end,
+            AppInfo2 = rebar_app_info:app_file_src(AppInfo1, AppSrcFile),
             case Validate of
                 valid ->
                     case rebar_app_utils:validate_application_info(AppInfo2) of
@@ -438,43 +481,30 @@ try_handle_app_file(AppInfo0, [File], AppDir, AppSrcFile, _, Validate) ->
     catch
         throw:{error, {Module, Reason}} ->
             ?DEBUG("Falling back to app.src file because .app failed: ~ts", [Module:format_error(Reason)]),
-            try_handle_app_src_file(AppInfo0, File, AppDir, AppSrcFile, Validate)
-    end;
-try_handle_app_file(_AppInfo, Other, _AppDir, _AppSrcFile, _, _Validate) ->
-    throw({error, {multiple_app_files, Other}}).
+            try_handle_app_src_file(AppInfo0, AppDir, AppSrcFile, Validate)
+    end.
 
 %% @doc Read in the .app.src file if we aren't looking for a valid (already
 %% built) app.
--spec try_handle_app_src_file(AppInfo, AppFile, AppDir, AppSrcFile, valid | invalid | all) ->
+-spec try_handle_app_src_file(AppInfo, AppDir, AppSrcFile, valid | invalid | all) ->
     {true, AppInfo} | false when
       AppInfo :: rebar_app_info:t(),
-      AppFile :: file:filename(),
       AppDir :: file:filename(),
       AppSrcFile :: file:filename().
-try_handle_app_src_file(AppInfo, _, _AppDir, [], _Validate) ->
-    %% if .app and .app.src are not found check for a mix config file
-    %% it is assumed a plugin will build the application, including
-    %% a .app after this step
-    case filelib:is_file(filename:join(rebar_app_info:dir(AppInfo), "mix.exs")) of
-        true ->
-            {true, rebar_app_info:project_type(AppInfo, mix)};
-        false ->
-            false
-    end;
-try_handle_app_src_file(_AppInfo, _, _AppDir, _AppSrcFile, valid) ->
+try_handle_app_src_file(_AppInfo, _AppDir, undefined, valid) ->
     false;
-try_handle_app_src_file(AppInfo, _, AppDir, [File], Validate) when Validate =:= invalid
-                                                                   ; Validate =:= all ->
+try_handle_app_src_file(_AppInfo, _AppDir, _AppSrcFile, valid) ->
+    false;
+try_handle_app_src_file(AppInfo, AppDir, AppSrcFile, _) ->
     AppInfo1 = rebar_app_info:app_file(AppInfo, undefined),
-    AppInfo2 = create_app_info(AppInfo1, AppDir, File),
-    case filename:extension(File) of
+    AppInfo2 = create_app_info(AppInfo1, AppDir, AppSrcFile),
+    case filename:extension(AppSrcFile) of
         ".script" ->
-            {true, rebar_app_info:app_file_src_script(AppInfo2, File)};
+            {true, rebar_app_info:app_file_src_script(AppInfo2, AppSrcFile)};
         _ ->
-            {true, rebar_app_info:app_file_src(AppInfo2, File)}
-    end;
-try_handle_app_src_file(_AppInfo, _, _AppDir, Other, _Validate) ->
-    throw({error, {multiple_app_files, Other}}).
+            {true, rebar_app_info:app_file_src(AppInfo2, AppSrcFile)}
+    end.
+
 
 %% @doc checks whether the given app is not blacklisted in the config.
 -spec enable(rebar_state:t(), rebar_app_info:t()) -> boolean().

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -10,7 +10,7 @@
          update_opts/3,
          update_opts/2,
          update_opts_deps/2,
-         discover/1,
+         discover/2,
          name/1,
          name/2,
          app_file_src/1,
@@ -255,9 +255,9 @@ deps_from_config(Dir, ConfigDeps) ->
     end.
 
 %% @doc discover a complete version of the app info with all fields set.
--spec discover(file:filename_all()) -> {ok, t()} | not_found.
-discover(Dir) ->
-    case rebar_app_discover:find_app(Dir, all) of
+-spec discover(file:filename_all(), rebar_state:t()) -> {ok, t()} | not_found.
+discover(Dir, State) ->
+    case rebar_app_discover:find_app(Dir, all, State) of
         {true, AppInfo} ->
             {ok, AppInfo};
         false ->

--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -255,7 +255,7 @@ dep_to_app(Parent, DepsDir, Name, Vsn, Source0, IsLock, State) ->
     {SubDir, Source1} = subdir(Name, Source0),
     FetchDir = rebar_utils:to_list(filename:join([DepsDir, Name])),
     CheckoutsDir = rebar_utils:to_list(rebar_dir:checkouts_dir(State, Name)),
-    AppInfo = case rebar_app_info:discover(CheckoutsDir) of
+    AppInfo = case rebar_app_info:discover(CheckoutsDir, State) of
                   {ok, App} ->
                       OutDir = filename:join(rebar_dir:checkouts_out_dir(State), Name),
                       rebar_app_info:out_dir(
@@ -264,7 +264,7 @@ dep_to_app(Parent, DepsDir, Name, Vsn, Source0, IsLock, State) ->
                   not_found ->
                       Dir = rebar_utils:to_list(filename:join([DepsDir, Name, SubDir])),
                       {ok, AppInfo0} =
-                          case rebar_app_info:discover(Dir) of
+                          case rebar_app_info:discover(Dir, State) of
                               {ok, App} ->
                                   App1 = rebar_app_info:name(App, Name),
                                   {ok, rebar_app_info:is_available(rebar_app_info:parent(App1, Parent),

--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -29,7 +29,7 @@
 -export([find/2,
          find/3,
          is_app_src/1,
-         app_src_to_app/2,
+         app_src_to_app/3,
          validate_application_info/1,
          validate_application_info/2,
          parse_deps/5,
@@ -70,20 +70,18 @@ is_app_src(Filename) ->
 
 %% @doc translates the name of the .app.src[.script] file to where
 %% its .app counterpart should be stored.
--spec app_src_to_app(OutDir, SrcFilename) -> OutFilename when
+-spec app_src_to_app(OutDir, SrcFilename, State) -> OutFilename when
       OutDir :: file:filename(),
       SrcFilename :: file:filename(),
+      State :: rebar_state:t(),
       OutFilename :: file:filename().
-app_src_to_app(OutDir, Filename) ->
-    AppFile =
-        case lists:suffix(".app.src", Filename) of
-            true ->
-                filename:join([OutDir, "ebin", filename:basename(Filename, ".app.src") ++ ".app"]);
-            false ->
-                filename:join([OutDir, "ebin", filename:basename(Filename,
-                                                                 ".app.src.script") ++ ".app"])
-        end,
-    filelib:ensure_dir(AppFile),
+app_src_to_app(OutDir, Filename, State) ->
+    Extensions = rebar_state:get(State, application_resource_extensions, ?DEFAULT_APP_RESOURCE_EXT),
+    [AppFile | _] = [
+        filename:join([OutDir, "ebin", filename:basename(Filename, Ext) ++ ".app"])
+        || Ext <- Extensions
+        , lists:suffix(Ext, Filename)
+    ],
     AppFile.
 
 %% @doc checks whether the .app file has all the required data to be valid,

--- a/src/rebar_fetch.erl
+++ b/src/rebar_fetch.erl
@@ -30,7 +30,7 @@ download_source(AppInfo, State)  ->
             %% freshly downloaded, update the app info opts to reflect the new config
             Config = rebar_config:consult(AppDir),
             AppInfo1 = rebar_app_info:update_opts(AppInfo, rebar_app_info:opts(AppInfo), Config),
-            case rebar_app_discover:find_app(AppInfo1, AppDir, all) of
+            case rebar_app_discover:find_app(AppInfo1, AppDir, all, State) of
                 {true, AppInfo2} ->
                     rebar_app_info:is_available(AppInfo2, true);
                 false ->

--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -138,7 +138,7 @@ preprocess(State, AppInfo, AppSrcFile) ->
             %% Setup file .app filename and write new contents
             EbinDir = rebar_app_info:ebin_dir(AppInfo),
             rebar_file_utils:ensure_dir(EbinDir),
-            AppFile = rebar_app_utils:app_src_to_app(OutDir, AppSrcFile),
+            AppFile = rebar_app_utils:app_src_to_app(OutDir, AppSrcFile, State),
             ok = rebar_file_utils:write_file_if_contents_differ(AppFile, Spec, utf8),
 
             rebar_app_info:app_file(rebar_app_info:vsn(AppInfo, Vsn), AppFile);

--- a/src/rebar_prv_clean.erl
+++ b/src/rebar_prv_clean.erl
@@ -45,7 +45,7 @@ do(State) ->
     if All; Specific =/= [] ->
         DepsDir = rebar_dir:deps_dir(State1),
         DepsDirs = filelib:wildcard(filename:join(DepsDir, "*")),
-        AllApps = rebar_app_discover:find_apps(DepsDirs, all),
+        AllApps = rebar_app_discover:find_apps(DepsDirs, all, State),
         Filter = case All of
             true -> fun(_) -> true end;
             false -> fun(AppInfo) -> filter_name(AppInfo, Specific) end

--- a/test/rebar_discover_SUITE.erl
+++ b/test/rebar_discover_SUITE.erl
@@ -50,6 +50,7 @@ bad_app_src(Config) ->
        {error, {rebar_app_discover, {bad_term_file, AppSrc, _}}},
        rebar_test_utils:run_and_check(Config, [], ["compile"], return)
     ),
+    ct:pal(""),
     ok.
 
 invalid_app_src() ->
@@ -66,4 +67,3 @@ invalid_app_src(Config) ->
        rebar_test_utils:run_and_check(Config, [], ["compile"], return)
     ),
     ok.
-

--- a/test/rebar_discover_SUITE.erl
+++ b/test/rebar_discover_SUITE.erl
@@ -50,7 +50,6 @@ bad_app_src(Config) ->
        {error, {rebar_app_discover, {bad_term_file, AppSrc, _}}},
        rebar_test_utils:run_and_check(Config, [], ["compile"], return)
     ),
-    ct:pal(""),
     ok.
 
 invalid_app_src() ->

--- a/test/rebar_discover_SUITE.erl
+++ b/test/rebar_discover_SUITE.erl
@@ -5,7 +5,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    [empty_app_src, bad_app_src, invalid_app_src].
+    [empty_app_src, bad_app_src, invalid_app_src, overwrite_extension].
      %% note: invalid .app files without a .app.src also present
      %% has rebar3 just ignoring the directory as not OTP-related.
 
@@ -67,3 +67,48 @@ invalid_app_src(Config) ->
        rebar_test_utils:run_and_check(Config, [], ["compile"], return)
     ),
     ok.
+
+overwrite_extension() ->
+    [{doc, "when we overwrite the default extension with "
+           "`[\".test.app.src\", \".app.src\"]` "
+           "check that the right application resource file is used. When "
+           "the order is reversed multiple_app_files should be returned."}].
+
+overwrite_extension(Config) ->
+    AppDir = ?config(apps, Config),
+    [Name] = ?config(app_names, Config),
+    AppSrc = filename:join([AppDir, "src", Name ++ ".app.src"]),
+    TestAppSrc = filename:join([AppDir, "src", Name ++ ".test.app.src"]),
+    AppSrcData =
+        io_lib:format(
+            "{application, ~s, [{description, \"some description\"},  "
+            "{vsn, \"0.1.0\"},  {applications, [kernel,stdlib]} ]}.~n",
+            [Name]
+        ),
+    TestAppSrcData =
+        io_lib:format(
+            "{application, ~s, [{description, \"some description\"},  "
+            "{vsn, \"0.42.0\"},  {applications, [kernel,stdlib]} ]}.~n",
+            [Name]
+        ),
+    ok = file:write_file(AppSrc, AppSrcData),
+    ok = file:write_file(TestAppSrc, TestAppSrcData),
+    {ok, AfterCompileState} =
+        rebar_test_utils:run_and_check(
+            Config,
+            [{application_resource_extensions, [".test.app.src", ".app.src"]}],
+            ["compile"],
+            return
+        ),
+    [App] = rebar_state:project_apps(AfterCompileState),
+    ?assertEqual("0.42.0", rebar_app_info:vsn(App)),
+    %% reverse order now, check that both are reported as conflicting
+    {error, {rebar_prv_app_discovery, {multiple_app_files, Conflicting}}} =
+        rebar_test_utils:run_and_check(
+            Config,
+            [{application_resource_extensions, [".app.src", ".test.app.src"]}],
+            ["compile"],
+            return
+        ),
+    ?assert(lists:member(AppSrc, Conflicting)),
+    ?assert(lists:member(TestAppSrc, Conflicting)).

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -1,7 +1,8 @@
 -module(rebar_test_utils).
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--export([init_rebar_state/1, init_rebar_state/2, run_and_check/3, run_and_check/4, check_results/3]).
+-export([init_rebar_state/1, init_rebar_state/2, run_and_check/3, run_and_check/4,
+         check_results/3, check_results/4]).
 -export([expand_deps/2, flat_deps/1, top_level_deps/1]).
 -export([create_app/4, create_plugin/4, create_eunit_app/4, create_empty_app/4,
          create_config/2, create_config/3, package_app/4]).
@@ -259,6 +260,10 @@ top_level_deps([{{Name, Vsn, Ref}, _} | Deps]) ->
 %%% Helpers %%%
 %%%%%%%%%%%%%%%
 check_results(AppDir, Expected, ProfileRun) ->
+    State = rebar_state:new(),
+    check_results(AppDir, Expected, ProfileRun, State).
+
+check_results(AppDir, Expected, ProfileRun, State) ->
     BuildDirs = filelib:wildcard(filename:join([AppDir, "_build", ProfileRun, "lib", "*"])),
     BuildSubDirs = [D || D <- filelib:wildcard(filename:join([AppDir, "_build", ProfileRun, "lib", "*", "*", "*"])),
                          filelib:is_dir(D)],
@@ -268,21 +273,21 @@ check_results(AppDir, Expected, ProfileRun) ->
     LockFile = filename:join([AppDir, "rebar.lock"]),
     Locks = lists:flatten(rebar_config:consult_lock_file(LockFile)),
 
-    InvalidApps = rebar_app_discover:find_apps(BuildDirs, invalid),
-    ValidApps = rebar_app_discover:find_apps(BuildDirs, valid),
+    InvalidApps = rebar_app_discover:find_apps(BuildDirs, invalid, State),
+    ValidApps = rebar_app_discover:find_apps(BuildDirs, valid, State),
 
     InvalidDepsNames = [{ec_cnv:to_list(rebar_app_info:name(App)), App} || App <- InvalidApps],
     ValidDepsNames = [{ec_cnv:to_list(rebar_app_info:name(App)), App} || App <- ValidApps],
 
-    Deps = rebar_app_discover:find_apps(BuildDirs, all),
-    SubDeps = rebar_app_discover:find_apps(BuildSubDirs, all),
+    Deps = rebar_app_discover:find_apps(BuildDirs, all, State),
+    SubDeps = rebar_app_discover:find_apps(BuildSubDirs, all, State),
     DepsNames = [{ec_cnv:to_list(rebar_app_info:name(App)), App} || App <- Deps],
     SubDirDepsNames = [{ec_cnv:to_list(rebar_app_info:name(App)), App} || App <- SubDeps],
-    Checkouts = rebar_app_discover:find_apps(CheckoutsDirs, all),
+    Checkouts = rebar_app_discover:find_apps(CheckoutsDirs, all, State),
     CheckoutsNames = [{ec_cnv:to_list(rebar_app_info:name(App)), App} || App <- Checkouts],
-    Plugins = rebar_app_discover:find_apps(PluginDirs, all),
+    Plugins = rebar_app_discover:find_apps(PluginDirs, all, State),
     PluginsNames = [{ec_cnv:to_list(rebar_app_info:name(App)), App} || App <- Plugins],
-    GlobalPlugins = rebar_app_discover:find_apps(GlobalPluginDirs, all),
+    GlobalPlugins = rebar_app_discover:find_apps(GlobalPluginDirs, all, State),
     GlobalPluginsNames = [{ec_cnv:to_list(rebar_app_info:name(App)), App} || App <- GlobalPlugins],
 
     lists:foreach(


### PR DESCRIPTION
This adds the ability to configure the default naming of the `.app.src` and `.app.src.script` files for application discovery:
- `application_resource_extensions` can be set  to define extension to the resource files
- the extensions will be tried to be resolved from left to right
- `.app` files are still handled like before (not configurable)
- `mix.exs` files are handled, but can be disabled (by removing from extension list), I'm not sure if this is the right thing todo here, or if they should be special cased like the `.app` files

Note: This still needs tests added.