### PR TITLE
Rework argument parsing in do/as providers

### DIFF
--- a/apps/rebar/test/rebar_utils_SUITE.erl
+++ b/apps/rebar/test/rebar_utils_SUITE.erl
@@ -24,6 +24,7 @@
          task_with_flag_with_commas/1,
          task_with_multiple_flags/1,
          special_task_do/1,
+         special_task_as_with_commas/1,
          valid_otp_version/1,
          valid_old_format_otp_version/1,
          valid_otp_version_equal/1,
@@ -70,6 +71,7 @@ groups() ->
                           task_with_flag_with_commas,
                           task_with_multiple_flags,
                           special_task_do,
+                          special_task_as_with_commas,
                           valid_otp_version,
                           valid_old_format_otp_version,
                           valid_otp_version_equal,
@@ -145,6 +147,20 @@ special_task_do(_Config) ->
                                                                         "do",
                                                                         "bar,",
                                                                         "baz"]).
+special_task_as_with_commas(_Config) ->
+    [{"as", ["profile"]}, {"bar", ["--x=y,z"]}, {"baz", ["--arg=a,b"]}] =
+      rebar_utils:args_to_tasks(["as", "profile,",
+                                 "bar", "--x=y,z,",
+                                 "baz", "--arg=a,b"]),
+    [{"as", ["profile"]}, {"bar", ["-x", "y,z"]}, {"baz", ["--a", "a,b"]}] =
+      rebar_utils:args_to_tasks(["as", "profile,",
+                                 "bar", "-x", "y,z,",
+                                 "baz", "--a", "a,b"]),
+    [{"as", ["profile"]}, {"bar", ["-x", "y"]}, {"z", []}, {"baz", ["--a", "a"]}, {"b",[]}] =
+      rebar_utils:args_to_tasks(["as", "profile,",
+                                 "bar", "-x", "y,", "z,",
+                                 "baz", "--a", "a,", "b"]),
+    ok.
 
 valid_otp_version(_Config) ->
     meck:new(rebar_utils, [passthrough]),


### PR DESCRIPTION
The current mechanism had a few oddities, as reported in https://github.com/erlang/rebar3/issues/2811:

- `rebar3 do a,b` runs `a` then `b`
- `rebar3 as profile task --a=b,c` runs the task with the flag `a` set to `b,c`
- `rebar3 as profile task -a b,c` runs the task with the flag `a` set to `b`, and then tries to run `c` as a task
- `rebar3 as profile task -a b, c` runs the task with the flag `a` set to `b`, and then tries to run `c` as a task

So the issue is that to pass a comma to an argument, we can only do so when it exists as a long form argument (`--flag`) and that it does not contain spaces.

This patch attempts to correct things by making the white-space following the comma significant. If it's missing, it gets grouped as a single entity. If it's there, the task is considered to be split.

This becomes significant for commands that internally parse the `,` to allow list of args (such as `rebar3 release --relnames one,two`) which were only invokable as `--relnames=one,two`, and not the spaced version nor the short version (`-m one,two`), which should now be supported. Also do note that we seemingly deal with quoting fine, and so `rebar3 do release --relnames "a, b"` will prevent the whitespace from splitting the argument into commands.

This should *not* break any backwards compatibility, but there is the possibility that users who did invoke many commands with both arguments and sequences without spaces (`rebar3 do release --relname a,tar`) now get broken commands. 

I don't quite know if we'd be okay taking that risk, so this is up for comments I guess.