### PR TITLE
add a log in the needs_update

### DIFF
--- a/src/rebar_fetch.erl
+++ b/src/rebar_fetch.erl
@@ -71,7 +71,9 @@ needs_update(AppInfo, State) ->
     try
         rebar_resource_v2:needs_update(AppInfo, State)
     catch
-        _:_ ->
+        Error:Reason ->
+            ?DEBUG("Failed checking if dependency needs updates : ~p:~p",
+                   [Error, Reason]),
             true
     end.
 


### PR DESCRIPTION
I recently have to debug a resource plugin and this log would have give me all the information I would have need.