### PR TITLE
Fix for `rebar3 shell` in Erlang 26 when ShellArgs==undefined

### DIFF
--- a/apps/rebar/src/rebar_prv_shell.erl
+++ b/apps/rebar/src/rebar_prv_shell.erl
@@ -175,6 +175,8 @@ setup_shell(ShellArgs) ->
             ok = start_interactive(ShellArgs)
     end.
 
+start_interactive(undefined) ->
+    start_interactive([]);
 start_interactive(ShellArgs) ->
     apply(shell, start_interactive, ShellArgs).
 

--- a/apps/rebar/src/rebar_prv_shell.erl
+++ b/apps/rebar/src/rebar_prv_shell.erl
@@ -133,7 +133,7 @@ format_error(Reason) ->
 shell(State) ->
     setup_name(State),
     setup_paths(State),
-    ShellArgs = debug_get_value(shell_args, rebar_state:get(State, shell, []), undefined,
+    ShellArgs = debug_get_value(shell_args, rebar_state:get(State, shell, []), [],
                                 "Found shell args from command line option or plugin."),
     setup_shell(ShellArgs),
     maybe_run_script(State),
@@ -175,8 +175,6 @@ setup_shell(ShellArgs) ->
             ok = start_interactive(ShellArgs)
     end.
 
-start_interactive(undefined) ->
-    start_interactive([]);
 start_interactive(ShellArgs) ->
     apply(shell, start_interactive, ShellArgs).
 
@@ -228,7 +226,7 @@ setup_new_shell(ShellArgs) ->
     _ = supervisor:terminate_child(kernel_sup, user),
     %% start a new shell (this also starts a new user under the correct group)
     case ShellArgs of
-        undefined ->
+        [] ->
             _ = user_drv:start();
         _ ->
             _ = user_drv:start(ShellArgs)


### PR DESCRIPTION
Heh folks!

It seems that https://github.com/erlang/rebar3/pull/2818 introduced a bug when there are no shell args defined (with Erlang 26), since the default value of `ShellArgs` in `rebar_prv_shell` is `undefined`.

This small fix just handles that situation, since `undefined` is not a valid value for the 3rd argument of `erlang:apply/3`.

Thanks!