### PR TITLE
Respect HEX_MIRROR environment variable

### DIFF
--- a/apps/rebar/src/rebar3.erl
+++ b/apps/rebar/src/rebar3.erl
@@ -132,7 +132,7 @@ run_aux(State, RawArgs) ->
     rebar_utils:check_blacklisted_otp_versions(rebar_state:get(State1, blacklisted_otp_vsns, undefined)),
 
     %% Maybe change the default hex CDN
-    State2 = case os:getenv("HEX_CDN", "") of
+    State2 = case hex_cdn() of
                  "" ->
                      State1;
                  CDN ->
@@ -486,3 +486,14 @@ test_defined([{d, 'TEST'}|_]) -> true;
 test_defined([{d, 'TEST', true}|_]) -> true;
 test_defined([_|Rest]) -> test_defined(Rest);
 test_defined([]) -> false.
+
+-spec hex_cdn() -> os:env_var_value().
+hex_cdn() ->
+    case os:getenv("HEX_CDN") of
+        false ->
+            %% Checking HEX_MIRROR can be useful when compiling dependencies
+            %% in a project managed by Mix.
+            os:getenv("HEX_MIRROR", "");
+        CDN ->
+            CDN
+    end.


### PR DESCRIPTION
Mix and Hex don't use HEX_CDN for a long time.  Mix can run Rebar3 to compile dependencies.  To complete this Rebar3 may need to fetch plugins.  It would be nice to specify Hex mirror for both Mix/Hex and Rebar3 using one variable.

Can we deprecate HEX_CDN in favor of HEX_MIRROR? If so, I can update PR.