### PR TITLE
Fix issue for duplicates options of 'parserfile' in 'yrl_opts'

### DIFF
--- a/src/rebar_compiler_yrl.erl
+++ b/src/rebar_compiler_yrl.erl
@@ -32,10 +32,16 @@ needed_files(_, FoundFiles, Mappings, AppInfo) ->
 dependencies(_, _, _) ->
     [].
 
-compile(Source, [{_, OutDir}], _, Opts) ->
-    BaseName = filename:basename(Source, ".yrl"),
-    Target = filename:join([OutDir, BaseName]),
-    AllOpts = [{parserfile, Target}, {return, true} | Opts],
+compile(Source, [{_, OutDir}], _, Opts0) ->
+    Opts = case proplists:get_value(parserfile, Opts0) of
+        undefined ->
+            BaseName = filename:basename(Source, ".yrl"),
+            Target = filename:join([OutDir, BaseName]),
+            [{parserfile, Target} | Opts0];
+        _ ->
+            Opts0
+    end,
+    AllOpts = [{return, true} | Opts],
     case yecc:file(Source, AllOpts) of
         {ok, _} ->
             ok;


### PR DESCRIPTION
Related to bug https://github.com/erlang/rebar3/issues/2652.