### PR TITLE
Experimental vendoring provider

### DIFF
--- a/src/rebar.app.src.script
+++ b/src/rebar.app.src.script
@@ -82,6 +82,7 @@
                      rebar_prv_unlock,
                      rebar_prv_update,
                      rebar_prv_upgrade,
+                     rebar_prv_vendor,
                      rebar_prv_version,
                      rebar_prv_xref,
                      rebar_prv_alias]} % must run last to prevent overloads

--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -19,7 +19,7 @@
 %% @doc from the base directory, find all the applications
 %% at the top level and their dependencies based on the configuration
 %% and profile information.
--spec do(rebar_state:t(), [file:filename()]) -> rebar_state:t().
+-spec do(rebar_state:t(), [file:filename()]) -> rebar_state:t() | no_return().
 do(State, LibDirs) ->
     BaseDir = rebar_state:dir(State),
     Dirs = [filename:join(BaseDir, LibDir) || LibDir <- LibDirs],

--- a/src/rebar_prv_vendor.erl
+++ b/src/rebar_prv_vendor.erl
@@ -1,0 +1,113 @@
+-module(rebar_prv_vendor).
+-behaviour(provider).
+
+-export([init/1,
+         do/1,
+         format_error/1]).
+
+-include("rebar.hrl").
+-include_lib("providers/include/providers.hrl").
+
+-define(PROVIDER, vendor).
+-define(NAMESPACE, experimental).
+-define(DEPS, []).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    State1 = rebar_state:add_provider(
+        State,
+        providers:create([{name, ?PROVIDER},
+                          {namespace, ?NAMESPACE},
+                          {module, ?MODULE},
+                          {bare, true},
+                          {deps, ?DEPS},
+                          {example, ""},
+                          {short_desc, "Turns dependencies into top-level apps"},
+                          {desc, "Turns dependencies into top-level applications"},
+                          {opts, []}])
+    ),
+    {ok, State1}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    %% Only vendor default profile runs
+    case rebar_state:current_profiles(State) of
+        [default] ->
+            case check_project_layout(State) of
+                umbrella -> do_(State);
+                _ -> ?PRV_ERROR(not_umbrella)
+            end;
+        Profiles ->
+            ?DEBUG("Profiles found: ~p, skipping", [Profiles]),
+            {ok, State}
+    end.
+
+%% @doc convert a given exception's payload into an io description.
+-spec format_error(any()) -> iolist().
+format_error(not_umbrella) ->
+    io_lib:format("Vendoring can only work on umbrella applications", []).
+
+do_(InitState) ->
+    %% TODO: figure out how to vendor and local-load plugins
+    %% delete the vendored files (or move them to another place)
+    RootDir = rebar_dir:root_dir(InitState),
+    VendorDir = filename:join(RootDir, "vendor"),
+    VendorBak = filename:join(RootDir, "_vendor"),
+    catch rebar_file_utils:rm_rf(VendorBak),
+    catch rebar_file_utils:mv(VendorDir, VendorBak),
+    filelib:ensure_dir(filename:join(VendorDir, ".touch")),
+    %% remove the src_dirs option for vendored files
+    CleanDirs = rebar_dir:lib_dirs(InitState) -- ["vendor/*"],
+    CleanState = rebar_state:set(InitState, project_app_dirs, CleanDirs),
+    %% re-run discovery
+    {ok, TmpState1} = rebar_prv_app_discovery:do(CleanState),
+    %% run a full fetch (which implicitly upgrades, since the lock file
+    %% should be unset for any vendored app)
+    {ok, TmpState2} = rebar_prv_install_deps:do(TmpState1),
+    %% move the libs to the vendor path
+    AllDeps = rebar_state:lock(TmpState2),
+    [begin
+        AppDir = rebar_app_info:dir(Dep),
+        NewAppDir = filename:join(VendorDir, filename:basename(AppDir)),
+        rebar_file_utils:mv(AppDir, NewAppDir)
+     end || Dep <- AllDeps, not(rebar_app_info:is_checkout(Dep))],
+    %% add the src_dirs options to the rebar.config file
+    %% -- we don't actually want to mess with the user's file so we have to
+    %% let them know what it should be:
+    NewAppDirs = CleanDirs ++ ["vendor/*"],
+    ?CONSOLE("Vendoring in place. To use the vendored libraries, configure "
+             "the source application directories for your project with:~n~n"
+             "{project_app_dirs, ~p}.~n~n"
+             "and move the {deps, ...} tuple to the rebar.config files "
+             "of the proper top-level applications rather than the project root.",
+             [NewAppDirs]),
+    State1 = rebar_state:set(InitState, project_app_dirs, NewAppDirs),
+    {ok, State1}.
+
+check_project_layout(State) ->
+    %% Do a project_app_discover run, look for the project root,
+    %% then drop the state.
+    %% No need to drop the vendor config here if it exists because it
+    %% only exists if we have the right structure.
+    case rebar_prv_app_discovery:do(State) of
+        {ok, TmpState} ->
+            Apps = rebar_state:project_apps(TmpState),
+            %% Code duplicated from rebar_prv_lock:define_root_app/2
+            RootDir = rebar_dir:root_dir(TmpState),
+            case ec_lists:find(fun(X) ->
+                    ec_file:real_dir_path(rebar_app_info:dir(X)) =:=
+                    ec_file:real_dir_path(RootDir)
+                 end, Apps) of
+                {ok, _App} ->
+                    non_umbrella;
+                error ->
+                    umbrella
+            end;
+        Other ->
+            Other
+    end.
+


### PR DESCRIPTION
The new experimental vendoring provider is called as `rebar3 experimental vendor`,
and works by doing the following:

- Detecting whether the app is an umbrella application (only works on
  them)
- Fetching all dependencies for the project
- Moving all dependencies to the top-level vendor/ directory
- Telling the user to configure `{project_app_directories, ...}` to
  include the vendored path
- Telling the user to move all `{deps, ...}` entries away from the
  top-level `rebar.config` file and into sub-applications' files

This then works by changing all non-checkout dependencies into top-level
apps stored elsewhere than the user-supplied ones.

This should also implicitly empty the lock file on the next compilation.

When called again, the provider:

- Makes itself ignore the previous `{project_app_directories, ...}`
  values
- Moves whatever the content of `vendor/` was into `_vendor/` (which is
  pre-emptively emptied) to capture errors of any kind.
- Re-fetches the dependencies (the ebin/ directories aren't cleared in
  case the dependency ships pre-built beam files)
    - Since the dependencies were unlikely to be locked, they are
      upgraded
- Tells the user to re-update their vendoring configuration


This is a proposed experimental value that would enshrine a suggested
vendoring mechanism for offline builds for Ericsson et al. The idea would be
that at some point, Rebar3 itself would be able to reuse that pattern (after
migrating to an umbrella project structure) in order to safely vendor deps and
allowing builds from official release tarballs on offline systems.

Currently not handled:
- Tests
- Support for any plugins whatsoever.
  - this would require adding support for project-internal plugins, which might actually be cool, but I couldn't tackle in a single night.
- Dealing with stray .git directories (and other source control artifacts) from dependencies that have been fetched
- User-friendly error-handling (including loud warnings of circular dependencies when `deps` stay at the top-level)