### PR TITLE
Reduce warnings around bootstrap and DAG operations

### DIFF
--- a/apps/rebar/src/rebar_compiler_erl.erl
+++ b/apps/rebar/src/rebar_compiler_erl.erl
@@ -301,6 +301,10 @@ compile_info(Target) ->
             CompileVsn = proplists:get_value(version, CompileInfo, "unknown"),
             {ok, [{compiler_version, CompileVsn}
                   | proplists:get_value(options, CompileInfo, [])]};
+        {error, beam_lib, {file_error, _, enoent}=Reason} ->
+            %% It's normal not to find a given file if this is a first build
+            ?DEBUG("Couldn't read debug info from ~p for reason: ~p", [Target, Reason]),
+            {error, Reason};
         {error, beam_lib, Reason} ->
             ?WARN("Couldn't read debug info from ~p for reason: ~p", [Target, Reason]),
             {error, Reason}

--- a/bootstrap
+++ b/bootstrap
@@ -32,10 +32,8 @@ main(Args) ->
     rm_rf("_build/prod"),
     %% The same pattern happens with default/ as well, particularly when
     %% developing new things.
-    %% Keep other deps in <profile>/lib for build environments like Nix
-    %% where internet access is disabled that deps are not downloadable.
-    rm_rf("_build/default/lib/rebar"),
-    rm_rf("_build/test/lib/rebar"),
+    rm_rf("_build/default/"),
+    rm_rf("_build/test/"),
 
     filelib:ensure_dir("_build/bootstrap/lib/rebar/ebin/"),
 


### PR DESCRIPTION
1. It's normal not to find a file in the DAG nor on disk when it has
   never been built before
2. The bootstrap deletion can be more aggressive since there's
   vendoring, and will prevent straggling file issues.