### PR TITLE
Make `rebar_file_utils:system_tmpdir/1` take `TMPDIR` envvar into account on *nix

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -406,7 +406,7 @@ system_tmpdir(PathComponents) ->
         "win32" ->
             "./tmp";
         _SysArch ->
-            "/tmp"
+            os:getenv("TMPDIR", "/tmp")
     end,
     filename:join([Tmp|PathComponents]).
 

--- a/test/rebar_file_utils_SUITE.erl
+++ b/test/rebar_file_utils_SUITE.erl
@@ -31,6 +31,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/file.hrl").
 
+-define(TMPDIR, "/test").
+
 
 all() ->
     [{group, tmpdir},
@@ -52,8 +54,19 @@ groups() ->
 
 init_per_group(reset_dir, Config) ->
     TmpDir = rebar_file_utils:system_tmpdir(["rebar_file_utils_SUITE", "resetable"]),
-    [{tmpdir, TmpDir}|Config];
+    [{tmpdir, TmpDir} | Config];
+init_per_group(tmpdir, Config) ->
+    PreviousTmpDir = os:getenv("TMPDIR"),
+    os:putenv("TMPDIR", ?TMPDIR),
+    [{previous_tmp, PreviousTmpDir} | Config];
 init_per_group(_, Config) -> Config.
+
+end_per_group(tmpdir, Config) ->
+    case ?config(previous_tmp, Config) of
+        false -> os:unsetenv("TMPDIR");
+        Val -> os:putenv("TMPDIR", Val)
+    end,
+    Config;
 end_per_group(_, Config) -> Config.
 
 init_per_testcase(Test, Config) ->
@@ -71,31 +84,27 @@ end_per_testcase(_Test, Config) ->
     Config.
 
 raw_tmpdir(_Config) ->
-    UnixTmpdir = os:getenv("TMPDIR", "/tmp"),
     case rebar_file_utils:system_tmpdir() of
-        UnixTmpdir -> ok;
-        "./tmp"    -> ok
+        ?TMPDIR -> ok;
+        "./tmp" -> ok
     end.
 
 empty_tmpdir(_Config) ->
-    UnixTmpdir = os:getenv("TMPDIR", "/tmp"),
     case rebar_file_utils:system_tmpdir([]) of
-        UnixTmpdir -> ok;
-        "./tmp"    -> ok
+        ?TMPDIR -> ok;
+        "./tmp" -> ok
     end.
 
 simple_tmpdir(_Config) ->
-    UnixTmpdir = os:getenv("TMPDIR", "/tmp") ++ "/test",
     case rebar_file_utils:system_tmpdir(["test"]) of
-        UnixTmpdir   -> ok;
-        "./tmp/test" -> ok
+        ?TMPDIR ++ "/test" -> ok;
+        "./tmp/test"       -> ok
     end.
 
 multi_tmpdir(_Config) ->
-    UnixTmpdir = os:getenv("TMPDIR", "/tmp") ++ "/a/b/c",
     case rebar_file_utils:system_tmpdir(["a", "b", "c"]) of
-        UnixTmpdir    -> ok;
-        "./tmp/a/b/c" -> ok
+        ?TMPDIR ++ "/a/b/c" -> ok;
+        "./tmp/a/b/c"       -> ok
     end.
 
 reset_nonexistent_dir(Config) ->

--- a/test/rebar_file_utils_SUITE.erl
+++ b/test/rebar_file_utils_SUITE.erl
@@ -71,26 +71,30 @@ end_per_testcase(_Test, Config) ->
     Config.
 
 raw_tmpdir(_Config) ->
+    UnixTmpdir = os:getenv("TMPDIR", "/tmp"),
     case rebar_file_utils:system_tmpdir() of
-        "/tmp"  -> ok;
-        "./tmp" -> ok
+        UnixTmpdir -> ok;
+        "./tmp"    -> ok
     end.
 
 empty_tmpdir(_Config) ->
+    UnixTmpdir = os:getenv("TMPDIR", "/tmp"),
     case rebar_file_utils:system_tmpdir([]) of
-        "/tmp"  -> ok;
-        "./tmp" -> ok
+        UnixTmpdir -> ok;
+        "./tmp"    -> ok
     end.
 
 simple_tmpdir(_Config) ->
+    UnixTmpdir = os:getenv("TMPDIR", "/tmp") ++ "/test",
     case rebar_file_utils:system_tmpdir(["test"]) of
-        "/tmp/test"  -> ok;
+        UnixTmpdir   -> ok;
         "./tmp/test" -> ok
     end.
 
 multi_tmpdir(_Config) ->
+    UnixTmpdir = os:getenv("TMPDIR", "/tmp") ++ "/a/b/c",
     case rebar_file_utils:system_tmpdir(["a", "b", "c"]) of
-        "/tmp/a/b/c"  -> ok;
+        UnixTmpdir    -> ok;
         "./tmp/a/b/c" -> ok
     end.
 


### PR DESCRIPTION
See the [linked issue](https://github.com/erlang/rebar3/issues/2596) issue for more details, but the motivation here is that nix, among other things it does, runs package builds as separate users with different temporary directories. But since for rebar3 the temporary file directory is always `/tmp`, it can potentially result in tests failing with permission issues for files created previously with a different user, that leaked into `/tmp`.

This PR makes rebar3 honour the `TMPDIR` environment variable when deciding what the directory for temporary files is on *nix is, avoiding such collisions.