### PR TITLE
Support OTP 23..25 inclusively

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,14 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [22, 23, 24]
+        otp_version: [23, 24, 25]
         os: [ubuntu-latest]
 
     container:
       image: erlang:${{ matrix.otp_version }}
 
     env:
-      LATEST_OTP_RELEASE: 24
+      LATEST_OTP_RELEASE: 25
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: erlef/setup-beam@v1
       with:
-          otp-version: '22.3.4.9'
+          otp-version: '23.3.4.14'
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: erlef/setup-beam@v1
       with:
-          otp-version: '22.3.4.9'
+          otp-version: '23.3.4.14'
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/.github/workflows/shelltests.yml
+++ b/.github/workflows/shelltests.yml
@@ -15,8 +15,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: erlef/setup-beam@v1
       with:
-          otp-version: '24.0.1'
-          elixir-version: '1.12'
+          otp-version: '25.0'
+          elixir-version: '1.13'
     - name: Compile
       run: ./bootstrap
     - name: Install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rebar3
 
-[![Build Status](https://github.com/erlang/rebar3/workflows/Common%20Test/badge.svg)](https://github.com/erlang/rebar3/actions?query=branch%3Amaster+workflow%3A"Common+Test") [![Erlang Versions](https://img.shields.io/badge/Supported%20Erlang%2FOTP-22.0%20to%2024.0-blue)](http://www.erlang.org)
+[![Build Status](https://github.com/erlang/rebar3/workflows/Common%20Test/badge.svg)](https://github.com/erlang/rebar3/actions?query=branch%3Amaster+workflow%3A"Common+Test") [![Erlang Versions](https://img.shields.io/badge/Supported%20Erlang%2FOTP-23.0%20to%2025.0-blue)](http://www.erlang.org)
 
 1. [What is Rebar3?](#what-is-rebar3)
 2. [Why Rebar3?](#why-rebar3)

--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -98,10 +98,9 @@ init(State) ->
     ),
     {ok, State1}.
 
--spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+-spec do(rebar_state:t()) -> no_return().
 do(Config) ->
-    shell(Config),
-    {ok, Config}.
+    shell(Config).
 
 -spec format_error(any()) -> iolist().
 format_error({unknown_app, Unknown}) ->


### PR DESCRIPTION
Adds a requirement to support OTP-25, which also means deprecating
explicit support for OTP-22.

We've got a couple of macros we can remove, but let's call this a soft-deprecation for the time being.