### PR TITLE
Add RTX_LOG macro option to top-level rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,8 @@
 {escript_incl_priv, [{relx, "templates/*"},
                      {rebar, "templates/*"}]}.
 
+{overrides, [{add, relx, [{erl_opts, [{d, 'RLX_LOG', rebar_log}]}]}]}.
+
 {profiles, [
     %% Only works at the top-level
     {systest, [


### PR DESCRIPTION
Before this commit, `rebar3 release` outputs relx's info log without line breaks.
This commit adds RTX_LOG macro to relx's erl_opts.

Steps to reproduce:

1. `rebar3 new app foo`
2. `cd foo`
3. Append `{relx, [{release, {foo, "0.0.1"}, [kernel, sasl, stdlib, foo], []}]}.`
4. `rebar3 release`

At the step 4, expectation is that it outputs (reasonably) concise log lines, but it outputs:

```
% rebar3.head release
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling foo
Solving Release foo-0.0.1Resolved foo-0.0.1release: foo-0.0.1
     erts: 13.1.1
     goals:
          kernel
          sasl
          stdlib
          foo
     applications:
          {kernel,"8.5.1"}
          {stdlib,"4.1.1"}
          {sasl,"4.2"}
          {foo,"0.1.0"}
Assembling release foo-0.0.1...Release output dir /home/shino/g/rebar3/foo/_build/default/rel/fooRewriting .app file: /home/shino/g/rebar3/foo/_build/default/rel/foo/lib/kernel-8.5.1/ebin/kernel.appRewriting .app file: /home/shino/g/rebar3/foo/_build/default/rel/foo/lib/stdlib-4.1.1/ebin/stdlib.appRewriting .app file: /home/shino/g/rebar3/foo/_build/default/rel/foo/lib/sasl-4.2/ebin/sasl.appRewriting .app file: /home/shino/g/rebar3/foo/_build/default/rel/foo/lib/foo-0.1.0/ebin/foo.apprelease start script createdRelease successfully assembled: _build/default/rel/foo
```