### PR TITLE
Strip CLI args from provider hooks

### DIFF
--- a/src/rebar_hooks.erl
+++ b/src/rebar_hooks.erl
@@ -59,7 +59,12 @@ run_provider_hooks_(Dir, Type, Command, Providers, TypeHooks, State) ->
         HookProviders ->
             rebar_paths:set_paths([plugins], State),
             Providers1 = rebar_state:providers(State),
-            State1 = rebar_state:providers(rebar_state:dir(State, Dir), Providers++Providers1),
+            %% Drop CLI arguments from the command for the hook.
+            State0 = rebar_state:command_parsed_args(
+                       rebar_state:command_args(State, []),
+                       {[], []}
+            ),
+            State1 = rebar_state:providers(rebar_state:dir(State0, Dir), Providers++Providers1),
             ?DEBUG("\t{provider_hooks, [{~p, ~p}]}.",
                    [Type, HookProviders]),
             case rebar_core:do(HookProviders, State1) of

--- a/test/rebar_hooks_SUITE.erl
+++ b/test/rebar_hooks_SUITE.erl
@@ -25,7 +25,7 @@ all() ->
     [build_and_clean_app, run_hooks_once, run_hooks_once_profiles,
      escriptize_artifacts, run_hooks_for_plugins, deps_hook_namespace,
      bare_compile_hooks_default_ns, deps_clean_hook_namespace, eunit_app_hooks,
-     sub_app_hooks, root_hooks].
+     sub_app_hooks, root_hooks, drop_hook_args].
 
 %% Test post provider hook cleans compiled project app, leaving it invalid
 build_and_clean_app(Config) ->
@@ -254,3 +254,14 @@ root_hooks(Config) ->
       Config, RConf, ["compile"],
       {ok, [{app, Name, invalid}]}
      ).
+
+drop_hook_args(Config) ->
+    RebarConfig = [
+        {provider_hooks, [
+            {pre, [{eunit, path}]}
+        ]}
+    ],
+    rebar_test_utils:run_and_check(
+        Config, RebarConfig, ["eunit", "--cover=false"],
+        {ok, []}
+    ).


### PR DESCRIPTION
Otherwise, arguments for one command are potentially passed to an
incompatible one.

Fixes #2545