### PR TITLE
 rebar3_dialyzer_format: Add missing message formatting

### DIFF
--- a/apps/rebar/src/rebar_dialyzer_format.erl
+++ b/apps/rebar/src/rebar_dialyzer_format.erl
@@ -130,6 +130,9 @@ message_to_string({guard_fail, []}) ->
 message_to_string({guard_fail, [Arg1, Infix, Arg2]}) ->
     fmt("~!^Guard test ~!!~ts ~ts ~ts~!^ can never succeed",
         [Arg1, Infix, Arg2]);
+message_to_string({map_update, [Type, Key]}) ->
+    fmt("~!^A key of type ~!!~ts~!^ cannot exist in a map of type ~!!~ts",
+        [Key, Type]);
 message_to_string({neg_guard_fail, [Arg1, Infix, Arg2]}) ->
     fmt("~!^Guard test not(~!!~ts ~ts ~ts~!^) can never succeed",
         [Arg1, Infix, Arg2]);
@@ -202,9 +205,17 @@ message_to_string({contract_range, [Contract, M, F, ArgStrings, Line, CRet]}) ->
 message_to_string({invalid_contract, [M, F, A, Sig]}) ->
     fmt("~!^Invalid type specification for function~!! ~w:~w/~w."
         "~!^ The success typing is~!! ~ts", [M, F, A, Sig]);
+message_to_string({contract_with_opaque, [M, F, A, OpaqueType, SigType]}) ->
+  fmt("~!^The specification for ~!!~w:~w/~w~!^ has an opaque"
+      " subtype ~!!~ts~!^ which is violated by the success typing ~!!~ts",
+      [M, F, A, OpaqueType, SigType]);
 message_to_string({extra_range, [M, F, A, ExtraRanges, SigRange]}) ->
     fmt("~!^The specification for ~!!~w:~w/~w~!^ states that the function"
         " might also return ~!!~ts~!^ but the inferred return is ~!!~ts",
+        [M, F, A, ExtraRanges, SigRange]);
+message_to_string({missing_range, [M, F, A, ExtraRanges, SigRange]}) ->
+    fmt("~!^The success typing for ~!!~w:~w/~w~!^ implies that the function"
+        " might also return ~!!~ts~!^ but the specification return is ~!!~ts",
         [M, F, A, ExtraRanges, SigRange]);
 message_to_string({overlapping_contract, [M, F, A]}) ->
     fmt("~!^Overloaded contract for ~!!~w:~w/~w~!^ has overlapping"
@@ -276,6 +287,9 @@ message_to_string({callback_spec_arg_type_mismatch, [B, F, A, N, ST, CT]}) ->
 message_to_string({callback_missing, [B, F, A]}) ->
     fmt("~!^Undefined callback function ~!!~w/~w~!^ (behaviour ~!!"
         "'~w'~!^)",[F, A, B]);
+message_to_string({callback_not_exported, [B, F, A]}) ->
+    fmt("~!^Callback function ~!!~w/~w~!^ exists but is not exported"
+        " (behaviour ~!!'~w'~!^)", [F, A, B]);
 message_to_string({callback_info_missing, [B]}) ->
     fmt("~!^Callback info about the ~!r~w~!!~!^"
         " behaviour is not available", [B]);


### PR DESCRIPTION
Add missing message string formatting to `rebar3_dialyzer_format`.

The messages are specify in the [dialyzer.erl](https://github.com/erlang/otp/blob/master/lib/dialyzer/src/dialyzer.erl#L408) so I ran the following commands for finding missing messages:
```bash
grep '^message_to_string' otp/lib/dialyzer/src/dialyzer.erl |  sed 's/message_to_string({\([a-z_]*\),.*/\1/g' | sort > /tmp/otp.txt
grep '^message_to_string' rebar3/apps/src/rebar_dialyzer_format.erl | sed 's/message_to_string({\([a-z_]*\),.*/\1/g' | sort > /tmp/rebar3.txt
```
The missing message types are `callback_not_exported`, `contract_with_opaque`,  `map_update`, `missing_range`. The file already have a message formatting for `invalid_contract` but it has been divided in two functions in OTP project so my command shows it.
`race_condition` was deprecated in OTP-25.
```diff
7a8
> callback_not_exported
17a19
> contract_with_opaque
27a30,32
> invalid_contract
> map_update
> missing_range
42d46
< race_condition
```