### PR TITLE
Do not load applications from CT provider

### DIFF
--- a/.github/workflows/shelltests.yml
+++ b/.github/workflows/shelltests.yml
@@ -24,7 +24,8 @@ jobs:
         sudo cp ./rebar3 /usr/local/bin/
 
     - name: Checkout shell tests
-      run: git clone https://github.com/tsloughter/rebar3_tests
+      # FIXME: change to original repo before merge.
+      run: git clone -b ct/sys-config https://github.com/dmitrivereshchagin/rebar3_tests
 
     - name: Install and run shelltestrunner
       run: |

--- a/apps/rebar/src/rebar_prv_common_test.erl
+++ b/apps/rebar/src/rebar_prv_common_test.erl
@@ -307,10 +307,6 @@ select_tests(State, ProjectApps, CmdOpts, CfgOpts) ->
     Configs = lists:flatmap(fun(Filename) ->
                                 rebar_file_utils:consult_config(State, Filename)
                             end, SysConfigs),
-    %% NB: load the applications (from user directories too) to support OTP < 17
-    %% to our best ability.
-    rebar_paths:set_paths([deps, plugins], State),
-    [application:load(Application) || Config <- Configs, {Application, _} <- Config],
     rebar_utils:reread_config(Configs, [update_logger]),
 
     Opts = merge_opts(CmdOpts,CfgOpts),


### PR DESCRIPTION
Currenlty CT provider tries to load each application mentioned in `sys_config` files.  This may silently fail (and in most cases it does) if the application is not found in the code path.  At the same time a provider that we can run before CT can add the application directory into the code path and make it happen.

For exmaple, if we want to tweak configuration for one of our test suites, we can put something like the following in `init_per_suite/1`:

    ok = application:load(acme),
    ok = application:set_env(acme, param, SomeValue),
    {ok, _} = application:ensure_all_started(acme),

Then `rebar3 ct` will pass.  But `rebar3 do eunit, ct` will fail, since the application will already be loaded.

However, the problem is not with the code path itself.  Seems like CT provider should not load applications from `sys_config` files.  This way it will mimic `-config` option more closely: application is not loaded, application parameters read from file persisted in application controller state and won't be available until the application is loaded. It will also fix `rebar3 do eunit, ct` in the above example.

Please take a look on tests in tsloughter/rebar3_tests#18.

Marked as draft, since shell tests workflow references `rebar3_tests` fork.