### PR TITLE
Fixup: rich compiler output in warnings

### DIFF
--- a/apps/rebar/src/rebar_base_compiler.erl
+++ b/apps/rebar/src/rebar_base_compiler.erl
@@ -32,6 +32,7 @@
          run/7,
          run/8,
          ok_tuple/2,
+         ok_tuple/4,
          error_tuple/4,
          error_tuple/5,
          report/1,
@@ -132,6 +133,12 @@ run(Config, FirstFiles, SourceDir, SourceExt0, TargetDir, TargetExt,
 -spec ok_tuple(file:filename(), [string()]) -> {ok, [string()]}.
 ok_tuple(Source, Ws) ->
     {ok, format_warnings(Source, Ws)}.
+
+%% @doc Format good compiler results with warnings to work with
+%% module internals. Assumes that warnings are not treated as errors.
+-spec ok_tuple(file:filename(), [string()], rebar_dict(), [{_,_}]) -> {ok, [string()]}.
+ok_tuple(Source, Ws, Config, Opts) ->
+    {ok, format_warnings(Source, Ws, Config, Opts)}.
 
 %% @doc format error and warning strings for a given source file
 %% according to user preferences.

--- a/apps/rebar/src/rebar_compiler.erl
+++ b/apps/rebar/src/rebar_compiler.erl
@@ -8,6 +8,7 @@
 
          needs_compile/3,
          ok_tuple/2,
+         ok_tuple/4,
          error_tuple/4,
          error_tuple/5,
          maybe_report/1,
@@ -127,6 +128,9 @@ needs_compile(Source, OutExt, Mappings) ->
 
 ok_tuple(Source, Ws) ->
     rebar_base_compiler:ok_tuple(Source, Ws).
+
+ok_tuple(Source, Ws, Config, Opts) ->
+    rebar_base_compiler:ok_tuple(Source, Ws, Config, Opts).
 
 error_tuple(Source, Es, Ws, Opts) ->
     rebar_base_compiler:error_tuple(Source, Es, Ws, Opts).

--- a/apps/rebar/src/rebar_compiler_erl.erl
+++ b/apps/rebar/src/rebar_compiler_erl.erl
@@ -138,7 +138,7 @@ compile(Source, [{_, OutDir}], Config, ErlOpts) ->
             ok;
         {ok, _Mod, Ws} ->
             FormattedWs = format_error_sources(Ws, Config),
-            rebar_compiler:ok_tuple(Source, FormattedWs);
+            rebar_compiler:ok_tuple(Source, FormattedWs, Config, ErlOpts);
         {error, Es, Ws} ->
             error_tuple(Source, Es, Ws, Config, ErlOpts);
         error ->
@@ -161,7 +161,7 @@ compile_and_track(Source, [{Ext, OutDir}], Config, ErlOpts) ->
             {ok, [{Source, Target, AllOpts}]};
         {ok, _Mod, Ws} ->
             FormattedWs = format_error_sources(Ws, Config),
-            {ok, Warns} = rebar_compiler:ok_tuple(Source, FormattedWs),
+            {ok, Warns} = rebar_compiler:ok_tuple(Source, FormattedWs, Config, ErlOpts),
             {ok, [{Source, Target, AllOpts}], Warns};
         {error, Es, Ws} ->
             error_tuple(Source, Es, Ws, Config, ErlOpts);

--- a/apps/rebar/src/rebar_compiler_xrl.erl
+++ b/apps/rebar/src/rebar_compiler_xrl.erl
@@ -39,7 +39,7 @@ compile(Source, [{_, _}], Config, Opts) ->
         {ok, _} ->
             ok;
         {ok, _Mod, Ws} ->
-            rebar_compiler:ok_tuple(Source, Ws);
+            rebar_compiler:ok_tuple(Source, Ws, Config, Opts);
         {error, Es, Ws} ->
             rebar_compiler:error_tuple(Source, Es, Ws, Config, Opts)
     end.

--- a/apps/rebar/src/rebar_compiler_yrl.erl
+++ b/apps/rebar/src/rebar_compiler_yrl.erl
@@ -46,7 +46,7 @@ compile(Source, [{_, OutDir}], Config, Opts0) ->
         {ok, _} ->
             ok;
         {ok, _Mod, Ws} ->
-            rebar_compiler:ok_tuple(Source, Ws);
+            rebar_compiler:ok_tuple(Source, Ws, Config, AllOpts);
         {error, Es, Ws} ->
             rebar_compiler:error_tuple(Source, Es, Ws, Config, AllOpts)
     end.


### PR DESCRIPTION
I hadn't seen this because all my projects use warnings_as_errors, but the warnings were never properly wired up.

This patch fixes that by adding the proper callbacks and invoking them from the 3 erlang-related compilers we support.

Sample run:

```
→ rebar3 as test compile
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling revault
===> Compiling maestro
    ┌─ apps/revault/test/id_shim.erl:
    │
 23 │  id_ask(From, To) ->
    │               ╰── Warning: variable 'To' is unused


===> Analyzing applications...
===> Compiling extra_test
```
This might look a bit like an error but yeah, not a good way to bypass that for now without further re-structuring of the code.