### PR TITLE
Improve completion for bash

### DIFF
--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -67,6 +67,7 @@ _rebar3()
             experimental \
             help \
             hex \
+            local \
             new \
             path \
             pkgs \
@@ -156,6 +157,11 @@ _rebar3()
             retire \
             search \
             user \
+            "
+    elif [[ ${prev} == local ]] ; then
+        cmdsnvars=" \
+            install \
+            upgrade \
             "
     elif [[ ${prev} == new ]] ; then
         sopts="-f"
@@ -281,6 +287,7 @@ _rebar3()
             experimental \
             help \
             hex \
+            local \
             new \
             path \
             pkgs \

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -89,8 +89,8 @@ _rebar3()
         get_profiles
         cmdsnvars="$profiles"
     elif [[ ${prev} == clean ]] ; then
-        sopts="-a"
-        lopts="--all"
+        sopts="-a -p"
+        lopts="--all --profile"
     elif [[ ${prev} == compile ]] ; then
         :
     elif [[ ${prev} == cover ]] ; then
@@ -305,6 +305,10 @@ _rebar3()
             version \
             xref \
             "
+    elif [[ ${first} == clean && (${prev} == "--profile" ||
+                                  ${prev} == "-p") ]] ; then
+        get_profiles
+        cmdsnvars="${profiles}"
     fi
 
     COMPREPLY=( $(compgen -W "${sopts} ${lopts} ${cmdsnvars}" -- ${cur}) )

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -19,7 +19,7 @@ _rebar3()
 
         if [ -f "$rebarconf" ]; then
             profconfig=$( cat "$rebarconf" \
-                          | grep -oPz '(?s){profiles.*?(?<=\.)' \
+                          | grep -oPz '(?s){profiles,\s*(\r\n)*\n*\r*\[\s*(\r\n)*\n*\r*.*?(?<=\s*(\r\n)*\n*\r*\}\s*(\r\n)*\n*\r*\.)' \
                           | tr -d '\0' \
                           | tr -d '\n' )
         fi

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -9,19 +9,38 @@ _rebar3()
     prev="${COMP_WORDS[curindex-1]}"
     first="${COMP_WORDS[1]}"
 
-    get_config_regex()
-    {
-        eval "$1=\"(?:{\s*$2\s*,\s*(\r\n)*\n*\r*\[).*?(?:\s*(\r\n)*\n*\r*}\s*(\r\n)*\n*\r*\.)\""
-    }
-
     get_config()
     {
-        local regex
-        get_config_regex regex "$3"
         eval "$1=\"$( cat $2 \
-                  | grep -oPz "(?s)${regex}" \
-                  | tr -d '\0' \
-                  | tr -d '\n' )\""
+                    | grep -oPz "(?s)(?:{\s*$3\s*,\s*(\r\n)*\n*\r*\[).*?(?:\s*(\r\n)*\n*\r*}\s*(\r\n)*\n*\r*\.)" \
+                    | tr -d '\0' \
+                    | tr -d '\n' \
+                    | grep -oPz '(?s)(?<=\[).*(?=\])' \
+                    | tr -d '\0' \
+                    | sed -e 's/^[[:space:]]*//' )\""
+    }
+
+    get_config_keys()
+    {
+        local picking acc key ch depth=0
+
+        while read -n1 ch; do
+            if [[ $depth == 0 && $ch == "{" ]]; then
+                picking=true
+            elif [[ $picking && ($ch == "," || $ch == " ") ]]; then
+                acc+=" $key"
+                unset key
+                unset picking
+            elif [[ $picking ]]; then
+                key+="$ch"
+            elif [[ $ch == "]" ]]; then
+                ((depth++))
+            elif [[ $ch == "[" ]]; then
+                ((depth--))
+            fi
+        done < <( echo -n "$1" )
+
+        eval "$2=\"${acc}\""
     }
 
     get_profiles()
@@ -30,32 +49,14 @@ _rebar3()
             return
         fi
 
