### PR TITLE
Support for all argument in unlock

### DIFF
--- a/src/rebar_prv_unlock.erl
+++ b/src/rebar_prv_unlock.erl
@@ -26,8 +26,8 @@ init(State) ->
                           {deps, ?DEPS},
                           {example, ""},
                           {short_desc, "Unlock dependencies."},
-                          {desc, "Unlock project dependencies. Mentioning no application "
-                                 "will unlock all dependencies. To unlock specific dependencies, "
+                          {desc, "Unlock project dependencies. Use the -all option "
+                                 "to unlock all dependencies. To unlock specific dependencies, "
                                  "their name can be listed in the command."},
                           {opts, [{all, $a, "all", undefined, "Unlock all dependencies and remove the lock file."},
                             {package, undefined, undefined, string,

--- a/src/rebar_prv_unlock.erl
+++ b/src/rebar_prv_unlock.erl
@@ -26,7 +26,7 @@ init(State) ->
                           {deps, ?DEPS},
                           {example, ""},
                           {short_desc, "Unlock dependencies."},
-                          {desc, "Unlock project dependencies. Use the -all option "
+                          {desc, "Unlock project dependencies. Use the --all option "
                                  "to unlock all dependencies. To unlock specific dependencies, "
                                  "their name can be listed in the command."},
                           {opts, [{all, $a, "all", undefined, "Unlock all dependencies and remove the lock file."},

--- a/src/rebar_prv_unlock.erl
+++ b/src/rebar_prv_unlock.erl
@@ -29,9 +29,9 @@ init(State) ->
                           {desc, "Unlock project dependencies. Mentioning no application "
                                  "will unlock all dependencies. To unlock specific dependencies, "
                                  "their name can be listed in the command."},
-                          {opts, [
+                          {opts, [{all, $a, "all", undefined, "Unlock all dependencies and remove the lock file."},
                             {package, undefined, undefined, string,
-                             "List of packages to unlock. If not specified, all dependencies are unlocked."}
+                             "List of packages to unlock."}
                           ]}
                          ])
     ),
@@ -57,23 +57,41 @@ format_error({file, Reason}) ->
     io_lib:format("Lock file editing failed for reason ~p", [Reason]);
 format_error(unknown_lock_format) ->
     "Lock file format unknown";
+format_error(no_arg) -> 
+    "Specify a list of dependencies to unlock, or --all to unlock them all";
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
 handle_unlocks(State, Locks, LockFile) ->
-    {Args, _} = rebar_state:command_parsed_args(State),
-    Names = parse_names(rebar_utils:to_binary(proplists:get_value(package, Args, <<"">>))),
-    case [Lock || Lock = {Name, _, _} <- Locks, not lists:member(Name, Names)] of
-        [] ->
+    {_All, Names} = handle_args(State),
+    case handle_args(State) of
+        %% a list of dependencies or --all is required
+        {false, []} -> 
+            throw(?PRV_ERROR(no_arg));
+        %% if --all is specified, delete the lock file
+        {true, _} -> 
             file:delete(LockFile),
             {ok, []};
-        _ when Names =:= [] -> % implicitly all locks
-            file:delete(LockFile),
-            {ok, []};
-        NewLocks ->
-            rebar_config:write_lock_file(LockFile, NewLocks),
-            {ok, NewLocks}
+        %% otherwise, unlock the given list of dependency names. if none are left, delete the lock file
+        {false, Names} -> 
+            case [Lock || Lock = {Name, _, _} <- Locks, not lists:member(Name, Names)] of
+                [] ->
+                    file:delete(LockFile),
+                    {ok, []};
+                _ when Names =:= [] -> % implicitly all locks
+                    file:delete(LockFile),
+                    {ok, []};
+                NewLocks -> 
+                    rebar_config:write_lock_file(LockFile, NewLocks),
+                    {ok, NewLocks}
+            end
     end.
+
+handle_args(State) -> 
+    {Args, _} = rebar_state:command_parsed_args(State),
+    All = proplists:get_value(all, Args, false),
+    Names = parse_names(rebar_utils:to_binary(proplists:get_value(package, Args, <<"">>))),
+    {All, Names}.
 
 parse_names(Bin) ->
     case lists:usort(re:split(Bin, <<" *, *">>, [trim, unicode])) of

--- a/src/rebar_prv_unlock.erl
+++ b/src/rebar_prv_unlock.erl
@@ -63,7 +63,6 @@ format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
 handle_unlocks(State, Locks, LockFile) ->
-    {_All, Names} = handle_args(State),
     case handle_args(State) of
         %% a list of dependencies or --all is required
         {false, []} -> 

--- a/test/rebar_alias_SUITE.erl
+++ b/test/rebar_alias_SUITE.erl
@@ -24,7 +24,7 @@ command(Config) ->
     Name = rebar_test_utils:create_random_name("alias_command_"),
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
-    RebarConfig = [{alias, [{test, [compile, unlock]}]}],
+    RebarConfig = [{alias, [{test, [compile, {unlock,"-a"}]}]}],
 
     %% compile job ran
     rebar_test_utils:run_and_check(Config, RebarConfig,
@@ -64,7 +64,7 @@ many(Config) ->
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
     RebarConfig = [{alias, [{test, [{eunit,"-c"}, cover]},
-                            {nolock, [compile, unlock]}]}],
+                            {nolock, [compile, {unlock,"-a"}]}]}],
 
     %% test job ran (compiled and succeeded)
     rebar_test_utils:run_and_check(Config, RebarConfig,

--- a/test/rebar_unlock_SUITE.erl
+++ b/test/rebar_unlock_SUITE.erl
@@ -54,7 +54,7 @@ unlock(Config) ->
 
 unlock_all(Config) ->
     [_|_] = read_locks(Config),
-    {ok, State} = rebar_test_utils:run_and_check(Config, [], ["unlock"], return),
+    {ok, State} = rebar_test_utils:run_and_check(Config, [], ["unlock", "--all"], return),
     ?assertEqual({error, enoent}, read_locks(Config)),
     ?assertEqual([], rebar_state:get(State, {locks, default})),
     ok.

--- a/test/rebar_unlock_SUITE.erl
+++ b/test/rebar_unlock_SUITE.erl
@@ -3,7 +3,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
 
-all() -> [pkgunlock, unlock, unlock_all].
+all() -> [pkgunlock, unlock, unlock_all, unlock_no_args].
 
 init_per_testcase(pkgunlock, Config0) ->
     Config = rebar_test_utils:init_rebar_state(Config0, "pkgunlock"),
@@ -57,6 +57,13 @@ unlock_all(Config) ->
     {ok, State} = rebar_test_utils:run_and_check(Config, [], ["unlock", "--all"], return),
     ?assertEqual({error, enoent}, read_locks(Config)),
     ?assertEqual([], rebar_state:get(State, {locks, default})),
+    ok.
+
+unlock_no_args(Config) ->
+    try rebar_test_utils:run_and_check(Config, [], ["unlock"], return)
+    catch {error, {rebar_prv_unlock, no_arg}} ->
+        ok
+    end,
     ok.
 
 read_locks(Config) ->


### PR DESCRIPTION
This alters the behavior of the `unlock` command as outlined in #2583. Previously, calling `rebar3 unlock` with no further arguments would simply delete the `rebar.lock` file. This change requires the `--all` flag to unlock all dependencies, and makes calling `unlock` with no arguments an error. When specifying a list of dependencies to unlock, the behavior is unchanged. 


#2583 requests similar behavior for `upgrade` and `plugins upgrade`. These will be addressed in separate PRs.