### PR TITLE
Remove duplicated message when trying to upgrade a checkout dep

### DIFF
--- a/src/rebar_prv_lock.erl
+++ b/src/rebar_prv_lock.erl
@@ -44,7 +44,6 @@ do(State) ->
             OldLockNames = [element(1,L) || L <- OldLocks] -- Checkouts,
             NewLockNames = [element(1,L) || L <- Locks],
 
-            %% TODO: don't output this message if the dep is now a checkout
             rebar_utils:info_useless(OldLockNames, NewLockNames),
             info_checkout_deps(Checkouts),
 
@@ -67,6 +66,7 @@ build_locks(State) ->
          rebar_app_info:dep_level(Dep)}
      end || Dep <- AllDeps, not(rebar_app_info:is_checkout(Dep))].
 
-info_checkout_deps(Checkouts) ->
+info_checkout_deps(Checkouts0) ->
+    Checkouts = lists:usort(Checkouts0),
     [?INFO("App ~ts is a checkout dependency and cannot be locked.", [CheckoutDep])
         || CheckoutDep <- Checkouts].


### PR DESCRIPTION
When running `rebar3 upgrade` on a project that has checkout dependencies,
a message of `"App $NAME is a checkout dependency and cannot be locked."`
will be printed by the `lock` provider.

As this provider is called twice (first to check the locked dependencies,
and then from the `upgrade` provider after updating the dependencies),
the message will show duplicated. To avoid this, this commit marks
all checkout dependencies as regular ones, after checking whether it makes
sense to do so, before calling the `lock` provider from the `upgrade`
provider.

Fixes #2466.