### PR TITLE
Hotfix erlware_commons config script

### DIFF
--- a/apps/rebar/src/rebar.app.src.script
+++ b/apps/rebar/src/rebar.app.src.script
@@ -1,6 +1,5 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
-
 {application, rebar,
  [{description, "Rebar: Erlang Build Tool"},
   {vsn, "git"},

--- a/vendor/erlware_commons/rebar.config.script
+++ b/vendor/erlware_commons/rebar.config.script
@@ -1,10 +1,4 @@
-IsRebar3 = case application:get_key(rebar, vsn) of
-               {ok, Vsn} ->
-                   [MajorVersion|_] = string:tokens(Vsn, "."),
-                   (list_to_integer(MajorVersion) >= 3);
-               undefined ->
-                   false
-           end,
+IsRebar3 = true,
 
 Rebar2Deps = [
               {cf, ".*", {git, "https://github.com/project-fifo/cf", {tag, "0.2.2"}}}


### PR DESCRIPTION
In switching to vendoring, we implicitly broke the configuration-based version checks that rely on the app vsn of rebar3. this app vsn isn't configured yet during the initial app discovery phase and the "git" value is seen as invalid, causing a bootstrap crash.

We didn't see it because since Rebar3 3.18.0, we had not returned to the "git" version for things built from main, which hid the weird behavior.

It will legitimately happen absolutely nowhere but in this repo, so until it is modified elsewhere I'm hotpatching the dep to fix nightly builds.