### PR TITLE
Support sys.config.src in common test

### DIFF
--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -515,8 +515,9 @@ apply_sys_config(State) ->
         proplists:get_value(sys_config, RawOpts, ""),
         [$,]
     ) ++ CfgSysCfg,
+    RootDir = rebar_dir:root_dir(State),
     Configs = lists:flatmap(
-        fun(Filename) -> rebar_file_utils:consult_config(State, Filename) end,
+        fun(Filename) -> rebar_file_utils:consult_config(RootDir, Filename) end,
         SysCfgs
     ),
     %% NB: load the applications (from user directories too) to support OTP < 17

--- a/test/rebar_ct_SUITE.erl
+++ b/test/rebar_ct_SUITE.erl
@@ -1158,6 +1158,10 @@ cmd_sys_config(Config) ->
     ok = filelib:ensure_dir(OtherCfgFile),
     ok = file:write_file(OtherCfgFile, other_sys_config_file(AppName)),
 
+    SrcCfgFile = filename:join([AppDir, "config", "source.config.src"]),
+    ok = filelib:ensure_dir(SrcCfgFile),
+    ok = file:write_file(SrcCfgFile, cfg_sys_src_config_file(AppName, "MyExpectedString")),
+
     RebarConfig = [{ct_opts, [{sys_config, CfgFile}]}],
     {ok, State1} = rebar_test_utils:run_and_check(Config, RebarConfig, ["as", "test", "lock"], return),
 
@@ -1165,6 +1169,8 @@ cmd_sys_config(Config) ->
     ?assertEqual({ok, cfg_value}, application:get_env(AppName, key)),
 
     ?assertEqual({ok, other_cfg_value}, application:get_env(AppName, other_key)),
+
+    ?assertEqual({ok, "MyExpectedString"}, application:get_env(AppName, src_key)),
 
     Providers = rebar_state:providers(State1),
     Namespace = rebar_state:namespace(State1),
@@ -1674,7 +1680,11 @@ cmd_sys_config_file(AppName) ->
     io_lib:format("[{~ts, [{key, cmd_value}]}].", [AppName]).
 
 cfg_sys_config_file(AppName) ->
-    io_lib:format("[{~ts, [{key, cfg_value}]}, \"config/other\"].", [AppName]).
+    io_lib:format("[{~ts, [{key, cfg_value}]}, \"config/other\", \"config/source.config.src\"].", [AppName]).
 
 other_sys_config_file(AppName) ->
     io_lib:format("[{~ts, [{other_key, other_cfg_value}]}].", [AppName]).
+
+cfg_sys_src_config_file(AppName, ExpectedValue) ->
+    os:putenv("SRC_VALUE", ExpectedValue),
+    io_lib:format("[{~ts, [{src_key, \"${SRC_VALUE}\"}]}].", [AppName]).


### PR DESCRIPTION
Fixes #2096

Hello!

It's really nice to call `rebar3 shell` and have `.config.src` files automatically loaded, much like they are in Erlang releases. I was surprised to see that `rebar3 ct` doesn't do the same sort of substitution with environment variables. With these changes, it is now possible.

A big portion of this PR is moving `consult_env_config/2` from `rebar_priv_shell.erl` to `rebar_file_utils.erl`.

I have some remaining questions/statements:

1. Would it be useful for `rebar_file_utils:consult_config/2` read the extension of the file, and automatically call `consult_env_config` if the extension is `.src`? The branching for `.config` and `.config.src` is currently duplicated, but I'm not exactly sure if it's the right move to DRY in this case.
2. Please note, I changed the logic slightly in `consult_config` to only prepend `RootDir` if a config file `consult`ed from a .config file is a relative path. [`erl -man config`](https://erlang.org/doc/man/config.html) seems to recommend using absolute paths in sys.config files, so I wanted to be sure that we don't do any unfortunate path mangling when there an absolute path is found.
3. Should I go ahead and implement this functionality for eunit tests? The way forward appears to be to accept an `env_file` option in `eunit_opts`, add a .config.src file to test/rebar_eunit_SUITE_data/syscfg_app.zip, along with an appropriate env_file. I could probably submit that as another PR; just say the word :)
4. `rebar_prv_common_test` currently calls `rebar_prv_shell:maybe_set_env_vars`, introducing a dependency edge between two provider modules that didn't exist before. I don't mind moving `maybe_set_env_vars` to a module like `rebar_file_utils` if you'd like to avoid coupling the rebar_prv_shell and rebar_prv_common_test.