### PR TITLE
Support CRLF in shell ENV files

### DIFF
--- a/apps/rebar/src/rebar_prv_shell.erl
+++ b/apps/rebar/src/rebar_prv_shell.erl
@@ -660,7 +660,7 @@ maybe_set_env_vars(State) ->
         {error, _} ->
             ?WARN("Failed to read file with environment variables: ~p", [EnvFile1]);
         {ok, Bin} ->
-            Lines = string:split(unicode:characters_to_list(Bin), "\n", all),
+            Lines = re:split(unicode:characters_to_list(Bin), "\n|\r\n", [{return, list}]),
             [handle_env_var_line(Line) || Line <- Lines]
     end.
 


### PR DESCRIPTION
As reported in a comment in https://github.com/erlang/rebar3/pull/2090 the current mechanism only breaks on a \n and does not even respect the \r\n grapheme cluster. So instead of using string functions, we go to regular expressions where we can specify both endings without a problem.