### PR TITLE
Honors the ignore_xref attributes in rebar3 release.

### DIFF
--- a/src/rebar_prv_xref.erl
+++ b/src/rebar_prv_xref.erl
@@ -7,7 +7,8 @@
 
 -export([init/1,
          do/1,
-         format_error/1]).
+         format_error/1,
+         filter_xref_results/3]).
 
 -include("rebar.hrl").
 -include_lib("providers/include/providers.hrl").


### PR DESCRIPTION
This diff comes in conjonction with https://github.com/erlware/relx/pull/874 in relx. The latter stores the xref_warnings in rlx_state, and ensures this one is returned to rebar3, instead of printing them.

This diff enforces that the xref_warnings emitted by relx and passed to rebar3 honor the ignore_xref attribute and tags.

This is achieved by relying on the filter method from rebar_prv_xref, before printing them on rebar side.

Note that this also slightly changes the output format :

Before:

```
===> There are missing function calls in the release.
===> Make sure all applications needed at runtime are included in the release.
===> module2:main_func/0 calls undefined function module1:local_func/2
```


Now
```
There are missing function calls in the release. 
Make sure all applications needed at runtime are included in the release. 
src/module2.erl:7: Warning: module2:main_func/0 calls undefined function module1:local_func/2 (Xref)
```

Tested on a small project with rebar3 release.