### PR TITLE
fix help shell output, --eval is misindeted

### DIFF
--- a/apps/rebar/src/rebar_prv_shell.erl
+++ b/apps/rebar/src/rebar_prv_shell.erl
@@ -96,9 +96,9 @@ init(State) ->
                          "Arguments passed to user_drv start function for "
                          "creating custom shells."},
                         {eval, undefined, "eval", string,
-                         "Erlang term(s) to execute after the apps have been
-                          started, but before the shell is presented to the 
-                          user"}
+                         "Erlang term(s) to execute after the apps have been "
+                         "started, but before the shell is presented to the "
+                         "user"}
                     ]}
             ])
     ),

--- a/apps/rebar/src/rebar_prv_shell.erl
+++ b/apps/rebar/src/rebar_prv_shell.erl
@@ -98,7 +98,7 @@ init(State) ->
                         {eval, undefined, "eval", string,
                          "Erlang term(s) to execute after the apps have been "
                          "started, but before the shell is presented to the "
-                         "user"}
+                         "user."}
                     ]}
             ])
     ),


### PR DESCRIPTION
before this patch the output of `rebar3 help shell` looked like this:
```
  --eval           Erlang term(s) to execute after the apps have been
     
                                        started, but before the shell is 
                   presented to the 
                          user
```