### PR TITLE
Support local plugins with `is_umbrella` settings

### DIFF
--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -16,6 +16,7 @@
 -define(DEFAULT_ROOT_DIR, ".").
 -define(DEFAULT_PROJECT_APP_DIRS, ["apps/*", "lib/*", "."]).
 -define(DEFAULT_PROJECT_PLUGIN_DIRS, ["plugins/*"]).
+-define(DEFAULT_UMBRELLA, false).
 -define(DEFAULT_CHECKOUTS_DIR, "_checkouts").
 -define(DEFAULT_CHECKOUTS_OUT_DIR, "checkouts").
 -define(DEFAULT_DEPS_DIR, "lib").

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -231,12 +231,17 @@ is_umbrella(State) ->
     %% So what we do here is look for the library directories without the ".",
     %% and if none of these paths exist but one of the src_dirs exist, then
     %% we know this is not an umbrella application.
-    Root = rebar_dir:root_dir(State),
-    LibPaths = lists:usort(rebar_dir:lib_dirs(State)) -- ["."],
-    SrcPaths = rebar_dir:src_dirs(rebar_state:opts(State), ["src"]),
-    lists:any(fun(Dir) -> [] == filelib:wildcard(filename:join(Root, Dir)) end, LibPaths)
-    andalso
-    lists:all(fun(Dir) -> not filelib:is_dir(filename:join(Root, Dir)) end, SrcPaths).
+    case rebar_dir:lib_dirs(State) of
+        ?DEFAULT_PROJECT_APP_DIRS ->
+            Root = rebar_dir:root_dir(State),
+            LibPaths = lists:usort(rebar_dir:lib_dirs(State)) -- ["."],
+            SrcPaths = rebar_dir:src_dirs(rebar_state:opts(State), ["src"]),
+            lists:any(fun(Dir) -> [] == filelib:wildcard(filename:join(Root, Dir)) end, LibPaths)
+                andalso
+            lists:all(fun(Dir) -> not filelib:is_dir(filename:join(Root, Dir)) end, SrcPaths);
+        _ ->
+            true
+    end.
 
 prepare_plugin(AppInfo) ->
     %% We need to handle plugins as dependencies to avoid re-building them

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -231,15 +231,15 @@ is_umbrella(State) ->
     %% So what we do here is look for the library directories without the ".",
     %% and if none of these paths exist but one of the src_dirs exist, then
     %% we know this is not an umbrella application.
-    case rebar_dir:lib_dirs(State) of
-        ?DEFAULT_PROJECT_APP_DIRS ->
+    case rebar_state:get(State, is_umbrella, ?DEFAULT_UMBRELLA) of
+        ?DEFAULT_UMBRELLA ->
             Root = rebar_dir:root_dir(State),
             LibPaths = lists:usort(rebar_dir:lib_dirs(State)) -- ["."],
             SrcPaths = rebar_dir:src_dirs(rebar_state:opts(State), ["src"]),
             lists:any(fun(Dir) -> [] == filelib:wildcard(filename:join(Root, Dir)) end, LibPaths)
-                andalso
+            andalso
             lists:all(fun(Dir) -> not filelib:is_dir(filename:join(Root, Dir)) end, SrcPaths);
-        _ ->
+        true ->
             true
     end.
 


### PR DESCRIPTION
Is it possible to read the `{project_app_dirs, ["src/*"]}` setting
and treat it as a proper umbrella project to use local plugins?

Issue: https://github.com/erlang/rebar3/issues/2712