### PR TITLE
Don't write a lock file if there are no locks.

### DIFF
--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -112,6 +112,8 @@ warn_vsn_once() ->
     end.
 
 %% Only call `write_lock_file/2' if the locks have changed.
+maybe_write_lock_file(_LockFile, [], []) ->
+    ok;
 maybe_write_lock_file(LockFile, Locks, OldLocks) when Locks =/= OldLocks ->
     write_lock_file(LockFile, Locks);
 maybe_write_lock_file(LockFile, Locks, Locks) ->

--- a/test/rebar_deps_SUITE.erl
+++ b/test/rebar_deps_SUITE.erl
@@ -3,7 +3,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> [sub_app_deps, newly_added_dep, newly_added_after_empty_lock, no_deps_empty_lock,
+all() -> [sub_app_deps, newly_added_dep, newly_added_after_empty_lock, no_deps_no_lock,
           http_proxy_settings, https_proxy_settings,
           http_os_proxy_settings, https_os_proxy_settings,
           semver_matching_lt, semver_matching_lte, semver_matching_gt,
@@ -45,7 +45,7 @@ init_per_testcase(semver_matching_gt, Config) ->
     rebar_test_utils:init_rebar_state(Config);
 init_per_testcase(newly_added_after_empty_lock, Config) ->
     rebar_test_utils:init_rebar_state(Config);
-init_per_testcase(no_deps_empty_lock, Config) ->
+init_per_testcase(no_deps_no_lock, Config) ->
     rebar_test_utils:init_rebar_state(Config);
 init_per_testcase(newly_added_dep, Config) ->
     rebar_test_utils:init_rebar_state(Config);
@@ -386,7 +386,7 @@ newly_added_after_empty_lock(Config) ->
       Config, RebarConfig3, ["compile"],
       {ok, [{app, Name}, {dep, "a", "1.0.0"}]}).
 
-no_deps_empty_lock(Config) ->
+no_deps_no_lock(Config) ->
     AppDir = ?config(apps, Config),
     Deps = rebar_test_utils:expand_deps(git, []),
     mock_git_resource:mock([{deps, Deps}]),
@@ -397,15 +397,9 @@ no_deps_empty_lock(Config) ->
       {ok, []}),
 
     LockFile = filename:join(AppDir, "rebar.lock"),
-    %% the lock file should exist
-    {ok,_} = file:read_file_info(LockFile),
-
-    %% and just in case, it should be empty
-    ?assertEqual([], rebar_config:consult_lock_file(LockFile)),
-    %% which means that merging that lock file with the current config
-    %% returns the same config
-    ?assertEqual(RebarConfig, rebar_config:merge_locks(RebarConfig,
-                                            rebar_config:consult_lock_file(LockFile))).
+    
+    %% the lock file should not exist.
+    ?assertMatch({error, enoent}, file:read_file_info(LockFile)).
 
 http_proxy_settings(_Config) ->
     %% Load config


### PR DESCRIPTION
This commit adjusts the behavior of maybe_write_lock_file/3 to only write a lock file if new or old locks exist.