### PR TITLE
Fix optimistic registry update of plugins being upgraded

### DIFF
--- a/src/rebar_prv_plugins_upgrade.erl
+++ b/src/rebar_prv_plugins_upgrade.erl
@@ -101,7 +101,7 @@ build_plugin(ToBuild, State) ->
 maybe_update_pkg(Tup, State) when is_tuple(Tup) ->
     maybe_update_pkg(element(1, Tup), State);
 maybe_update_pkg(Name, State) ->
-    try rebar_app_utils:parse_dep(root, unicode:characters_to_binary(?DEFAULT_PLUGINS_DIR), Name, State, [], 0) of
+    try rebar_app_utils:parse_dep(Name, root, unicode:characters_to_list(?DEFAULT_PLUGINS_DIR), State, [], 0) of
         AppInfo ->
             Source = rebar_app_info:source(AppInfo),
             case element(1, Source) of


### PR DESCRIPTION
This apparently never worked properly, the call being made swapped
arguments order, but kept the type correct enough that no type warning
would be raised.

This isn't a problem though, because before this optimization, people
were already used to calling 'rebar3 update' before upgrading a plugin.
This being fixed makes that call optional now.