### PR TITLE
Warn of EUnit issues on OTP-25.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,14 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [23, 24, 25]
+        otp_version: [23, 24, 25.0]
         os: [ubuntu-latest]
 
     container:
       image: erlang:${{ matrix.otp_version }}
 
     env:
-      LATEST_OTP_RELEASE: 25
+      LATEST_OTP_RELEASE: 25.0
 
     steps:
     - uses: actions/checkout@v2

--- a/apps/rebar/src/rebar_prv_eunit.erl
+++ b/apps/rebar/src/rebar_prv_eunit.erl
@@ -40,6 +40,7 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
+    warn_version(),
     Tests = prepare_tests(State),
     %% inject `eunit_first_files`, `eunit_compile_opts` and any
     %% directories required by tests into the applications
@@ -114,6 +115,19 @@ format_error({error, Error}) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
+
+warn_version() ->
+    application:start(eunit),
+    case application:get_key(eunit, vsn) of
+        {ok, "2.8"} ->
+            %% See https://github.com/erlang/otp/pull/6322
+            ?WARN("The EUnit version 2.8 (OTP-25.1) contains a "
+                  "regression in its interface that may cause "
+                  "runtime errors. Older or newer versions are "
+                  "not impacted.", []);
+        _ ->
+            ok
+    end.
 
 setup_name(State) ->
     {Long, Short, Opts} = rebar_dist_utils:find_options(State),


### PR DESCRIPTION
The regression was added there and is fixed in the upcoming 25.1.1 release. All other cases are fine.

The code is untested because we can't run our own tests on 25.1 without failures, so just skip it entirely.