### PR TITLE
Ignore _vendor folder

### DIFF
--- a/apps/rebar/priv/templates/gitignore
+++ b/apps/rebar/priv/templates/gitignore
@@ -1,6 +1,7 @@
 .rebar3
 _build
 _checkouts
+_vendor
 .eunit
 *.o
 *.beam


### PR DESCRIPTION
This folder is created only as a backup of `vendor/` and for upgrading censored deps.

This is a follow-up to #2758.