### PR TITLE
Support for all argument in upgrade plugin

### DIFF
--- a/src/rebar_prv_plugins_upgrade.erl
+++ b/src/rebar_prv_plugins_upgrade.erl
@@ -24,8 +24,9 @@ init(State) ->
                     {bare, true},
                     {deps, ?DEPS},
                     {example, "rebar3 plugins upgrade <plugin>"},
-                    {short_desc, "Upgrade plugins"},
-                    {desc, "List or upgrade plugins"},
+                    {short_desc, "Upgrade plugins."},
+                    {desc, "List or upgrade plugins. Use the -a/--all option to upgrade"
+                           " all plugins."},
                     {opts, [{plugin, undefined, undefined, string,
                              "Plugin to upgrade"},
                             {all, $a, "all", undefined, "Upgrade all plugins."}]}])),
@@ -33,9 +34,9 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    {Args, _} = rebar_state:command_parsed_args(State),
-    case proplists:get_value(plugin, Args, none) of
-        none ->
+    case handle_args(State) of 
+        {false, undefined} -> throw(?PRV_ERROR(no_arg));
+        {true, _} -> 
             {_, LocalPluginsNames} = rebar_prv_plugins:list_local_plugins(State),
             lists:foldl(
                 fun (LocalPluginName, {ok, StateAcc}) ->
@@ -43,15 +44,22 @@ do(State) ->
                 end,
                 {ok, State},
                 LocalPluginsNames);
-        Plugin ->
-            upgrade(Plugin, State)
+        {false, Plugin} -> upgrade(Plugin, State)
     end.
 
 -spec format_error(any()) -> iolist().
 format_error({not_found, Plugin}) ->
     io_lib:format("Plugin to upgrade not found: ~ts", [Plugin]);
+format_error(no_arg) -> 
+     "Specify a plugin to upgrade, or --all to upgrade them all";
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
+
+handle_args(State) -> 
+     {Args, _} = rebar_state:command_parsed_args(State),
+     All = proplists:get_value(all, Args, false),
+     Plugin = proplists:get_value(plugin, Args),
+     {All, Plugin}.
 
 upgrade(Plugin, State) ->
     Profiles = rebar_state:current_profiles(State),

--- a/src/rebar_prv_plugins_upgrade.erl
+++ b/src/rebar_prv_plugins_upgrade.erl
@@ -27,7 +27,8 @@ init(State) ->
                     {short_desc, "Upgrade plugins"},
                     {desc, "List or upgrade plugins"},
                     {opts, [{plugin, undefined, undefined, string,
-                             "Plugin to upgrade"}]}])),
+                             "Plugin to upgrade"},
+                            {all, $a, "all", undefined, "Upgrade all plugins."}]}])),
     {ok, State1}.
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.

--- a/src/rebar_prv_plugins_upgrade.erl
+++ b/src/rebar_prv_plugins_upgrade.erl
@@ -24,7 +24,7 @@ init(State) ->
                     {bare, true},
                     {deps, ?DEPS},
                     {example, "rebar3 plugins upgrade <plugin>"},
-                    {short_desc, "Upgrade plugins."},
+                    {short_desc, "Upgrade plugins"},
                     {desc, "List or upgrade plugins. Use the -a/--all option to upgrade"
                            " all plugins."},
                     {opts, [{plugin, undefined, undefined, string,

--- a/test/rebar_plugins_SUITE.erl
+++ b/test/rebar_plugins_SUITE.erl
@@ -12,6 +12,7 @@
          list/1,
          upgrade/1,
          upgrade_project_plugin/1,
+         upgrade_no_args/1,
          sub_app_plugins/1,
          sub_app_plugin_overrides/1,
          project_plugins/1,
@@ -220,7 +221,7 @@ upgrade(Config) ->
      ),
 
     rebar_test_utils:run_and_check(
-        Config, RConf, ["plugins", "upgrade"],
+        Config, RConf, ["plugins", "upgrade", "--all"],
         {ok, [{app, Name, valid}, {file, PluginBeam}, {plugin, PkgName}]}
      ).
 
@@ -262,6 +263,13 @@ upgrade_project_plugin(Config) ->
         Config, RConf, ["plugins", "upgrade", PkgName],
         {ok, [{app, Name}, {plugin, PkgName, <<"0.1.3">>}]}
      ).
+
+upgrade_no_args(Config) ->
+    try rebar_test_utils:run_and_check(Config, [], ["plugins", "upgrade"], return)
+    catch {error, {rebar_prv_plugins_upgrade, no_arg}} ->
+        ok
+    end,
+    ok.
 
 sub_app_plugins(Config) ->
     AppDir = ?config(apps, Config),


### PR DESCRIPTION
Adds support for `-a/--all` to `rebar3 plugins upgrade`, replacing the no argument functionality with the all flag.

See #2583.