### PR TITLE
Add --offline option and REBAR_OFFLINE environment variable

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -7,7 +7,7 @@ main(Args) ->
         true ->
             os:putenv("REBAR_OFFLINE", "1");
         false ->
-            _
+            ok
     end,
     ensure_app(crypto),
     ensure_app(asn1),

--- a/bootstrap
+++ b/bootstrap
@@ -2,14 +2,25 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ft=erlang ts=4 sw=4 et
 
-main(_) ->
+main(Args) ->
+    case lists:member("--offline", Args) of
+        true ->
+            os:putenv("REBAR_OFFLINE", "1");
+        false ->
+            _
+    end,
     ensure_app(crypto),
     ensure_app(asn1),
     ensure_app(public_key),
-    ensure_app(ssl),
-    inets:start(),
-    inets:start(httpc, [{profile, rebar}]),
-    set_httpc_options(),
+    case os:getenv("REBAR_OFFLINE") of
+        "1" ->
+            ok;
+        _ ->
+            ensure_app(ssl),
+            inets:start(),
+            inets:start(httpc, [{profile, rebar}]),
+            set_httpc_options()
+    end,
 
     %% Clear directories for builds since bootstrapping may require
     %% a changed structure from an older one
@@ -117,6 +128,14 @@ extract(Binary) ->
     {ok, Contents}.
 
 request(Url) ->
