### PR TITLE
Prevent crashes on recursive src_dir definitions in deps

### DIFF
--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -344,14 +344,18 @@ find_app(AppInfo, AppDir, SrcDirs, Validate, State) ->
     {true, rebar_app_info:t()} | false.
 find_app_(AppInfo, AppDir, SrcDirs, Validate, State) ->
     Extensions = rebar_state:get(State, application_resource_extensions, ?DEFAULT_APP_RESOURCE_EXT),
+    NormSrcDirs = [case SrcDir of
+                       {SrcDir, _Opts} -> SrcDir;
+                       _ -> SrcDir
+                   end || SrcDir <- SrcDirs],
     ResourceFiles = [
         {app, filelib:wildcard(filename:join([AppDir, "ebin", "*.app"]))},
-        {mix_exs, filelib:wildcard(filename:join([AppDir, "src", "mix.exs"]))} |
-        [
-        {extension_type(Ext), lists:append([ filelib:wildcard(filename:join([AppDir, SrcDir, "*" ++ Ext]))
-        || SrcDir <- SrcDirs])}
-        || Ext <- Extensions
-    ]],
+        {mix_exs, filelib:wildcard(filename:join([AppDir, "src", "mix.exs"]))}
+        | [{extension_type(Ext),
+            lists:append([filelib:wildcard(filename:join([AppDir, SrcDir, "*" ++ Ext]))
+                          || SrcDir <- NormSrcDirs])}
+           || Ext <- Extensions]
+    ],
     FlattenedResourceFiles = flatten_resource_files(ResourceFiles),
     try_handle_resource_files(AppInfo, AppDir, FlattenedResourceFiles, Validate).
 

--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -345,7 +345,7 @@ find_app(AppInfo, AppDir, SrcDirs, Validate, State) ->
 find_app_(AppInfo, AppDir, SrcDirs, Validate, State) ->
     Extensions = rebar_state:get(State, application_resource_extensions, ?DEFAULT_APP_RESOURCE_EXT),
     NormSrcDirs = [case SrcDir of
-                       {SrcDir, _Opts} -> SrcDir;
+                       {ActualSrcDir, _Opts} -> ActualSrcDir;
                        _ -> SrcDir
                    end || SrcDir <- SrcDirs],
     ResourceFiles = [


### PR DESCRIPTION
In some rare cases (see https://github.com/erlang/rebar3/issues/2581 for a sample interplay between plugins
and recursive dep definitions with apps) there can be some interplay where
a dependency declares recursive directories but the lookup for app files does
not acknowledge these and causes problems.

This patch simply ignores such cases by stripping options; this should
have no backward compatibility impact since the value was just ignored
before anyway, but will prevent crashes in hard-to-reproduce cases.

Possibly fixes #2581 but I haven't been able to reproduce this in tests
since it seems to require a very peculiar setup to trigger.