### PR TITLE
Treat applications and included_applications the same way when builing Dialyzer PLTs

### DIFF
--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -223,7 +223,11 @@ proj_apps(State) ->
 
 proj_plt_apps(State) ->
     Apps = rebar_state:project_apps(State),
-    DepApps = lists:flatmap(fun rebar_app_info:applications/1, Apps),
+    DepApps = lists:flatmap(
+               fun(App) ->
+                       rebar_app_info:applications(App) ++
+                           rebar_app_info:included_applications(App)
+               end, Apps),
     ProjApps = proj_apps(State),
     case get_config(State, plt_apps, top_level_deps) of
         top_level_deps ->


### PR DESCRIPTION
Hello,

[included_applications](https://erlang.org/doc/design_principles/included_applications.html) is not a much-used feature afaik. When toying around with the feature I got some dialyzer errors (Callback info about the ... behaviour is not available) when I defined a behaviour in the included application and used it in the primary application. This should fix it :)
