### PR TITLE
Only support 3 newest OTP versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [20, 21, 22, 23, 24]
+        otp_version: [22, 23, 24]
         os: [ubuntu-latest]
 
     container:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: gleam-lang/setup-erlang@master
       with:
-        otp-version: 21.3.8.17
+        otp-version: 22.3.4.18
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: gleam-lang/setup-erlang@master
       with:
-        otp-version: 21.3.8.17
+        otp-version: 22.3.4.18
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rebar3
 
-[![Build Status](https://github.com/erlang/rebar3/workflows/Common%20Test/badge.svg)](https://github.com/erlang/rebar3/actions?query=branch%3Amaster+workflow%3A"Common+Test") [![Erlang Versions](https://img.shields.io/badge/Supported%20Erlang%2FOTP-19.0%20to%2023.0-blue)](http://www.erlang.org)
+[![Build Status](https://github.com/erlang/rebar3/workflows/Common%20Test/badge.svg)](https://github.com/erlang/rebar3/actions?query=branch%3Amaster+workflow%3A"Common+Test") [![Erlang Versions](https://img.shields.io/badge/Supported%20Erlang%2FOTP-22.0%20to%2024.0-blue)](http://www.erlang.org)
 
 1. [What is Rebar3?](#what-is-rebar3)
 2. [Why Rebar3?](#why-rebar3)
@@ -94,7 +94,7 @@ by [Erlang Solutions](https://www.erlang-solutions.com/resources/download.html),
 but be sure to choose the "Standard" download option or you'll have issues building
 projects.
 
-Do note that if you are planning to work with multiple Erlang versions on the same machine, you will want to build Rebar3 with the oldest one of them. The five newest major Erlang releases are supported at any given time: if the newest version is OTP-23, building with versions as old as OTP-19 will be supported, and produce an executable that will work with those that follow.
+Do note that if you are planning to work with multiple Erlang versions on the same machine, you will want to build Rebar3 with the oldest one of them. The 3 newest major Erlang releases are supported at any given time: if the newest version is OTP-24, building with versions as old as OTP-22 will be supported, and produce an executable that will work with those that follow.
 
 ## Documentation
 


### PR DESCRIPTION
The burden of 5 major versions is too high, use the fact that people are
gonna want to switch to OTP-24 for the JIT to clamp down on how much
backwards compat we sign up to reasonnably support and do the same as
what the OTP team is doing.