### PR TITLE
Dereference symbolic links when copying files from ct data folder

### DIFF
--- a/apps/rebar/src/rebar_file_utils.erl
+++ b/apps/rebar/src/rebar_file_utils.erl
@@ -150,7 +150,7 @@ win32_symlink_or_copy(Source, Target) ->
             [{use_stdout, false}, return_on_error]),
     case win32_mklink_ok(Res, Target) of
         true -> ok;
-        false -> cp_r_win32(Source, drop_last_dir_from_path(Target))
+        false -> cp_r_win32(Source, drop_last_dir_from_path(Target), [])
     end.
 
 %% @private specifically pattern match against the output
@@ -251,7 +251,7 @@ cp_r(Sources, Dest, Options) ->
                                       [{use_stdout, true}, abort_on_error]),
             ok;
         {win32, _} ->
-            lists:foreach(fun(Src) -> ok = cp_r_win32(Src,Dest) end, Sources),
+            lists:foreach(fun(Src) -> ok = cp_r_win32(Src,Dest,Options) end, Sources),
             ok
     end.
 
@@ -548,9 +548,24 @@ delete_each_dir_win32([Dir | Rest]) ->
                               [{use_stdout, false}, return_on_error]),
     delete_each_dir_win32(Rest).
 
-xcopy_win32(Source,Dest)->
+xcopy_win32(Source,Dest, Options)->
     %% "xcopy \"~ts\" \"~ts\" /q /y /e 2> nul", Changed to robocopy to
     %% handle long names. May have issues with older windows.
+    
+    CopySubdirectories = "/e",
+    DontFollow = "/sl",
+    
+    Opt = [CopySubdirectories],
+    % By default Windows follows symbolic links except if the "/sl" options is given.
+    % Add "/sl" for default so it doesn't follow symbolic links and behaves more like unix
+    OptStr = case proplists:get_value(dereference, Options, false) of
+        true -> 
+            string:join(Opt, " ");
+        false -> 
+            % Default option
+            string:join([DontFollow|Opt], " ")
+    end,
+
     Cmd = case filelib:is_dir(Source) of
               true ->
                   %% For robocopy, copying /a/b/c/ to /d/e/f/ recursively does not
@@ -559,14 +574,16 @@ xcopy_win32(Source,Dest)->
                   %% must manually add the last fragment of a directory to the `Dest`
                   %% in order to properly replicate POSIX platforms
                   NewDest = filename:join([Dest, filename:basename(Source)]),
-                  ?FMT("robocopy \"~ts\" \"~ts\" /e 1> nul",
+                  ?FMT("robocopy \"~ts\" \"~ts\" ~s 1> nul",
                        [rebar_utils:escape_double_quotes(filename:nativename(Source)),
-                        rebar_utils:escape_double_quotes(filename:nativename(NewDest))]);
+                        rebar_utils:escape_double_quotes(filename:nativename(NewDest)),
+                        OptStr]);
               false ->
-                  ?FMT("robocopy \"~ts\" \"~ts\" \"~ts\" /e 1> nul",
+                  ?FMT("robocopy \"~ts\" \"~ts\" \"~ts\" ~s 1> nul",
                        [rebar_utils:escape_double_quotes(filename:nativename(filename:dirname(Source))),
                         rebar_utils:escape_double_quotes(filename:nativename(Dest)),
-                        rebar_utils:escape_double_quotes(filename:basename(Source))])
+                        rebar_utils:escape_double_quotes(filename:basename(Source)),
+                        OptStr])
           end,
     Res = rebar_utils:sh(Cmd,
                 [{use_stdout, false}, return_on_error]),
@@ -578,21 +595,32 @@ xcopy_win32(Source,Dest)->
                                             [Source, Dest]))}
     end.
 
-cp_r_win32({true, SourceDir}, {true, DestDir}) ->
+cp_r_win32({true, SourceDir}, {true, DestDir}, Options) ->
     %% from directory to directory
      ok = case file:make_dir(DestDir) of
              {error, eexist} -> ok;
              Other -> Other
          end,
-    ok = xcopy_win32(SourceDir, DestDir);
-cp_r_win32({false, Source} = S,{true, DestDir}) ->
+    ok = xcopy_win32(SourceDir, DestDir, Options);
+cp_r_win32({false, Source} = S,{true, DestDir}, Options) ->
     %% from file to directory
