### PR TITLE
Properly carry overlay_vars settings for files in relx

### DIFF
--- a/src/rebar_relx.erl
+++ b/src/rebar_relx.erl
@@ -36,7 +36,7 @@ do(Provider, State) ->
     DefaultOutputDir = filename:join(rebar_dir:base_dir(State), ?DEFAULT_RELEASE_DIR),
     RelxConfig1 = RelxMode ++ [output_dir(DefaultOutputDir, Opts),
                                {overlay_vars_values, ExtraOverlays},
-                               {overlay_vars, [{base_dir, rebar_dir:base_dir(State)} | overlay_vars(Opts)]}
+                               {overlay_vars, [{base_dir, rebar_dir:base_dir(State)} | overlay_vars(RelxConfig, Opts)]}
                                | merge_overlays(RelxConfig)],
 
     Args = [include_erts, system_libs, vm_args, sys_config],
@@ -219,10 +219,9 @@ merge_overlays(Config) ->
     NewOverlay = lists:flatmap(fun({overlay, Overlay}) -> Overlay end, lists:reverse(Overlays)),
     [{overlay, NewOverlay} | Others].
 
-overlay_vars(Opts) ->
-    case proplists:get_value(overlay_vars, Opts) of
-        undefined ->
-            [];
+overlay_vars(RelxConfig, Opts) ->
+    case proplists:get_value(overlay_vars, Opts, []) ++
+         proplists:get_value(overlay_vars, RelxConfig, []) of
         [] ->
             [];
         FileName when is_list(FileName) ->

--- a/test/rebar_release_SUITE.erl
+++ b/test/rebar_release_SUITE.erl
@@ -242,7 +242,7 @@ profile_overlays(Config) ->
                             {copy, filename:join(AppDir,"./dev.file"), "{{env}}.file"},
                             {chmod, 8#00770, "profile.file"}]},
                  {lib_dirs, [AppDir]}]},
-         {profiles, [{prod, 
+         {profiles, [{prod,
             [{relx, [
                 {debug_info, keep},
                 {overlay_vars, filename:join(AppDir, "prod.vars")},
@@ -250,7 +250,6 @@ profile_overlays(Config) ->
                            {copy, filename:join(AppDir, "./prod.file"), "{{env}}.file"},
                            {copy, filename:join(AppDir, "./prod.file"), "profile.file"},
                            {chmod, 8#00770, "profile.file"}]}
-            
             ]}]
          }]}
         ])),


### PR DESCRIPTION
Without fetching the value otherwise, we ended up with a broken partial config like this:

                    [{output_dir,"/tmp/rc_example/_build/dev1/rel"},
                     {overlay_vars_values,[{profile_string,"dev1"}]},
                     {overlay_vars, [{base_dir,"/tmp/rc_example/_build/dev1"}},
                     {overlay,
                         [{template,"conf/sys.config",
                              "releases/{{default_release_version}}/sys.config"},
                          {template,"conf/vm.args",
                              "releases/{{default_release_version}}/vm.args"}]},
                     {dev_mode,true},
                     {extended_start_script,false},
                     {include_erts,false},
                     {overlay_vars,"conf/vars_dev1.config"},
                     {release,{rc_example,"0.1.0"},[rc_example]},
                     {sys_config,"conf/sys.config"},
                     {vm_args,"conf/vm.args"}]

Since the `overlay_vars` key was there twice, only the first one was consulted and the rest was ignored. The new format instead looks like this:

                    [{output_dir,"/tmp/rc_example/_build/dev1/rel"},
                     {overlay_vars_values,[{profile_string,"dev1"}]},
                     {overlay_vars,
                         [{base_dir,"/tmp/rc_example/_build/dev1"},
                          "conf/vars_dev1.config"]},
                     {overlay,
                         [{template,"conf/sys.config",
                              "releases/{{default_release_version}}/sys.config"},
                          {template,"conf/vm.args",
                              "releases/{{default_release_version}}/vm.args"}]},
                     {dev_mode,true},
                     {extended_start_script,false},
                     {include_erts,false},
                     {overlay_vars,"conf/vars_dev1.config"},
                     {release,{rc_example,"0.1.0"},[rc_example]},
                     {sys_config,"conf/sys.config"},
                     {vm_args,"conf/vm.args"}]

Should fix https://github.com/erlang/rebar3/issues/2710