### PR TITLE
Do not discard parameters --system_libs and --include-erts when duplicate values exist

### DIFF
--- a/src/rebar_relx.erl
+++ b/src/rebar_relx.erl
@@ -236,9 +236,13 @@ maybe_obey_command_args(RelxConfig, Opts, Args) ->
                      undefined ->
                          Acc;
                      V ->
-                         lists:keystore(Opt, 1, Acc, {Opt, V})
+                         replace_all_instance(Opt, V, Acc)
                  end
         end, RelxConfig, Args).
+
+replace_all_instance(Opt, Value, RelxConfig) ->
+    lists:map(fun({K, _}) when K =:= Opt -> {K, Value};
+            (Other) -> Other end, RelxConfig).
 
 %%
 


### PR DESCRIPTION
When merging #2503 it was not taken for account that `include_erts` and the other variables can be present multiple time in the `RelxConfig`. This can occurs when a variable is define in a profile. Following is an `rebar.config` file example and the result before this fix.

```
{relx, [{release, {tt, "0.1.0"},
         [tt,
          sasl]},

        {sys_config, "./config/sys.config"},
        {vm_args, "./config/vm.args"},
	{include_erts, false}
]}.

{profiles, [{prod, [{relx,
                     [
			{include_erts, true}
                     ]
            }]}]}.
```

```erlang
[{mode,prod},
                     {output_dir,"/home/jbouchard/ws/erl/tt/_build/prod/rel"},
                     {overlay_vars_values,[{profile_string,"prod"}]},
                     {overlay_vars,
                         [{base_dir,"/home/jbouchard/ws/erl/tt/_build/prod"}]},
                     {overlay,[]},
                     {include_erts,"/usr/lib/er"},
                     {include_erts,true},
                     {release,{tt,"0.1.0"},[tt,sasl]},
                     {sys_config,"./config/sys.config"},
                     {vm_args,"./config/vm.args"}]
```

The solution propose is to replace all the occurrence before sending them to rlx_config:to_state. The reason the problem exist is because the rlx_config:to_state use `list:foldl` so the last occurence take preceence. 