### PR TITLE
Do not ignore everything starting with underscore recursively

### DIFF
--- a/apps/rebar/priv/templates/gitignore
+++ b/apps/rebar/priv/templates/gitignore
@@ -1,5 +1,6 @@
 .rebar3
-./_*
+_build
+_checkouts
 .eunit
 *.o
 *.beam
@@ -12,7 +13,6 @@ log
 erl_crash.dump
 .rebar
 logs
-_build
 .idea
 *.iml
 rebar3.crashdump

--- a/apps/rebar/priv/templates/gitignore
+++ b/apps/rebar/priv/templates/gitignore
@@ -1,5 +1,5 @@
 .rebar3
-_*
+./_*
 .eunit
 *.o
 *.beam


### PR DESCRIPTION
If you have other things in your project structure, e.g. `scripts/__main__.py` it would be ignored with the simple rule `_*` ("anything that starts with underscore anywhere").

It's better to use `./_*` meaning "anything that starts with underscore in the root folder (e.g. `_build`).