### PR TITLE
scope local install VSN variable

### DIFF
--- a/apps/rebar/src/rebar_prv_local_install.erl
+++ b/apps/rebar/src/rebar_prv_local_install.erl
@@ -65,8 +65,8 @@ format_error(Reason) ->
 bin_contents(OutputDir, Vsn) ->
     <<"#!/usr/bin/env sh
 ## Rebar3 ", (iolist_to_binary(Vsn))/binary, "
-VSN=${VSN:-", (iolist_to_binary(Vsn))/binary, "}
-erl -pz ", (rebar_utils:to_binary(OutputDir))/binary,"/${VSN}/lib/*/ebin +sbtu +A1 -noshell -boot start_clean -s rebar3 main $REBAR3_ERL_ARGS -extra \"$@\"
+REBAR3_VSN=${REBAR3_VSN:-", (iolist_to_binary(Vsn))/binary, "}
+erl -pz ", (rebar_utils:to_binary(OutputDir))/binary,"/${REBAR3_VSN}/lib/*/ebin +sbtu +A1 -noshell -boot start_clean -s rebar3 main $REBAR3_ERL_ARGS -extra \"$@\"
 ">>.
 
 extract_escript(State, ScriptPath) ->


### PR DESCRIPTION
See https://github.com/erlang/rebar3/issues/2751

By default we use the `VSN` variable and let it be overridden. But that variable is not prefixed to anything rebar3 so unrelated variables from random scripts are possible to break by doing this. 

I believe `VSN` is not documented anywhere, so we should be safe in changing it  right away.

CC @tsloughter