### PR TITLE
Fix override relx log macro

### DIFF
--- a/apps/rebar/rebar.config
+++ b/apps/rebar/rebar.config
@@ -30,8 +30,6 @@
 {escript_incl_priv, [{relx, "templates/*"},
                      {rebar, "templates/*"}]}.
 
-{overrides, [{add, relx, [{erl_opts, [{d, 'RLX_LOG', rebar_log}]}]}]}.
-
 {erl_opts, [warnings_as_errors,
             {platform_define, "^(2[1-9])|(20\\\\.3)", filelib_find_source},
             {platform_define, "^(1|(20))", no_customize_hostname_check},

--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,8 @@
 {escript_incl_priv, [{relx, "templates/*"},
                      {rebar, "templates/*"}]}.
 
+{overrides, [{add, relx, [{erl_opts, [{d, 'RLX_LOG', rebar_log}]}]}]}.
+
 {profiles, [
     %% Only works at the top-level
     {systest, [


### PR DESCRIPTION
This PR is a workaround (maybe a fix) for override `RLX_LOG` macro.

This issue was introduced in #2720, the `overrides` does not take effect inside `apps/rebar/rebar.config` but in the root config. I have no idea why, maybe this is a bug of `overrides` I guess.