-        local profconfig depth profile naming ch
+        local profconfig
 
         if [ -f "$rebarconf" ]; then
             get_config profconfig "${rebarconf}" "profiles"
         fi
 
         if [ -n "$profconfig" ]; then
-            depth=0;
-            while read -n1 ch; do
-                if [[ $depth == 0 && $ch == "{" ]]; then
-                    naming=true
-                elif [[ $naming && ($ch == "," || $ch == " ") ]]; then
-                    profiles+=" $profile"
-                    unset profile
-                    unset naming
-                elif [[ $naming ]]; then
-                    profile+="$ch"
-                elif [[ $ch == "]" ]]; then
-                    ((depth++))
-                elif [[ $ch == "[" ]]; then
-                    ((depth--))
-                fi
-            done < <( echo -n "$profconfig" \
-                      | grep -oPz '(?s)(?<=\[).*(?=\])' \
-                      | tr -d '\0' \
-                      | sed -e 's/^[[:space:]]*//' )
+            get_config_keys "${profconfig}" profiles
         else
             profiles="default"
         fi

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -4,8 +4,10 @@ _rebar3()
 {
     local cur prev sopts lopts cmdsnvars profiles rebarconf="rebar.config"
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    curindex="${COMP_CWORD}"
+    cur="${COMP_WORDS[curindex]}"
+    prev="${COMP_WORDS[curindex-1]}"
+    first="${COMP_WORDS[1]}"
 
     get_profiles()
     {
@@ -247,6 +249,36 @@ _rebar3()
         :
     elif [[ ${prev} == xref ]] ; then
         :
+    elif [[ ${first} == as && ${curindex} == 3 ]] ; then
+        cmdsnvars=" \
+            clean \
+            compile \
+            cover \
+            ct \
+            deps \
+            dialyzer \
+            do \
+            edoc \
+            escriptize \
+            eunit \
+            help \
+            new \
+            path \
+            pkgs \
+            plugins \
+            release \
+            relup \
+            report \
+            shell \
+            tar \
+            tree \
+            unlock \
+            unstable \
+            update \
+            upgrade \
+            version \
+            xref \
+            "
     fi
 
     COMPREPLY=( $(compgen -W "${sopts} ${lopts} ${cmdsnvars}" -- ${cur}) )

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -15,7 +15,7 @@ _rebar3()
             return
         fi
 
-        local profconfig depth profile namming ch
+        local profconfig depth profile naming ch
 
         if [ -f "$rebarconf" ]; then
             profconfig=$( cat "$rebarconf" \
@@ -28,12 +28,12 @@ _rebar3()
             depth=0;
             while read -n1 ch; do
                 if [[ $depth == 0 && $ch == "{" ]]; then
-                    namming=true
-                elif [[ $namming && ($ch == "," || $ch == " ") ]]; then
+                    naming=true
+                elif [[ $naming && ($ch == "," || $ch == " ") ]]; then
                     profiles+=" $profile"
                     unset profile
-                    unset namming
-                elif [[ $namming ]]; then
+                    unset naming
+                elif [[ $naming ]]; then
                     profile+="$ch"
                 elif [[ $ch == "]" ]]; then
                     ((depth++))

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -2,10 +2,50 @@
 
 _rebar3()
 {
-    local cur prev sopts lopts cmdsnvars
+    local cur prev sopts lopts cmdsnvars profiles rebarconf="rebar.config"
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    get_profiles()
+    {
+        if [ -n "${profiles}" ]; then
+            return
+        fi
+
+        local profconfig depth profile namming ch
+
+        if [ -f "$rebarconf" ]; then
+            profconfig=$( cat "$rebarconf" \
+                          | grep -oPz '(?s){profiles.*?(?<=\.)' \
+                          | tr -d '\0' \
+                          | tr -d '\n' )
+        fi
+
+        if [ -n "$profconfig" ]; then
+            depth=0;
+            while read -n1 ch; do
+                if [[ $depth == 0 && $ch == "{" ]]; then
+                    namming=true
+                elif [[ $namming && ($ch == "," || $ch == " ") ]]; then
+                    profiles+=" $profile"
+                    unset profile
+                    unset namming
+                elif [[ $namming ]]; then
+                    profile+="$ch"
+                elif [[ $ch == "]" ]]; then
+                    ((depth++))
+                elif [[ $ch == "[" ]]; then
+                    ((depth--))
+                fi
+            done < <( echo -n "$profconfig" \
+                      | grep -oPz '(?s)(?<=\[).*(?=\])' \
+                      | tr -d '\0' \
+                      | sed -e 's/^[[:space:]]*//' )
+        else
+            profiles="default"
+        fi
+    }
 
     if [[ ${prev} == rebar3 ]] ; then
         sopts="-h -v"
@@ -41,7 +81,8 @@ _rebar3()
             xref \
             "
     elif [[ ${prev} == as ]] ; then
-        :
+        get_profiles
+        cmdsnvars="$profiles"
     elif [[ ${prev} == clean ]] ; then
         sopts="-a"
         lopts="--all"

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -12,6 +12,7 @@ _rebar3()
     get_config()
     {
         eval "$3=\"$( cat $1 \
+                    | grep -v '\s*%.*' \
                     | grep -oPz "(?s)(?:{\s*$2\s*,\s*(\r\n)*\n*\r*\[).*?(?:\s*(\r\n)*\n*\r*}\s*(\r\n)*\n*\r*\.)" \
                     | tr -d '\0' \
                     | tr -d '\n' \

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -64,6 +64,7 @@ _rebar3()
             edoc \
             escriptize \
             eunit \
+            experimental \
             help \
             new \
             path \
@@ -138,6 +139,10 @@ _rebar3()
     elif [[ ${prev} == eunit ]] ; then
         sopts="-c -e -v -d -f -m -s -g"
         lopts="--app --application --cover --dir --error_on_warning --file --module --suite --generator --verbose"
+    elif [[ ${prev} == experimental ]] ; then
+        cmdsnvars=" \
+            vendor \
+            "
     elif [[ ${prev} == help ]] ; then
         :
     elif [[ ${prev} == new ]] ; then
@@ -261,6 +266,7 @@ _rebar3()
             edoc \
             escriptize \
             eunit \
+            experimental \
             help \
             new \
             path \

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -66,6 +66,7 @@ _rebar3()
             eunit \
             experimental \
             help \
+            hex \
             new \
             path \
             pkgs \
@@ -145,6 +146,17 @@ _rebar3()
             "
     elif [[ ${prev} == help ]] ; then
         :
+    elif [[ ${prev} == hex ]] ; then
+        cmdsnvars=" \
+            build \
+            cut \
+            organization \
+            owner \
+            publish \
+            retire \
+            search \
+            user \
+            "
     elif [[ ${prev} == new ]] ; then
         sopts="-f"
         lopts="--force"
@@ -268,6 +280,7 @@ _rebar3()
             eunit \
             experimental \
             help \
+            hex \
             new \
             path \
             pkgs \

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -2,7 +2,7 @@
 
 _rebar3()
 {
-    local cur prev sopts lopts cmdsnvars profiles rebarconf="rebar.config"
+    local cur prev sopts lopts cmdsnvars profiles rebarconfig="rebar.config"
     COMPREPLY=()
     curindex="${COMP_CWORD}"
     cur="${COMP_WORDS[curindex]}"
@@ -11,8 +11,8 @@ _rebar3()
 
     get_config()
     {
-        eval "$1=\"$( cat $2 \
-                    | grep -oPz "(?s)(?:{\s*$3\s*,\s*(\r\n)*\n*\r*\[).*?(?:\s*(\r\n)*\n*\r*}\s*(\r\n)*\n*\r*\.)" \
+        eval "$3=\"$( cat $1 \
+                    | grep -oPz "(?s)(?:{\s*$2\s*,\s*(\r\n)*\n*\r*\[).*?(?:\s*(\r\n)*\n*\r*}\s*(\r\n)*\n*\r*\.)" \
                     | tr -d '\0' \
                     | tr -d '\n' \
                     | grep -oPz '(?s)(?<=\[).*(?=\])' \
@@ -22,20 +22,20 @@ _rebar3()
 
     get_config_keys()
     {
-        local picking acc key ch depth=0
+        local ch picking key acc depth=0
 
         while read -n1 ch; do
-            if [[ $depth == 0 && $ch == "{" ]]; then
+            if [[ ${depth} == 0 && ${ch} == "{" ]]; then
                 picking=true
-            elif [[ $picking && ($ch == "," || $ch == " ") ]]; then
-                acc+=" $key"
+            elif [[ ${picking} && (${ch} == "," || ${ch} == " ") ]]; then
+                acc+=" ${key}"
                 unset key
                 unset picking
-            elif [[ $picking ]]; then
-                key+="$ch"
-            elif [[ $ch == "]" ]]; then
+            elif [[ ${picking} ]]; then
+                key+="${ch}"
+            elif [[ ${ch} == "]" ]]; then
                 ((depth++))
-            elif [[ $ch == "[" ]]; then
+            elif [[ ${ch} == "[" ]]; then
                 ((depth--))
             fi
         done < <( echo -n "$1" )
@@ -49,14 +49,14 @@ _rebar3()
             return
         fi
 
-        local profconfig
+        local profilesconfig
 
-        if [ -f "$rebarconf" ]; then
-            get_config profconfig "${rebarconf}" "profiles"
+        if [ -f "$rebarconfig" ]; then
+            get_config "${rebarconfig}" "profiles" profilesconfig
         fi
 
-        if [ -n "$profconfig" ]; then
-            get_config_keys "${profconfig}" profiles
+        if [ -n "$profilesconfig" ]; then
+            get_config_keys "${profilesconfig}" profiles
         else
             profiles="default"
         fi

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -182,7 +182,10 @@ _rebar3()
     elif [[ ${prev} == pkgs ]] ; then
         :
     elif [[ ${prev} == plugins ]] ; then
-        :
+        cmdsnvars=" \
+            list \
+            upgrade \
+            "
     elif [[ ${prev} == release ]] ; then
         sopts="-n -v -g -u -o -h -l -p -V -d -i -a -c -r"
         lopts=" \

--- a/apps/rebar/priv/shell-completion/bash/rebar3
+++ b/apps/rebar/priv/shell-completion/bash/rebar3
@@ -9,6 +9,21 @@ _rebar3()
     prev="${COMP_WORDS[curindex-1]}"
     first="${COMP_WORDS[1]}"
 
+    get_config_regex()
+    {
+        eval "$1=\"(?:{\s*$2\s*,\s*(\r\n)*\n*\r*\[).*?(?:\s*(\r\n)*\n*\r*}\s*(\r\n)*\n*\r*\.)\""
+    }
+
+    get_config()
+    {
+        local regex
+        get_config_regex regex "$3"
+        eval "$1=\"$( cat $2 \
+                  | grep -oPz "(?s)${regex}" \
+                  | tr -d '\0' \
+                  | tr -d '\n' )\""
+    }
+
     get_profiles()
     {
         if [ -n "${profiles}" ]; then
@@ -18,10 +33,7 @@ _rebar3()
         local profconfig depth profile naming ch
 
         if [ -f "$rebarconf" ]; then
-            profconfig=$( cat "$rebarconf" \
-                          | grep -oPz '(?s){profiles,\s*(\r\n)*\n*\r*\[\s*(\r\n)*\n*\r*.*?(?<=\s*(\r\n)*\n*\r*\}\s*(\r\n)*\n*\r*\.)' \
-                          | tr -d '\0' \
-                          | tr -d '\n' )
+            get_config profconfig "${rebarconf}" "profiles"
         fi
 
         if [ -n "$profconfig" ]; then


### PR DESCRIPTION
This PR improves the completion for `bash`.

Currently the improvements are:
- Profiles completion: typing `rebar3 as <tab>` gives a list of the `rebar,config` profiles, same for `rebar3 clean --project/-p <tab>`

Any tips or comments about this are welcome.

_Note: For now I will do this for `bash`. Maybe in the future for `fish` and `zsh`._