### PR TITLE
Make bootstrap use _checkouts

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -92,7 +92,19 @@ fetch_and_compile({Name, ErlFirstFiles}, Deps) ->
 
     compile(Name, ErlFirstFiles).
 
-fetch({pkg, Name, Vsn}, App) ->
+fetch(Source, App) ->
+    Dir = filename:join([filename:absname("_checkouts"), App]),
+    case filelib:is_dir(Dir) of
+        false ->
+            fetch_from_hex(Source, App);
+        true ->
+            io:format("Using ~p from ~p~n", [App, Dir]),
+            Dest = filename:absname("_build/default/lib"),
+            ok = filelib:ensure_dir(filename:join([Dest, "dummy"])),
+            cp_r([Dir], Dest)
+    end.
+
+fetch_from_hex({pkg, Name, Vsn}, App) ->
     Dir = filename:join([filename:absname("_build/default/lib/"), App]),
     case filelib:is_dir(Dir) of
         false ->


### PR DESCRIPTION
This makes it possible to run the bootstrap offline by placing the deps
in the already documented _checkouts directory in advance.