### PR TITLE
Fix ssl check hostname options for wildcard certificate

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -34,6 +34,7 @@
 
 {erl_opts, [warnings_as_errors,
             {platform_define, "^(2[1-9])|(20\\\\.3)", filelib_find_source},
+            {platform_define, "^(1|(20))", no_customize_hostname_check},
             {platform_define, "^(20)", fun_stacktrace}
            ]}.
 


### PR DESCRIPTION
Got `Handshake Failure - {bad_cert,hostname_check_failed}` when making a request to a third-party mirror with wildcard certificates of hex repo. For example https://hexpm.upyun.com (from: https://hex.pm/docs/mirrors).

According to https://github.com/benoitc/hackney/issues/624#issuecomment-631340823

## References

- https://bugs.erlang.org/browse/ERL-1232