-    cp_r_win32(S, {false, filename:join(DestDir, filename:basename(Source))});
-cp_r_win32({false, Source},{false, Dest}) ->
+    cp_r_win32(S, {false, filename:join(DestDir, filename:basename(Source))}, Options);
+cp_r_win32({false, Source},{false, Dest}, Options) ->
     %% from file to file
-    {ok,_} = file:copy(Source, Dest),
+    case file:read_link(Source) of
+        {ok, OriginalFile} -> case proplists:get_value(dereference, Options, false) of
+            true ->
+                {ok, _} = file:copy(Source, Dest),
+                ok;
+            false -> 
+                file:make_symlink(OriginalFile, Dest)
+            end;
+        _ -> 
+            {ok, _} = file:copy(Source, Dest),
+            ok
+    end,
     ok;
-cp_r_win32({true, SourceDir}, {false, DestDir}) ->
+cp_r_win32({true, SourceDir}, {false, DestDir}, Options) ->
     case filelib:is_regular(DestDir) of
         true ->
             %% From directory to file? This shouldn't happen
@@ -604,16 +632,16 @@ cp_r_win32({true, SourceDir}, {false, DestDir}) ->
             %% So let's attempt to create this directory
             case ensure_dir(DestDir) of
                 ok ->
-                    ok = xcopy_win32(SourceDir, DestDir);
+                    ok = xcopy_win32(SourceDir, DestDir, Options);
                 {error, Reason} ->
                     {error, lists:flatten(
                               io_lib:format("Unable to create dir ~p: ~p\n",
                                             [DestDir, Reason]))}
             end
     end;
-cp_r_win32(Source,Dest) ->
+cp_r_win32(Source, Dest, Options) ->
     Dst = {filelib:is_dir(Dest), Dest},
     lists:foreach(fun(Src) ->
-                          ok = cp_r_win32({filelib:is_dir(Src), Src}, Dst)
+                          ok = cp_r_win32({filelib:is_dir(Src), Src}, Dst, Options)
                   end, filelib:wildcard(Source)),
     ok.

--- a/apps/rebar/src/rebar_prv_common_test.erl
+++ b/apps/rebar/src/rebar_prv_common_test.erl
@@ -621,7 +621,7 @@ copy_bare_suites(From, To) ->
     DataDirs = lists:filter(fun filelib:is_dir/1,
                             filelib:wildcard(filename:join([From, "*_SUITE_data"]))),
     ok = rebar_file_utils:cp_r(SrcFiles, To),
-    rebar_file_utils:cp_r(DataDirs, To, true).
+    rebar_file_utils:cp_r(DataDirs, To, [{dereference, true}]).
 
 maybe_copy_spec(State, [App|Apps], Spec) ->
     case rebar_file_utils:path_from_ancestor(filename:dirname(Spec), rebar_app_info:dir(App)) of

--- a/apps/rebar/src/rebar_prv_common_test.erl
+++ b/apps/rebar/src/rebar_prv_common_test.erl
@@ -621,7 +621,7 @@ copy_bare_suites(From, To) ->
     DataDirs = lists:filter(fun filelib:is_dir/1,
                             filelib:wildcard(filename:join([From, "*_SUITE_data"]))),
     ok = rebar_file_utils:cp_r(SrcFiles, To),
-    rebar_file_utils:cp_r(DataDirs, To).
+    rebar_file_utils:cp_r(DataDirs, To, true).
 
 maybe_copy_spec(State, [App|Apps], Spec) ->
     case rebar_file_utils:path_from_ancestor(filename:dirname(Spec), rebar_app_info:dir(App)) of


### PR DESCRIPTION
When running `rebar3 ct`, `rebar_prv_common_test` copies the data folders
to a different location. If `{name}_SUITE_data` folder contains relative
symbolic links, the symbolic links might stop working since the path
might be different.

A solution is to add the `-L` option to `cp` so it dereferences the
symbolic links and copies the original content in the target file.

This is only done for the data folder but and won't change any code that
previously used `rebar_file_utils:cp_r`.

I asked in [erlangforum](https://erlangforums.com/t/what-is-the-best-way-of-providing-test-data-from-outside-the-suite-data-folder/1650) a few days ago because I thought it was `common test`
problem but today I realised that is rebar3 copying the files.

I'm not sure if this problem happens with Windows too since I don't have
any computer with it installed.

I'm not 100% sure about if this change will be wanted so I did a quick
implementation to discuss it.

Thank you