### PR TITLE
Attempt to find apps in git subdirs (sparse checkouts)

### DIFF
--- a/src/rebar_prv_path.erl
+++ b/src/rebar_prv_path.erl
@@ -82,12 +82,15 @@ rel_dir(State)  -> io_lib:format("~ts/rel", [rebar_dir:base_dir(State)]).
 
 ebin_dirs(Apps, State) ->
     lists:flatmap(fun(App) -> [io_lib:format("~ts/~ts/ebin", [rebar_dir:checkouts_out_dir(State), App]),
+                               io_lib:format("~ts/~ts/apps/~ts/ebin", [rebar_dir:deps_dir(State), App, App]),
                                io_lib:format("~ts/~ts/ebin", [rebar_dir:deps_dir(State), App]) ] end, Apps).
 priv_dirs(Apps, State) ->
     lists:flatmap(fun(App) -> [io_lib:format("~ts/~ts/priv", [rebar_dir:checkouts_out_dir(State), App]),
+                               io_lib:format("~ts/~ts/apps/~ts/priv", [rebar_dir:deps_dir(State), App, App]),
                                io_lib:format("~ts/~ts/priv", [rebar_dir:deps_dir(State), App]) ] end, Apps).
 src_dirs(Apps, State) ->
     lists:flatmap(fun(App) -> [io_lib:format("~ts/~ts/src", [rebar_dir:checkouts_out_dir(State), App]),
+                               io_lib:format("~ts/~ts/apps/~ts/src", [rebar_dir:deps_dir(State), App, App]),
                                io_lib:format("~ts/~ts/src", [rebar_dir:deps_dir(State), App]) ] end, Apps).
 
 print_paths_if_exist(Paths, State) ->


### PR DESCRIPTION
A naive addition to the list of directories being searched for path inclusion.

I *think* that as a result of how applications in rebar.config are named/sparse checkouted, that this assumption is valid across all of the git subdirs that we are currently using - but I don't know if that assumption is true in all cases. ( APP_NAME/apps/APP_NAME) ??.

Either way, this fixes our usages of path for #2686 