### PR TITLE
rebar3 release to honour the ignore-xref attribute

### DIFF
--- a/src/rebar_prv_xref.erl
+++ b/src/rebar_prv_xref.erl
@@ -7,7 +7,8 @@
 
 -export([init/1,
          do/1,
-         format_error/1]).
+         format_error/1,
+         filter_xref_results/3]).
 
 -include("rebar.hrl").
 -include_lib("providers/include/providers.hrl").

--- a/src/rebar_relx.erl
+++ b/src/rebar_relx.erl
@@ -42,7 +42,11 @@ do(Provider, State) ->
     Args = [include_erts, system_libs, vm_args, sys_config],
     RelxConfig2 = maybe_obey_command_args(RelxConfig1, Opts, Args),
 
-    {ok, RelxState} = rlx_config:to_state(RelxConfig2),
+    {ok, RelxState_0} = rlx_config:to_state(RelxConfig2),
+    XrefIgnores = rebar_state:get(State, xref_ignores, []),
+    RelxState = rlx_state:filter_xref_warning(RelxState_0,
+        fun(Warnings) ->
+            rebar_prv_xref:filter_xref_results(undefined_function_calls, XrefIgnores, Warnings) end),
 
     Providers = rebar_state:providers(State),
     Cwd = rebar_state:dir(State),


### PR DESCRIPTION
This comes in coniunction with https://github.com/erlware/relx/pull/882, that allows RELX to accept in its state a method to filter xref warnings.
We pass to it the method that rebar3 currently uses to filter them based on the ignore-xref attributes in erlang file.