### PR TITLE
Handle abstract code starting with a non-file attribute

### DIFF
--- a/src/rebar_prv_xref.erl
+++ b/src/rebar_prv_xref.erl
@@ -296,7 +296,7 @@ find_function_source(M, F, A, Bin) ->
 
 find_function_source_in_abstract_code(F, A, AbstractCode) ->
     %% Extract the original source filename from the abstract code
-    [{attribute, _, file, {Source0, _}} | _] = AbstractCode,
+    [{attribute, _, file, {Source0, _}} | _] = [Attr || Attr = {attribute, _, file, _} <- AbstractCode],
     Source = rebar_dir:make_relative_path(Source0, rebar_dir:get_cwd()),
     %% Extract the line number for a given function def
     Fn = [E || E <- AbstractCode,


### PR DESCRIPTION
I'm not really sure how to provoke this, but I had a file that compiled in OTP24 via rebar3 to abstract code that started with a `-compile({no_warn_unused_record, [contract]}).`, so the first entry of the `AbstractCode` list was `{attribute,0,compile,{nowarn_unused_record,[[contract]]}}`. This PR filters the `AbstractCode` list for `-file` attributes before matching. I can make this more efficient if you want.