### PR TITLE
Fix global cache config overriding

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -207,9 +207,10 @@ init_config() ->
 
     Config = rebar_config:consult_root(),
     Config1 = rebar_config:merge_locks(Config, rebar_config:consult_lock_file(?LOCK_FILE)),
+    InitState = rebar_state:new(Config1),
 
     %% If $HOME/.config/rebar3/rebar.config exists load and use as global config
-    GlobalConfigFile = rebar_dir:global_config(),
+    GlobalConfigFile = rebar_dir:global_config(InitState),
     State = case filelib:is_regular(GlobalConfigFile) of
                 true ->
                     ?DEBUG("Load global config file ~ts", [GlobalConfigFile]),
@@ -217,10 +218,10 @@ init_config() ->
                     catch
                         _:_ ->
                             ?WARN("Global config ~ts exists but can not be read. Ignoring global config values.", [GlobalConfigFile]),
-                            rebar_state:new(Config1)
+                            InitState
                     end;
                 false ->
-                    rebar_state:new(Config1)
+                    InitState
             end,
 
     %% Determine the location of the rebar executable; important for pulling

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -163,8 +163,8 @@ run_aux(State, RawArgs) ->
     State5 = case os:getenv("REBAR_CACHE_DIR") of
                 false ->
                     State4;
-                ConfigFile ->
-                    rebar_state:set(State4, global_rebar_dir, ConfigFile)
+                CachePath ->
+                    rebar_state:set(State4, global_rebar_dir, CachePath)
             end,
 
     {ok, Providers} = application:get_env(rebar, providers),
@@ -403,7 +403,14 @@ ensure_running(App, Caller) ->
 -spec state_from_global_config([term()], file:filename()) -> rebar_state:t().
 state_from_global_config(Config, GlobalConfigFile) ->
     GlobalConfigTerms = rebar_config:consult_file(GlobalConfigFile),
-    GlobalConfig = rebar_state:new(GlobalConfigTerms),
+    GlobalConfigTmp = rebar_state:new(GlobalConfigTerms),
+
+    GlobalConfig = case os:getenv("REBAR_CACHE_DIR") of
+                false ->
+                    GlobalConfigTmp;
+                CachePath ->
+                    rebar_state:set(GlobalConfigTmp, global_rebar_dir, CachePath)
+            end,
 
     %% We don't want to worry about global plugin install state effecting later
     %% usage. So we throw away the global profile state used for plugin install.

--- a/src/rebar_prv_plugins.erl
+++ b/src/rebar_prv_plugins.erl
@@ -32,7 +32,7 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    GlobalConfigFile = rebar_dir:global_config(),
+    GlobalConfigFile = rebar_dir:global_config(State),
     GlobalConfig = rebar_state:new(rebar_config:consult_file(GlobalConfigFile)),
     GlobalPlugins = rebar_state:get(GlobalConfig, plugins, []),
     GlobalSrcDirs = rebar_state:get(GlobalConfig, src_dirs, ["src"]),

--- a/test/rebar_plugins_SUITE.erl
+++ b/test/rebar_plugins_SUITE.erl
@@ -84,6 +84,7 @@ compile_global_plugins(Config) ->
 
     meck:new(rebar_dir, [passthrough]),
     meck:expect(rebar_dir, global_config, fun() -> GlobalConfig end),
+    meck:expect(rebar_dir, global_config, fun(_) -> GlobalConfig end),
     meck:expect(rebar_dir, global_cache_dir, fun(_) -> GlobalDir end),
 
     Name = rebar_test_utils:create_random_name("app1_"),


### PR DESCRIPTION
There was some confusion in the code:

- `rebar_dir:global_config()` returns the default path
- `rebar_dir:global_config(State)` returns the configured path based on
  the ENV overrides, and defaults to `global_config()` if nothing is
  given

Since no State term existed at this point in time, we just called out
directly to the argument-free version of the call, but this ignored all
overrides. Instead, we call it with an initialized `rebar_state:new()` to
properly handle configuration from users, and then use the actual
configured state (if any).