### PR TITLE
Add escript_incl_priv so escriptize priv dir inclusion works with _checkouts and profiles

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,10 +25,10 @@
 {escript_wrappers_windows, ["cmd", "powershell"]}.
 {escript_comment, "%%Rebar3 3.16.1\n"}.
 {escript_emu_args, "%%! +sbtu +A1\n"}.
-%% escript_incl_extra is for internal rebar-private use only.
+%% escript_incl_priv is for internal rebar-private use only.
 %% Do not use outside rebar. Config interface is not stable.
-{escript_incl_extra, [{"relx/priv/templates/*", "_build/default/lib/"},
-                      {"rebar/priv/templates/*", "_build/default/lib/"}]}.
+{escript_incl_priv, [{relx, "templates/*"},
+                     {rebar, "templates/*"}]}.
 
 {overrides, [{add, relx, [{erl_opts, [{d, 'RLX_LOG', rebar_log}]}]}]}.
 
@@ -67,10 +67,6 @@
             {bootstrap, []},
 
             {prod, [
-                {escript_incl_extra, [
-                    {"relx/priv/templates/*", "_build/prod/lib/"},
-                    {"rebar/priv/templates/*", "_build/prod/lib/"}
-                ]},
                 {erl_opts, [no_debug_info]},
                 {overrides, [
                     {override, erlware_commons, [


### PR DESCRIPTION
When developing `relx` and testing changes with `rebar3`, it is convenient to make `relx` a checkout dependency.

However, the current implementation of `escript_incl_extra` expects the output directory of `relx` to be under `_build/<profile>/lib/`, which is not the case if `relx` is a checkout dependency.

Fixes #2600

### Note

Due to the change in `rebar.config`, this is a **backwards-incompatible** change when using an older version of `rebar3` to build a new version of `rebar3`. But because the recommended way to build `rebar3` is with `./bootstrap`, perhaps this is okay.

### Test plan

1. Check out `rebar3`
2. Check out `relx` at `rebar3/_checkouts/relx`
3. Build `rebar3` using `./bootstrap`
4. Run `${path-to-rebar3-repo}/rebar3 release` on another project
    - Before this fix, `rebar3` crashes as reported in #2600
3. Run `./escript-archive-list ${path-to-rebar3-repo}/rebar3` (see below)
    - Before this fix, `relx/priv` paths do not appear in the `rebar3` `escript` archive

#### `escript`

```erl
#!/usr/bin/env escript
% escript-archive-list

main([EscriptPath]) ->
    {ok, Escript} = escript:extract(EscriptPath, []),
    [_Shebang, _Comment, _EmuArgs, Body] = Escript,
    {archive, ArchiveBin} = Body,
    zip:foldl(fun(Name, _, _, _) -> io:format("~s~n", [Name]) end,
                  undefined,
                  {EscriptPath, ArchiveBin}).
```