### PR TITLE
Defer hostname check to OTP when supported

### DIFF
--- a/apps/rebar/src/rebar_utils.erl
+++ b/apps/rebar/src/rebar_utils.erl
@@ -1073,13 +1073,10 @@ get_cacerts() ->
 ssl_opts(ssl_verify_enabled, Url) ->
     case check_ssl_version() of
         true ->
-            #{host := Hostname} = rebar_uri:parse(rebar_utils:to_list(Url)),
-            VerifyFun = {fun ssl_verify_hostname:verify_fun/3,
-                         [{check_hostname, Hostname}]},
             CACerts = get_cacerts(),
             SslOpts = [{verify, verify_peer}, {depth, 10}, {cacerts, CACerts},
-                       {partial_chain, fun partial_chain/1}, {verify_fun, VerifyFun}],
-            check_hostname_opt(SslOpts);
+                       {partial_chain, fun partial_chain/1}],
+            check_hostname_opt(Url, SslOpts);
         false ->
             ?WARN("Insecure HTTPS request (peer verification disabled), "
                   "please update to OTP 17.4 or later", []),
@@ -1087,12 +1084,15 @@ ssl_opts(ssl_verify_enabled, Url) ->
     end.
 
 -ifdef(no_customize_hostname_check).
-check_hostname_opt(Opts) ->
-  Opts.
+check_hostname_opt(Url, Opts) ->
+    #{host := Hostname} = rebar_uri:parse(rebar_utils:to_list(Url)),
+    VerifyFun = {fun ssl_verify_hostname:verify_fun/3,
+                 [{check_hostname, Hostname}]},
+    [{verify_fun, VerifyFun} | Opts].
 -else.
-check_hostname_opt(Opts) ->
-  MatchFun = public_key:pkix_verify_hostname_match_fun(https),
-  [{customize_hostname_check, [{match_fun, MatchFun}]} | Opts].
+check_hostname_opt(_, Opts) ->
+    MatchFun = public_key:pkix_verify_hostname_match_fun(https),
+    [{customize_hostname_check, [{match_fun, MatchFun}]} | Opts].
 -endif.
 
 -spec partial_chain(Certs) -> Res when


### PR DESCRIPTION
While investigating the work required to support
https://github.com/erlang/rebar3/pull/2803, I found out that the code was already in place.

However, despite the code being there, we still passed the old `ssl_verify_hostname:verify_fun/3` function of pre-21.0 on top of it, which I supposed ignored the check.

So this change reworks the flow such that we fall back to the legacy check only if it isn't supported by the OTP library at this point. Getting this going would require someone to build a new release on an Erlang copy older than OTP-21 (which is no longer supported) which is unlikely.

This follows guidelines from
https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl