### PR TITLE
add support for otp24 optional applications

### DIFF
--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -415,6 +415,7 @@ create_app_info(AppInfo, AppDir, AppFile) ->
             AppVsn = proplists:get_value(vsn, AppDetails),
             Applications = proplists:get_value(applications, AppDetails, []),
             IncludedApplications = proplists:get_value(included_applications, AppDetails, []),
+            OptionalApplications = proplists:get_value(optional_applications, AppDetails, []),
             AppInfo1 = rebar_app_info:name(
                          rebar_app_info:vsn(
                            rebar_app_info:original_vsn(
@@ -422,14 +423,15 @@ create_app_info(AppInfo, AppDir, AppFile) ->
             AppInfo2 = rebar_app_info:applications(
                          rebar_app_info:app_details(AppInfo1, AppDetails), Applications),
             AppInfo3 = rebar_app_info:included_applications(AppInfo2, IncludedApplications),
-            Valid = case rebar_app_utils:validate_application_info(AppInfo3) =:= true
-                        andalso rebar_app_info:has_all_artifacts(AppInfo3) =:= true of
+            AppInfo4 = rebar_app_info:optional_applications(AppInfo3, OptionalApplications),
+            Valid = case rebar_app_utils:validate_application_info(AppInfo4) =:= true
+                        andalso rebar_app_info:has_all_artifacts(AppInfo4) =:= true of
                         true ->
                             true;
                         _ ->
                             false
                     end,
-            rebar_app_info:dir(rebar_app_info:valid(AppInfo3, Valid), AppDir);
+            rebar_app_info:dir(rebar_app_info:valid(AppInfo4, Valid), AppDir);
         _Invalid ->
             throw({error, {?MODULE, {cannot_read_app_file, AppFile}}})
     catch

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -32,6 +32,8 @@
          applications/2,
          included_applications/1,
          included_applications/2,
+         optional_applications/1,
+         optional_applications/2,
          profiles/1,
          profiles/2,
          deps/1,
@@ -94,6 +96,7 @@
                      app_details=[]     :: list(),
                      applications=[]    :: list(),
                      included_applications=[] :: [atom()],
+                     optional_applications=[] :: [atom()],
                      deps=[]            :: list(),
                      profiles=[default] :: [atom()],
                      default=dict:new() :: rebar_dict(),
@@ -181,6 +184,7 @@ new(Parent, AppName, Vsn, Dir, Deps) ->
                            vsn := app_vsn(),
                            applications := [atom()],
                            included_applications := [atom()],
+                           optional_applications := [atom()],
                            dir := file:name(),
                            out_dir := file:name(),
                            ebin_dir := file:name(),
@@ -189,12 +193,14 @@ app_to_map(#app_info_t{name=Name,
                        vsn=Vsn,
                        applications=Applications,
                        included_applications=IncludedApplications,
+                       optional_applications=OptionalApplications,
                        out_dir=OutDir,
                        ebin_dir=EbinDir}) ->
     #{name => ec_cnv:to_atom(Name),
       vsn => Vsn,
       applications => Applications,
       included_applications => IncludedApplications,
+      optional_applications => OptionalApplications,
       dir => OutDir,
       out_dir => OutDir,
       ebin_dir => EbinDir,
@@ -467,6 +473,17 @@ included_applications(#app_info_t{included_applications=Applications}) ->
 -spec included_applications(t(), list()) -> t().
 included_applications(AppInfo=#app_info_t{}, Applications) ->
     AppInfo#app_info_t{included_applications=Applications}.
+
+%% @doc returns the list of optional_applications the app depends on.
+-spec optional_applications(t()) -> list().
+optional_applications(#app_info_t{optional_applications=Applications}) ->
+    Applications.
+
+%% @doc sets the list of optional applications the app depends on.
+%% Should be obtained from the app file.
+-spec optional_applications(t(), list()) -> t().
+optional_applications(AppInfo=#app_info_t{}, Applications) ->
+    AppInfo#app_info_t{optional_applications=Applications}.
 
 %% @doc returns the list of active profiles
 -spec profiles(t()) -> list().

--- a/src/rebar_relx.erl
+++ b/src/rebar_relx.erl
@@ -249,9 +249,10 @@ app_info_to_relx(#{name := Name,
                    vsn := Vsn,
                    applications := Applications,
                    included_applications := IncludedApplications,
+                   optional_applications := OptionalApplications,
                    dir := Dir,
                    link := false}, AppType) ->
-    rlx_app_info:new(Name, Vsn, Dir, Applications, IncludedApplications, AppType).
+    rlx_app_info:new(Name, Vsn, Dir, Applications, IncludedApplications, OptionalApplications, AppType).
 
 -spec opt_spec_list() -> [getopt:option_spec()].
 opt_spec_list() ->


### PR DESCRIPTION
This PR adds support for optional applications, adding that metadata to the appinfo and passing it down into relx.

this PR requires: https://github.com/erlware/relx/pull/885