### PR TITLE
Maintain cth_log_redirect default in CT runs

### DIFF
--- a/apps/rebar/src/rebar_prv_common_test.erl
+++ b/apps/rebar/src/rebar_prv_common_test.erl
@@ -278,7 +278,7 @@ add_hooks(Opts, State) ->
             Opts;
         {Other, false} ->
             [{ct_hooks, [cth_readable_failonly, readable_shell_type(Other),
-                         cth_retry] ++ FailFast} | Opts];
+                         cth_retry] ++ FailFast ++ cth_log_redirect()} | Opts];
         {Other, {ct_hooks, Hooks}} ->
             %% Make sure hooks are there once only and add wanted hooks that are not defined yet
             ReadableHooks = [cth_readable_failonly, readable_shell_type(Other),
@@ -299,6 +299,12 @@ is_defined(Key, [_ | Hs]) -> is_defined(Key, Hs).
 
 readable_shell_type(true) -> cth_readable_shell;
 readable_shell_type(compact) -> cth_readable_compact_shell.
+
+cth_log_redirect() ->
+    case code:ensure_loaded(cth_log_redirect) of
+        {error, _} -> [];
+        {module, _} -> [cth_log_redirect]
+    end.
 
 select_tests(_, _, _, {error, _} = Error) -> Error;
 select_tests(State, ProjectApps, CmdOpts, CfgOpts) ->


### PR DESCRIPTION
By default, common test should be redirecting log output via the cth_log_redirect hook. However, whenever we override the values to enable the stuff in cth_readable, we take that log redirection away.

This restores it so it is the same, so long as the user does not specify their own log values in it, which keeps the override/removal as-is.