+    case os:getenv("REBAR_OFFLINE") of
+        "1" ->
+            {error, {offline, Url}};
+        _ ->
+            request_online(Url)
+    end.
+
+request_online(Url) ->
     HttpOptions = [{relaxed, true} | get_proxy_auth()],
 
     case httpc:request(get, {Url, []},

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -186,7 +186,7 @@ run_aux(State, RawArgs) ->
                   false ->
                       os:getenv("REBAR_OFFLINE") =:= "1"
               end,
-    State10 = rebar_state:set(State9, offline, Offline);
+    State10 = rebar_state:set(State9, offline, Offline),
 
     State11 = rebar_state:code_paths(State10, default, code:get_path()),
 

--- a/src/rebar_fetch.erl
+++ b/src/rebar_fetch.erl
@@ -50,10 +50,10 @@ download_source(AppInfo, State)  ->
     end.
 
 download_source_(AppInfo, State) ->
-    case os:getenv("REBAR_OFFLINE") of
-        "1" ->
+    case rebar_state:get(State, offline, false) of
+        true ->
             {error, {?MODULE, offline}};
-        _ ->
+        false ->
             download_source_online(AppInfo, State)
     end.
 
@@ -76,11 +76,11 @@ download_source_online(AppInfo, State) ->
 -spec needs_update(rebar_app_info:t(), rebar_state:t())
                   -> boolean() | {error, string()}.
 needs_update(AppInfo, State) ->
-    case os:getenv("REBAR_OFFLINE") of
-        "1" ->
+    case rebar_state:get(State, offline, false) of
+        true ->
             ?DEBUG("Can't check if dependency needs updates in offline mode", []),
             false;
-        _ ->
+        false ->
             needs_update_online(AppInfo, State)
     end.
 

--- a/src/rebar_fetch.erl
+++ b/src/rebar_fetch.erl
@@ -50,6 +50,14 @@ download_source(AppInfo, State)  ->
     end.
 
 download_source_(AppInfo, State) ->
+    case os:getenv("REBAR_OFFLINE") of
+        "1" ->
+            {error, {?MODULE, offline}};
+        _ ->
+            download_source_online(AppInfo, State)
+    end.
+
+download_source_online(AppInfo, State) ->
     AppDir = rebar_app_info:dir(AppInfo),
     TmpDir = ec_file:insecure_mkdtemp(),
     AppDir1 = rebar_utils:to_list(AppDir),
@@ -68,6 +76,17 @@ download_source_(AppInfo, State) ->
 -spec needs_update(rebar_app_info:t(), rebar_state:t())
                   -> boolean() | {error, string()}.
 needs_update(AppInfo, State) ->
+    case os:getenv("REBAR_OFFLINE") of
+        "1" ->
+            ?DEBUG("Can't check if dependency needs updates in offline mode", []),
+            false;
+        _ ->
+            needs_update_online(AppInfo, State)
+    end.
+
+-spec needs_update_online(rebar_app_info:t(), rebar_state:t())
+                         -> boolean() | {error, string()}.
+needs_update_online(AppInfo, State) ->
     try
         rebar_resource_v2:needs_update(AppInfo, State)
     catch

--- a/src/rebar_httpc_adapter.erl
+++ b/src/rebar_httpc_adapter.erl
@@ -9,6 +9,18 @@
 %%====================================================================
 
 request(Method, URI, ReqHeaders, Body, AdapterConfig) ->
+    case os:getenv("REBAR_OFFLINE") of
+        "1" ->
+            {error, {offline, URI}};
+        _ ->
+            request_online(Method, URI, ReqHeaders, Body, AdapterConfig)
+    end.
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+request_online(Method, URI, ReqHeaders, Body, AdapterConfig) ->
     Profile = maps:get(profile, AdapterConfig, default),
     Request = build_request(URI, ReqHeaders, Body),
     SSLOpts = [{ssl, rebar_utils:ssl_opts(URI)}],
@@ -18,10 +30,6 @@ request(Method, URI, ReqHeaders, Body, AdapterConfig) ->
             {ok, {StatusCode, RespHeaders2, RespBody}};
         {error, Reason} -> {error, Reason}
     end.
-
-%%====================================================================
-%% Internal functions
-%%====================================================================
 
 build_request(URI, ReqHeaders, Body) ->
     build_request2(binary_to_list(URI), dump_headers(ReqHeaders), Body).

--- a/src/rebar_prv_local_upgrade.erl
+++ b/src/rebar_prv_local_upgrade.erl
@@ -120,6 +120,19 @@ etag(Path) ->
       ETag :: false | string(),
       Res :: 'error' | {ok, cached} | {ok, any(), string()}.
 request(Url, ETag) ->
+    case os:getenv("REBAR_OFFLINE") of
+        "1" ->
+            ?DEBUG("Rebar is in offline mode"),
+            error;
+        _ ->
+            request_online(Url, ETag)
+    end.
+
+-spec request_online(Url, ETag) -> Res when
+      Url :: string(),
+      ETag :: false | string(),
+      Res :: 'error' | {ok, cached} | {ok, any(), string()}.
+request_online(Url, ETag) ->
     HttpOptions = [{ssl, rebar_utils:ssl_opts(Url)},
                    {relaxed, true} | rebar_utils:get_proxy_auth()],
     case httpc:request(get, {Url, [{"if-none-match", "\"" ++ ETag ++ "\""}

--- a/src/rebar_prv_local_upgrade.erl
+++ b/src/rebar_prv_local_upgrade.erl
@@ -122,7 +122,7 @@ etag(Path) ->
 request(Url, ETag) ->
     case os:getenv("REBAR_OFFLINE") of
         "1" ->
-            ?DEBUG("Rebar is in offline mode"),
+            ?DEBUG("Rebar is in offline mode", []),
             error;
         _ ->
             request_online(Url, ETag)

--- a/src/vendored/r3_hex_http_httpc.erl
+++ b/src/vendored/r3_hex_http_httpc.erl
@@ -11,18 +11,6 @@
 %%====================================================================
 
 request(Method, URI, ReqHeaders, Body, AdapterConfig) ->
-    case os:getenv("REBAR_OFFLINE") of
-        "1" ->
-            {error, {offline, URI}};
-        _ ->
-            request_online(Method, URI, ReqHeaders, Body, AdapterConfig)
-    end.
-
-%%====================================================================
-%% Internal functions
-%%====================================================================
-
-request_online(Method, URI, ReqHeaders, Body, AdapterConfig) ->
     Profile = maps:get(profile, AdapterConfig, default),
     Request = build_request(URI, ReqHeaders, Body),
     case httpc:request(Method, Request, [], [{body_format, binary}], Profile) of
@@ -32,6 +20,9 @@ request_online(Method, URI, ReqHeaders, Body, AdapterConfig) ->
         {error, Reason} -> {error, Reason}
     end.
 
+%%====================================================================
+%% Internal functions
+%%====================================================================
 
 build_request(URI, ReqHeaders, Body) ->
     build_request2(binary_to_list(URI), dump_headers(ReqHeaders), Body).

--- a/src/vendored/r3_hex_http_httpc.erl
+++ b/src/vendored/r3_hex_http_httpc.erl
@@ -11,6 +11,18 @@
 %%====================================================================
 
 request(Method, URI, ReqHeaders, Body, AdapterConfig) ->
+    case os:getenv("REBAR_OFFLINE") of
+        "1" ->
+            {error, {offline, URI}};
+        _ ->
+            request_online(Method, URI, ReqHeaders, Body, AdapterConfig)
+    end.
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+request_online(Method, URI, ReqHeaders, Body, AdapterConfig) ->
     Profile = maps:get(profile, AdapterConfig, default),
     Request = build_request(URI, ReqHeaders, Body),
     case httpc:request(Method, Request, [], [{body_format, binary}], Profile) of
@@ -20,9 +32,6 @@ request(Method, URI, ReqHeaders, Body, AdapterConfig) ->
         {error, Reason} -> {error, Reason}
     end.
 
-%%====================================================================
-%% Internal functions
-%%====================================================================
 
 build_request(URI, ReqHeaders, Body) ->
     build_request2(binary_to_list(URI), dump_headers(ReqHeaders), Body).


### PR DESCRIPTION
If --offline or REBAR_OFFLINE=1 is given, inets is not started and
all calls to httpc:request/N are prevented. If any online resource
is needed, an error occurs rather than trying to fetch the online
resource.

The purpose is described in #1281 and #2640.

Combined with placing the dependencies in `_checkouts`, I think it makes it possible to build using dependencies provided manually (which is what's required in the scenario that all dependencies need to be separately reviewed and verified legally and security wise). When combined with #2642, even rebar3 itself can be built in this way.