### PR TITLE
Print diagnostic when failing to get VSN with Git

### DIFF
--- a/apps/rebar/src/rebar_git_resource.erl
+++ b/apps/rebar/src/rebar_git_resource.erl
@@ -317,13 +317,17 @@ git_ref(Dir, Arg) ->
 collect_default_refcount(Dir) ->
     %% Get the tag timestamp and minimal ref from the system. The
     %% timestamp is really important from an ordering perspective.
-    case rebar_utils:sh("git log -n 1 --pretty=format:\"%h\n\" ",
+    Command = "git log -n 1 --pretty=format:\"%h\n\" ",
+    case rebar_utils:sh(Command,
                        [{use_stdout, false},
                         return_on_error,
                         {cd, Dir}]) of
-        {error, _} ->
+        {error, {Rc, Error}} ->
             ?WARN("Getting log of git repo failed in ~ts. "
                   "Falling back to version 0.0.0", [Dir]),
+            ?DIAGNOSTIC("Command sh(~ts)~n"
+                        "returned error code ~w with the following output:~n"
+                        "~ts", [Command, Rc, Error]),
             {plain, "0.0.0"};
         {ok, String} ->
             RawRef = rebar_string:trim(String, both, "\n"),


### PR DESCRIPTION
The function `collect_default_refcount/1` of `rebar_git_resource` did not log the error message when it failed to get the vsn number with its `git log` command.

- A diagnostic error message is now printed with the status code and output message of the failing command.

I encountered this error with GitHub Actions CI (https://github.com/actions/checkout/issues/1169)
and failed to find the appropriate error cause because there was no diagnostic logging from rebar.

According to the CONTRIBUTING documentation, a test should be attached with this PR but I'm not sure how to add a test for this.
Any guidance would be appreciated.
