### PR TITLE
Lift Ubuntu runner in CI for Nightly and Publish

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Publish escript for every merge to main
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Create release and publish escript for every new tag
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The ubuntu-18.04 runner is [deprecated](https://github.com/actions/runner-images/issues/6002) and removed 2023/04/01.
Replace it with 20.04 so that [erlef/setup-beam can setup OTP23](https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp).

Forced runs (without the AWS interactions):
- [Publish](https://github.com/Nordix/rebar3/actions/runs/4552321276)
- [Nightly](https://github.com/Nordix/rebar3/actions/runs/4552321268)

