### PR TITLE
Error out on unknown templates in 'new' command

### DIFF
--- a/src/rebar_prv_new.erl
+++ b/src/rebar_prv_new.erl
@@ -40,19 +40,21 @@ do(State) ->
             {ok, State};
         ["help", TemplateName] ->
             case lists:keyfind(TemplateName, 1, list_templates(State)) of
-                false -> ?CONSOLE("template not found.", []);
-                Term -> show_template(Term)
-            end,
-            {ok, State};
+                false ->
+                    ?PRV_ERROR({template_not_found, TemplateName});
+                Term ->
+                    show_template(Term),
+                    {ok, State}
+            end;
         [TemplateName | Opts] ->
             case lists:keyfind(TemplateName, 1, list_templates(State)) of
                 false ->
-                    ?CONSOLE("template not found.", []);
+                    ?PRV_ERROR({template_not_found, TemplateName});
                 _ ->
                     Force = is_forced(State),
-                    ok = rebar_templater:new(TemplateName, parse_opts(Opts), Force, State)
-            end,
-            {ok, State};
+                    ok = rebar_templater:new(TemplateName, parse_opts(Opts), Force, State),
+                    {ok, State}
+            end;
         [] ->
             show_short_templates(list_templates(State)),
             {ok, State}
@@ -61,6 +63,8 @@ do(State) ->
 -spec format_error(any()) -> iolist().
 format_error({consult, File, Reason}) ->
     io_lib:format("Error consulting file at ~ts for reason ~p", [File, Reason]);
+format_error({template_not_found, Name}) ->
+    io_lib:format("Template '~ts' not found.", [Name]);
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 

--- a/test/rebar_new_SUITE.erl
+++ b/test/rebar_new_SUITE.erl
@@ -7,7 +7,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() -> [app_git_user, app_hg_user, app_with_fallbacks,
-          app_with_flags1, app_with_flags2, plugin_tpl].
+          app_with_flags1, app_with_flags2, plugin_tpl, unknown_template].
 
 
 init_per_testcase(plugin_tpl, Config) ->
@@ -159,6 +159,14 @@ plugin_tpl(Config) ->
     {ok, Bin} = file:read_file(Result),
     {match, _} = re:run(Bin, Name, [multiline,global]).
 
+unknown_template(Config) ->
+    Name = float_to_list(rand:uniform()),
+    rebar_test_utils:run_and_check(Config, [], ["new", Name],
+                                   {error, {rebar_prv_new, {template_not_found, Name}}}),
+    rebar_test_utils:run_and_check(Config, [], ["new", "help", Name],
+                                   {error, {rebar_prv_new, {template_not_found, Name}}}),
+    ok.
+
 validate_files(_Config, Name, Checks) ->
     [begin
         Path = filename:join([Name, File]),
@@ -168,4 +176,3 @@ validate_files(_Config, Name, Checks) ->
          || Pattern <- Patterns]
      end || {File, Patterns} <- Checks],
     ok.
-


### PR DESCRIPTION
Fixes https://github.com/erlang/rebar3/issues/2675

Uses the now project-standard rebar3 error structures, which were
possibly not even there when we originally set up the provider for this.