### PR TITLE
Track mib compilation artifacts

### DIFF
--- a/src/rebar_compiler_dag.erl
+++ b/src/rebar_compiler_dag.erl
@@ -428,6 +428,7 @@ maybe_rm_artifact_and_edge(G, OutDir, SrcExt, Ext, Source) ->
                     lists:foreach(fun(Target) ->
                         ?DIAGNOSTIC("Source ~ts is gone, deleting artifact ~ts "
                                     "if it exists", [Source, Target]),
+                        digraph:del_vertex(G, Target),
                         file:delete(Target)
                     end, Targets)
             end,

--- a/src/rebar_compiler_dag.erl
+++ b/src/rebar_compiler_dag.erl
@@ -100,13 +100,15 @@ safe_dir([H|T]) -> [H|safe_dir(T)].
 is_deleted_source(_G, _F, Extension, Extension, _ArtifactExt) ->
     %% source file
     true;
-is_deleted_source(_G, _F, Extension, _SrcExt, Extension) ->
-    %% artifact file - skip
-    false;
-is_deleted_source(G, F, _Extension, _SrcExt, _ArtifactExt) ->
-    %% must be header file or artifact
-    digraph:in_edges(G, F) == [] andalso maybe_rm_vertex(G, F),
-    false.
+is_deleted_source(G, F, Extension, _SrcExt, ArtifactExt) ->
+    case lists:member(Extension, ArtifactExt) of
+        true -> % artifact file, skip
+            false;
+        false ->
+            %% must be header file or artifact
+            digraph:in_edges(G, F) == [] andalso maybe_rm_vertex(G, F),
+            false
+    end.
 
 %% This can be implemented using smarter trie, but since the
 %%  whole procedure is rare, don't bother with optimisations.

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -1563,7 +1563,19 @@ umbrella_mib_first_test(Config) ->
     true = filelib:is_file(filename:join([AppDir, "include", "AIMPORTER-MIB.hrl"])),
 
     %% check the mibs dir was linked into the _build dir
-    true = filelib:is_dir(filename:join([AppsDir, "_build", "default", "lib", Name, "mibs"])).
+    true = filelib:is_dir(filename:join([AppsDir, "_build", "default", "lib", Name, "mibs"])),
+
+    %% Check that files are tracked and not rebuilt multiple times
+    BinMod = filelib:last_modified(filename:join([PrivMibsDir, "AIMPORTER-MIB.bin"])),
+    HrlMod = filelib:last_modified(filename:join([AppDir, "include", "AIMPORTER-MIB.hrl"])),
+    timer:sleep(1000),
+
+    rebar_test_utils:run_and_check(Config, SuccessRebarConfig, ["compile"], {ok, [{app, Name}]}),
+
+    ?assertEqual(BinMod, filelib:last_modified(filename:join([PrivMibsDir, "AIMPORTER-MIB.bin"]))),
+    ?assertEqual(HrlMod, filelib:last_modified(filename:join([AppDir, "include", "AIMPORTER-MIB.hrl"]))),
+
+    ok.
 
 deps_mib_test() ->
     [{doc, "reproduces the dependency handling required for the issue "


### PR DESCRIPTION
This has two parts:

1.  Fix extension matching in compiler DAG

Turns out this didn't work! Now it does. The check of edge acted as a
workaround that prevented clearing more files than necessary, but when
multiple output artifacts existed, it over-deleted them, apparently.

So now this is properly checked as a bit of logic and all tests keep
passing.

2.  Track and match MIB file build artifacts in DAG

This allows incremental builds with these files.