### PR TITLE
Don't crash on printing non-ASCII characters

### DIFF
--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -68,7 +68,7 @@ process_namespace(State, Command) ->
         not_found ->
             case providers:get_providers_by_namespace(Command, Providers) of
                 [] ->
-                    {error, io_lib:format("Command ~p not found", [Command])};
+                    {error, io_lib:format("Command ~ts not found", [atom_to_list(Command)])};
                 _ ->
                     %% Replay 'do' as a command of that namespace
                     {ok, rebar_state:namespace(State, Command), do}
@@ -98,10 +98,10 @@ process_command(State, Command) ->
         not_found when Command =/= do ->
             case Namespace of
                 default ->
-                    {error, io_lib:format("Command ~p not found", [Command])};
+                    {error, io_lib:format("Command ~ts not found", [atom_to_list(Command)])};
                 _ ->
-                    {error, io_lib:format("Command ~p not found in namespace ~p",
-                                          [Command, Namespace])}
+                    {error, io_lib:format("Command ~ts not found in namespace ~ts",
+                                          [atom_to_list(Command), atom_to_list(Namespace)])}
             end;
         not_found when Command =:= do, Namespace =/= default ->
             do([{default, do} | TargetProviders], State);
@@ -120,7 +120,7 @@ process_command(State, Command) ->
                             State2 = rebar_state:command_parsed_args(State1, Args),
                             do(TargetProviders, State2);
                         {error, {invalid_option, Option}} ->
-                            {error, io_lib:format("Invalid option ~ts on task ~p", [Option, Command])};
+                            {error, io_lib:format("Invalid option ~ts on task ~ts", [Option, atom_to_list(Command)])};
                         {error, {invalid_option_arg, {Option, Arg}}} ->
                             {error, io_lib:format("Invalid argument ~ts to option ~ts", [Arg, Option])};
                         {error, {missing_option_arg, Option}} ->
@@ -137,7 +137,7 @@ process_command(State, Command) ->
 do([], State) ->
     {ok, State};
 do([ProviderName | Rest], State) ->
-    ?DEBUG("Running provider: ~p", [friendly_provider(ProviderName)]),
+    ?DEBUG("Running provider: ~tp", [friendly_provider(ProviderName)]),
     %% Special providers like 'as', 'do' or some hooks may be passed
     %% as a tuple {Namespace, Name}, otherwise not. Handle them
     %% on a per-need basis.

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -481,8 +481,9 @@ add_provider(State=#state_t{providers=Providers, allow_provider_overrides=false}
     case lists:any(fun(P) ->
                            case {providers:impl(P), providers:namespace(P)} of
                                {Name, Namespace} ->
-                                   ?DEBUG("Not adding provider ~p ~p from module ~p because it already exists from module ~p",
-                                          [Namespace, Name, Module, providers:module(P)]),
+                                   ?DEBUG("Not adding provider ~ts ~ts from module ~ts because it already exists from module ~ts",
+                                          [atom_to_list(Namespace), atom_to_list(Name),
+                                           atom_to_list(Module), atom_to_list(providers:module(P))]),
                                    true;
                                _ ->
                                    false


### PR DESCRIPTION
Closes #2618.

`~p` uses `'` to print non-ASCII atoms, so that's avoided.
`~ts` is for the UTF-8 stuff.

This would go nicely with https://github.com/tsloughter/providers/pull/13, but it can be merged before that one's merged and tagged, too.

Also, I'm not sure if/how you wanna test this, so I'll wait for further guidance.