### PR TITLE
Introduce hex_core HTTP adapter for rebar3 (3.13.x)

### DIFF
--- a/src/rebar_httpc_adapter.erl
+++ b/src/rebar_httpc_adapter.erl
@@ -1,0 +1,41 @@
+%% Derived from hex_core v0.5.1 for extra flexibility.
+
+-module(rebar_httpc_adapter).
+-behaviour(r3_hex_http).
+-export([request/5]).
+
+%%====================================================================
+%% API functions
+%%====================================================================
+
+request(Method, URI, ReqHeaders, Body, AdapterConfig) ->
+    Profile = maps:get(profile, AdapterConfig, default),
+    Request = build_request(URI, ReqHeaders, Body),
+    SSLOpts = [{ssl, rebar_utils:ssl_opts(URI)}],
+    case httpc:request(Method, Request, SSLOpts, [{body_format, binary}], Profile) of
+        {ok, {{_, StatusCode, _}, RespHeaders, RespBody}} ->
+            RespHeaders2 = load_headers(RespHeaders),
+            {ok, {StatusCode, RespHeaders2, RespBody}};
+        {error, Reason} -> {error, Reason}
+    end.
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+build_request(URI, ReqHeaders, Body) ->
+    build_request2(binary_to_list(URI), dump_headers(ReqHeaders), Body).
+
+build_request2(URI, ReqHeaders, undefined) ->
+    {URI, ReqHeaders};
+build_request2(URI, ReqHeaders, {ContentType, Body}) ->
+    {URI, ReqHeaders, ContentType, Body}.
+
+dump_headers(Map) ->
+    maps:fold(fun(K, V, Acc) ->
+        [{binary_to_list(K), binary_to_list(V)} | Acc] end, [], Map).
+
+load_headers(List) ->
+    lists:foldl(fun({K, V}, Acc) ->
+        maps:put(list_to_binary(K), list_to_binary(V), Acc) end, #{}, List).
+

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -29,7 +29,7 @@
 -spec init(atom(), rebar_state:t()) -> {ok, rebar_resource_v2:resource()}.
 init(Type, State) ->
     {ok, Vsn} = application:get_key(rebar, vsn),
-    BaseConfig = #{http_adapter => r3_hex_http_httpc,
+    BaseConfig = #{http_adapter => rebar_httpc_adapter,
                    http_user_agent_fragment =>
                        <<"(rebar3/", (list_to_binary(Vsn))/binary, ") (httpc)">>,
                    http_adapter_config => #{profile => rebar}},

--- a/test/rebar_pkg_repos_SUITE.erl
+++ b/test/rebar_pkg_repos_SUITE.erl
@@ -319,6 +319,7 @@ use_first_repo_match(Config) ->
     ?assertMatch({ok,{package,{<<"B">>, {{2,0,0}, {[],[]}}, Repo2},
                       <<"some checksum">>, false, []},
                   #{name := Repo2,
+                    http_adapter := rebar_httpc_adapter,
                     http_adapter_config := #{profile := rebar}}},
                  rebar_packages:resolve_version(<<"B">>, <<"> 1.4.0">>, undefined,
                                                 ?PACKAGE_TABLE, State)),
@@ -326,6 +327,7 @@ use_first_repo_match(Config) ->
     ?assertMatch({ok,{package,{<<"B">>, {{1,4,0}, {[],[]}}, Repo3},
                       <<"some checksum">>, false, []},
                   #{name := Repo3,
+                    http_adapter := rebar_httpc_adapter,
                     http_adapter_config := #{profile := rebar}}},
                  rebar_packages:resolve_version(<<"B">>, <<"~> 1.4.0">>, undefined,
                                                 ?PACKAGE_TABLE, State)).
@@ -337,6 +339,7 @@ use_exact_with_hash(Config) ->
     ?assertMatch({ok,{package,{<<"C">>, {{1,3,1}, {[],[]}}, Repo2},
                       <<"good checksum">>, false, []},
                   #{name := Repo2,
+                    http_adapter := rebar_httpc_adapter,
                     http_adapter_config := #{profile := rebar}}},
                  rebar_packages:resolve_version(<<"C">>, <<"1.3.1">>, <<"good checksum">>,
                                                 ?PACKAGE_TABLE, State)).
@@ -347,6 +350,7 @@ fail_repo_update(Config) ->
     ?assertMatch({ok,{package,{<<"B">>, {{1,4,0}, {[],[]}}, Repo3},
                       <<"some checksum">>, false, []},
                   #{name := Repo3,
+                    http_adapter := rebar_httpc_adapter,
                     http_adapter_config := #{profile := rebar}}},
                  rebar_packages:resolve_version(<<"B">>, <<"~> 1.4.0">>, undefined,
                                                 ?PACKAGE_TABLE, State)).
@@ -358,6 +362,7 @@ ignore_match_in_excluded_repo(Config) ->
     ?assertMatch({ok,{package,{<<"B">>, {{1,4,6}, {[],[]}}, Hexpm},
                       <<"some checksum">>, #{reason := 'RETIRED_INVALID'}, []},
                   #{name := Hexpm,
+                    http_adapter := rebar_httpc_adapter,
                     http_adapter_config := #{profile := rebar}}},
                  rebar_packages:resolve_version(<<"B">>, <<"~> 1.4.0">>, undefined,
                                                 ?PACKAGE_TABLE, State)),
@@ -366,6 +371,7 @@ ignore_match_in_excluded_repo(Config) ->
     ?assertMatch({ok,{package,{<<"A">>, {{0,1,1}, {[],[]}}, Repo2},
                       <<"good checksum">>, false, []},
                   #{name := Repo2,
+                    http_adapter := rebar_httpc_adapter,
                     http_adapter_config := #{profile := rebar}}},
                  rebar_packages:resolve_version(<<"A">>, <<"0.1.1">>, <<"good checksum">>,
                                                 ?PACKAGE_TABLE, State)).
@@ -376,6 +382,7 @@ optional_prereleases(Config) ->
     ?assertMatch({ok,{package,{<<"B">>, {{1,5,0}, {[],[]}}, Hexpm},
                       <<"some checksum">>, false, []},
                   #{name := Hexpm,
+                    http_adapter := rebar_httpc_adapter,
                     http_adapter_config := #{profile := rebar}}},
                  rebar_packages:resolve_version(<<"B">>, <<"~> 1.5.0">>, undefined,
                                                 ?PACKAGE_TABLE, State)),
@@ -383,6 +390,7 @@ optional_prereleases(Config) ->
     ?assertMatch({ok,{package,{<<"B">>, {{1,5,6}, {[<<"rc">>,0],[]}}, Hexpm},
                       <<"some checksum">>, true, []},
                   #{name := Hexpm,
+                    http_adapter := rebar_httpc_adapter,
                     http_adapter_config := #{profile := rebar}}},
                  rebar_packages:resolve_version(<<"B">>, <<"1.5.6-rc.0">>, <<"some checksum">>,
                                                 ?PACKAGE_TABLE, State)),
@@ -392,6 +400,7 @@ optional_prereleases(Config) ->
     ?assertMatch({ok,{package,{<<"B">>, {{1,5,6}, {[<<"rc">>,0],[]}}, Hexpm},
                       <<"some checksum">>, true, []},
                   #{name := Hexpm,
+                    http_adapter := rebar_httpc_adapter,
                     http_adapter_config := #{profile := rebar}}},
                  rebar_packages:resolve_version(<<"B">>, <<"~> 1.5.0">>, <<"some checksum">>,
                                                 ?PACKAGE_TABLE, State1)).


### PR DESCRIPTION
Resolves https://github.com/erlang/rebar3/issues/2564.

Based on https://github.com/erlang/rebar3/pull/2561, an adaptation of erlang@751fa916b81a444db74a7c37c6addfc7ffb8b511 for rebar3 3.13.x.

Per https://ferd.ca/you-ve-got-to-upgrade-rebar3.html:

> [The patch](https://github.com/erlang/rebar3/commit/17848f4c7711981806cd28bcd580eb96a2f9b660#diff-4b5af60b80cd23cfd32adbf1b5e7647c8d89a8d7046c89cee2be5a5ae14dc95fR14) is not that complex on new versions and should be relatively easy to port to older versions if anyone ends up wanting to help.

This should work for anyone on rebar3 3.13.2 either due to running an older OTP or still needing the old pre-compile hook behavior (https://github.com/erlang/rebar3/pull/2211#issuecomment-705888811).