### PR TITLE
Use default branch for git and git_subdir resources with no revision

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -97,7 +97,7 @@
     {rebar,           % mercurial is also supported
      {hg, "https://github.com/rebar/rebar.git", {tag, "1.0.0"}}},
     %% Alternative formats, backwards compatible declarations
-    {rebar,           % implicit main, will warn recommending explicit branch
+    {rebar,           % default branch, will warn recommending explicit branch
      {git, "git://github.com/rebar/rebar.git"}},
     {rebar, "1.0.*",  % regex version check, ignored
      {git, "git://github.com/rebar/rebar.git"}},

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -84,16 +84,12 @@ needs_update_(Dir, {git, Url, "main"}) ->
     needs_update_(Dir, {git, Url, {branch, "main"}});
 needs_update_(Dir, {git, Url, "master"}) ->
     needs_update_(Dir, {git, Url, {branch, "master"}});
-needs_update_(Dir, {git, _Url}) ->
+needs_update_(Dir, {git, Url}) ->
     {ok, _} = rebar_utils:sh("git fetch origin", [{cd, Dir}]),
-    {ok, Head} = rebar_utils:sh("git rev-parse --short=7 -q HEAD", [{cd, Dir}]),
-    Head1 = rebar_string:trim(rebar_string:trim(Head, both, "\n"), both, "\r"),
-    {ok, OriginHead} = rebar_utils:sh("git rev-parse --short=7 -q origin/HEAD",
-                                      [{cd, Dir}]),
-    OriginHead1 = rebar_string:trim(rebar_string:trim(OriginHead, both, "\n"),
-                                    both, "\r"),
-    ?DEBUG("Comparing git origin/HEAD ~ts with HEAD ~ts", [OriginHead1, Head1]),
-    (OriginHead1 =/= Head1);
+    {ok, Current} = rebar_utils:sh("git log HEAD..origin/HEAD --oneline",
+                                   [{cd, Dir}]),
+    ?DEBUG("Checking new commits from HEAD to origin/HEAD: ~.7ts", [Current]),
+    not ((Current =:= []) andalso compare_url(Dir, Url));
 needs_update_(Dir, {git, Url, ""}) ->
     needs_update_(Dir, {git, Url});
 needs_update_(Dir, {git, _, Ref}) ->

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -156,7 +156,7 @@ download(Dir, AppInfo, State) ->
     download_(Dir, AppInfo, State).
 
 download_(Dir, {git, Url}, State) ->
-    ?DEBUG("Git revision is not specified, using origin/HEAD", []),
+    ?WARN("WARNING: It is recommended to use {branch, Name}, {tag, Tag} or {ref, Ref} since default branch selection is not consistent across all versions of rebar.", []),
     download_(Dir, {git, Url, {ref, "origin/HEAD"}}, State);
 download_(Dir, {git, Url, ""}, State) ->
     download_(Dir, {git, Url}, State);


### PR DESCRIPTION
Where git revision is not specified for a dependency, check out and upgrade from the default branch (origin/HEAD) instead of the hardcoded `master`, consistently with rebar 2. Mostly to support GitHub repos where the default branch has been (re)named `main` or something else.

Resolves #2651.