### PR TITLE
Clean up no longer present test suites from _build

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -73,22 +73,17 @@ do(State, Tests) ->
     %% Run ct provider pre hooks for all project apps and top level project hooks
     rebar_hooks:run_project_and_app_hooks(Cwd, pre, ?PROVIDER, Providers, State),
 
-    case Tests of
-        {ok, T} ->
-            case run_tests(State, T) of
-                ok    ->
-                    %% Run ct provider post hooks for all project apps and top level project hooks
-                    rebar_hooks:run_project_and_app_hooks(Cwd, post, ?PROVIDER, Providers, State),
-                    rebar_paths:set_paths([plugins, deps], State),
-                    symlink_to_last_ct_logs(State, T),
-                    {ok, State};
-                Error ->
-                    rebar_paths:set_paths([plugins, deps], State),
-                    symlink_to_last_ct_logs(State, T),
-                    Error
-            end;
+    {ok, T} = Tests,
+    case run_tests(State, T) of
+        ok    ->
+            %% Run ct provider post hooks for all project apps and top level project hooks
+            rebar_hooks:run_project_and_app_hooks(Cwd, post, ?PROVIDER, Providers, State),
+            rebar_paths:set_paths([plugins, deps], State),
+            symlink_to_last_ct_logs(State, T),
+            {ok, State};
         Error ->
             rebar_paths:set_paths([plugins, deps], State),
+            symlink_to_last_ct_logs(State, T),
             Error
     end.
 


### PR DESCRIPTION
This PR is an attempt to fix a bug described in #2377

The bug causes rebar3 to execute or attempt to execute ct suites, that has been renamed or removed in the source code as there is no orphan file cleanup

The chosen approach has limitations. Perhaps utilizing the code in compile-related modules would be a more robust solution, but I feel like I would need a lot more time and some guidance to make a change there.

One of the discovered limitations of this approach is inability to handle duplicate module names. If two suites in different directories have the same name, deleting/renaming one of them would still leave it's object file in respective _build directory.

The PR has no tests yet, as I found it difficult to reproduce the bug conditions within tests. Help would be appreciated

I would appreciate knowing if for now we can advance with the proposed approach or the bug in question requires a more robust solution