### PR TITLE
Shell commands now use PowerShell on Windows instead of CMD

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,8 +17,8 @@
                "cp \"$REBAR_BUILD_DIR/bin/rebar3\" ./rebar3"},
               {"win32",
                escriptize,
-               "robocopy \"%REBAR_BUILD_DIR%/bin/\" ./ rebar3* "
-               "/njs /njh /nfl /ndl & exit /b 0"} % silence things
+               "robocopy \"$REBAR_BUILD_DIR/bin/\" ./ rebar3* "
+               "/njs /njh /nfl /ndl ; exit 0"} % silence things
              ]}.
 
 {escript_name, rebar3}.

--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -326,7 +326,7 @@ robocopy_mv_and_rename(Source, Dest, SrcDir, SrcName, DestDir, DestName) ->
     end.
 
 robocopy_file(SrcPath, DestPath, FileName) ->
-    Cmd = ?FMT("robocopy /move /e \"~ts\" \"~ts\" \"~ts\" 1> nul",
+    Cmd = ?FMT("robocopy \"~ts\" \"~ts\" \"~ts\" /move /e",
                [rebar_utils:escape_double_quotes(SrcPath),
                 rebar_utils:escape_double_quotes(DestPath),
                 rebar_utils:escape_double_quotes(FileName)]),
@@ -342,7 +342,7 @@ robocopy_file(SrcPath, DestPath, FileName) ->
     end.
 
 robocopy_dir(Source, Dest) ->
-    Cmd = ?FMT("robocopy /move /e \"~ts\" \"~ts\" 1> nul",
+    Cmd = ?FMT("robocopy \"~ts\" \"~ts\" /move /e",
                [rebar_utils:escape_double_quotes(Source),
                 rebar_utils:escape_double_quotes(Dest)]),
     Res = rebar_utils:sh(Cmd,
@@ -526,7 +526,7 @@ ensure_dir(Path) ->
 
 delete_each_dir_win32([]) -> ok;
 delete_each_dir_win32([Dir | Rest]) ->
-    {ok, []} = rebar_utils:sh(?FMT("rd /q /s \"~ts\"",
+    {ok, []} = rebar_utils:sh(?FMT("rm \"~ts\" -r -fo",
                                    [rebar_utils:escape_double_quotes(filename:nativename(Dir))]),
                               [{use_stdout, false}, return_on_error]),
     delete_each_dir_win32(Rest).
@@ -542,11 +542,11 @@ xcopy_win32(Source,Dest)->
                   %% must manually add the last fragment of a directory to the `Dest`
                   %% in order to properly replicate POSIX platforms
                   NewDest = filename:join([Dest, filename:basename(Source)]),
-                  ?FMT("robocopy \"~ts\" \"~ts\" /e 1> nul",
+                  ?FMT("robocopy \"~ts\" \"~ts\" /e | Out-Null",
                        [rebar_utils:escape_double_quotes(filename:nativename(Source)),
                         rebar_utils:escape_double_quotes(filename:nativename(NewDest))]);
               false ->
-                  ?FMT("robocopy \"~ts\" \"~ts\" \"~ts\" /e 1> nul",
+                  ?FMT("robocopy \"~ts\" \"~ts\" \"~ts\" /e | Out-Null",
                        [rebar_utils:escape_double_quotes(filename:nativename(filename:dirname(Source))),
                         rebar_utils:escape_double_quotes(filename:nativename(Dest)),
                         rebar_utils:escape_double_quotes(filename:basename(Source))])

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -2895,17 +2895,20 @@ split_project_apps_hooks(Config) ->
     ok = filelib:ensure_dir(filename:join([AppDir2, "src", "dummy"])),
     ok = filelib:ensure_dir(filename:join([AppDir2, "include", "dummy"])),
     ok = filelib:ensure_dir(filename:join([HookDir, "dummy"])),
-    Cmd = case os:type() of
-        {win32, _} -> "dir /B";
-        _ -> "ls"
+    Cmd = fun(Content) ->
+        case os:type() of
+            % Powershell writes in UTF16 so it's better to use cmd
+            {win32, _} -> "cmd /q /c 'dir /B " ++ Content ++ "'";
+            _ -> "ls " ++ Content
+        end
     end,
     Cfg = fun(Name) ->
-        [{pre_hooks, [{compile,      Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "pre-compile-"++Name)++"\""},
-                      {erlc_compile, Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "pre-erlc-"++Name)++"\""},
-                      {app_compile,  Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "pre-app-"++Name)++"\""}]},
-         {post_hooks, [{compile,      Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "post-compile-"++Name)++"\""},
-                       {erlc_compile, Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "post-erlc-"++Name)++"\""},
-                       {app_compile,  Cmd++" \""++HookDir++"\" > \""++filename:join(HookDir, "post-app-"++Name)++"\""}]}
+        [{pre_hooks, [{compile,      Cmd("\""++HookDir++"\" > \""++filename:join(HookDir, "pre-compile-"++Name)++"\"")},
+                      {erlc_compile, Cmd("\""++HookDir++"\" > \""++filename:join(HookDir, "pre-erlc-"++Name)++"\"")},
+                      {app_compile,  Cmd("\""++HookDir++"\" > \""++filename:join(HookDir, "pre-app-"++Name)++"\"")}]},
+         {post_hooks, [{compile,      Cmd("\""++HookDir++"\" > \""++filename:join(HookDir, "post-compile-"++Name)++"\"")},
+                       {erlc_compile, Cmd("\""++HookDir++"\" > \""++filename:join(HookDir, "post-erlc-"++Name)++"\"")},
+                       {app_compile,  Cmd("\""++HookDir++"\" > \""++filename:join(HookDir, "post-app-"++Name)++"\"")}]}
         ]
     end,
     ok = file:write_file(filename:join(AppDir1, "rebar.config"),

--- a/test/rebar_hooks_SUITE.erl
+++ b/test/rebar_hooks_SUITE.erl
@@ -134,11 +134,11 @@ bare_compile_hooks_default_ns(Config) ->
     HookFile = filename:join([?config(priv_dir, Config), "bare-post.hook"]),
 
     Cmd = case os:type() of
-        {win32, _} -> "dir";
+        {win32, _} -> "ls -Name";
         _ -> "ls"
     end,
     ConfOpts = [{provider_hooks, [{post, [{compile, clean}]}]},
-                {post_hooks, [{compile, Cmd ++ " > " ++ HookFile}]}],
+                {post_hooks, [{compile, Cmd ++ " > \"" ++ HookFile ++ "\""}]}],
     RConfFile = rebar_test_utils:create_config(AppDir, ConfOpts),
     {ok, RConf} = file:consult(RConfFile),
     rebar_test_utils:run_and_check(


### PR DESCRIPTION
Managed to patch the shell commands for PowerShell, all ct tests succeeded (few are skipped anyway on Windows)
My testing was limited to running ct tests on my Windows machine.

[ct_tests_win_10.txt](https://github.com/erlang/rebar3/files/8306657/ct_tests_win_10.txt)

I also runned ct on Ubuntu (WSL) to be sure.

This change enables to use some common commands that work both in bash and powershell like:
cp, rm, mv ..ecc
These in some cases need different a sintax for the arguments or deliver different text outputs.

For example 
"cp -R" now would work the same since is accepted by PS
"cp -Rf" is not accepted, so one should run "cp -R -Fo"

Another not so funny thing of Powershell 5.1 ...
If you redirect the stdout on a file, it is written as UTF16, since a test in ct was reading a written file i had to launch a CMD command inside powershell...
PowerShell Core will fix this encoding problem in future but is still not the default on Windows.