### PR TITLE
Allow for less verbose test execution output on SKIPPED

### DIFF
--- a/apps/rebar/rebar.config
+++ b/apps/rebar/rebar.config
@@ -9,7 +9,7 @@
         {bbmustache,       "1.12.2"},
         {relx,             "4.8.0"},
         {cf,               "0.3.1"},
-        {cth_readable,     "1.5.1"},
+        {cth_readable,     "1.6.0"},
         {eunit_formatters, "0.5.0"}]}.
 
 {post_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)",

--- a/apps/rebar/src/rebar_prv_common_test.erl
+++ b/apps/rebar/src/rebar_prv_common_test.erl
@@ -21,6 +21,8 @@
 %% we need to modify app_info state before compile
 -define(DEPS, [lock]).
 
+-define(VERBOSE_DEFAULT, false).
+
 %% ===================================================================
 %% Public API
 %% ===================================================================
@@ -92,7 +94,7 @@ run_tests(State, Opts) ->
     Opts2 = turn_off_auto_compile(Opts1),
     ?DEBUG("Running tests with {ct_opts, ~p}.", [Opts2]),
     CTOpts = rebar_state:get(State, ct_opts, []),
-    VerboseFromConfig = verbose({from_config, State}, _DefaultFromConfig = false, CTOpts),
+    VerboseFromConfig = verbose({from_config, State}, _DefaultFromConfig = ?VERBOSE_DEFAULT, CTOpts),
     Result = case verbose({from_cli, State}, VerboseFromConfig) of
         true  -> run_test_verbose(Opts2);
         false -> run_test_quiet(Opts2)
@@ -274,7 +276,7 @@ add_hooks(Opts, State) ->
         true -> [cth_fail_fast];
         false -> []
     end,
-    VerboseFromConfig = verbose({from_config, State}, _DefaultFromConfig = false, Opts),
+    VerboseFromConfig = verbose({from_config, State}, _DefaultFromConfig = ?VERBOSE_DEFAULT, Opts),
     Verbose = [{verbose, verbose({from_cli, State}, VerboseFromConfig)}],
     case {readable(State), lists:keyfind(ct_hooks, 1, Opts)} of
         {false, _} ->

--- a/apps/rebar/src/rebar_prv_common_test.erl
+++ b/apps/rebar/src/rebar_prv_common_test.erl
@@ -277,11 +277,13 @@ add_hooks(Opts, State) ->
         {false, _} ->
             Opts;
         {Other, false} ->
-            [{ct_hooks, [cth_readable_failonly, readable_shell_type(Other),
+            ShellTypeWithOpts = {readable_shell_type(Other), [verbose(Opts)]},
+            [{ct_hooks, [cth_readable_failonly, ShellTypeWithOpts,
                          cth_retry] ++ FailFast ++ cth_log_redirect()} | Opts];
         {Other, {ct_hooks, Hooks}} ->
             %% Make sure hooks are there once only and add wanted hooks that are not defined yet
-            ReadableHooks = [cth_readable_failonly, readable_shell_type(Other),
+            ShellTypeWithOpts = {readable_shell_type(Other), [verbose(Opts)]},
+            ReadableHooks = [cth_readable_failonly, ShellTypeWithOpts,
                              cth_retry] ++ FailFast,
             NewHooks = Hooks ++ [ReadableHook ||
                 ReadableHook <- ReadableHooks,
@@ -296,6 +298,8 @@ is_defined(Key, [{Key, _Opts} | _Hs]) -> true;
 is_defined(Key, [{Key, _Opts, _Prio} | _Hs]) -> true;
 is_defined(Key, [_ | Hs]) -> is_defined(Key, Hs).
 
+verbose(Opts) ->
+    {verbose, proplists:get_value(verbose, Opts, true)}.
 
 readable_shell_type(true) -> cth_readable_shell;
 readable_shell_type(compact) -> cth_readable_compact_shell.

--- a/vendor/cth_readable/README.md
+++ b/vendor/cth_readable/README.md
@@ -34,7 +34,7 @@ Add the following to your `rebar.config`:
 
 ```erlang
 {deps, [
-    {cth_readable, {git, "https://github.com/ferd/cth_readable.git", {tag, "v1.5.1"}}}
+    {cth_readable, {git, "https://github.com/ferd/cth_readable.git", {tag, "v1.6.0"}}}
     ]}.
 
 {ct_compile_opts, [{parse_transform, cth_readable_transform}]}.
@@ -70,6 +70,9 @@ It will let you have both proper formatting and support for arbitrary
 configurations.
 
 ## Changelog
+1.6.0:
+- Adding support for less verbose test skipping (thanks @paulo-ferraz-oliveira)
+
 1.5.1:
 - Adding support for `cthr:pal/5` (thanks @ashleyjlive)
 

--- a/vendor/cth_readable/hex_metadata.config
+++ b/vendor/cth_readable/hex_metadata.config
@@ -3,7 +3,7 @@
 {<<"description">>,<<"Common Test hooks for more readable logs">>}.
 {<<"files">>,
  [<<"LICENSE">>,<<"README.md">>,<<"rebar.config">>,<<"rebar.config.script">>,
-  <<"rebar.lock">>,<<"src/cth_readable.app.src">>,
+  <<"rebar.lock">>,<<"src">>,<<"src/cth_readable.app.src">>,
   <<"src/cth_readable_compact_shell.erl">>,
   <<"src/cth_readable_failonly.erl">>,<<"src/cth_readable_helpers.erl">>,
   <<"src/cth_readable_lager_backend.erl">>,<<"src/cth_readable_nosasl.erl">>,
@@ -17,4 +17,4 @@
    [{<<"app">>,<<"cf">>},
     {<<"optional">>,false},
     {<<"requirement">>,<<"~>0.2.1">>}]}]}.
-{<<"version">>,<<"1.5.1">>}.
+{<<"version">>,<<"1.6.0">>}.

--- a/vendor/cth_readable/rebar.config
+++ b/vendor/cth_readable/rebar.config
@@ -15,6 +15,6 @@
 
 {profiles, [
     {test, [
-        {deps, [{lager, "3.6.10"}]}
+        {deps, [{lager, "3.9.2"}]}
     ]}
 ]}.

--- a/vendor/cth_readable/src/cth_readable.app.src
+++ b/vendor/cth_readable/src/cth_readable.app.src
@@ -1,6 +1,6 @@
 {application,cth_readable,
              [{description,"Common Test hooks for more readable logs"},
-              {vsn,"1.5.1"},
+              {vsn,"1.6.0"},
               {registered,[cth_readable_failonly,cth_readable_logger]},
               {applications,[kernel,stdlib,syntax_tools,cf]},
               {env,[]},

--- a/vendor/cth_readable/src/cth_readable_compact_shell.erl
+++ b/vendor/cth_readable/src/cth_readable_compact_shell.erl
@@ -63,15 +63,7 @@ init(Id, Opts) ->
     {ok, #state{id=Id, opts=Opts, last_suite=undefined}}.
 
 %% @doc Called before init_per_suite is called.
-pre_init_per_suite(Suite,Config,#state{opts = Opts, last_suite = LastSuite} = State) ->
-    IsFirstSuite = LastSuite =:= undefined,
-    IsVerbose = is_verbose(Opts),
-    case IsFirstSuite of
-        false when IsVerbose ->
-            io:format(user, "~n", []);
-        _Else ->
-            ok
-    end,
+pre_init_per_suite(Suite,Config,State) ->
     io:format(user, "%%% ~p", [Suite]),
     {Config, State#state{suite=Suite, groups=[]}}.
 
@@ -114,7 +106,7 @@ post_end_per_testcase(SuiteName,TC,_Config,ok,State=#state{suite=Suite, groups=G
     case IsFirstInSuite of
         true ->
             io:format(user, ": ", []);
-        _Else ->
+        false ->
             ok
     end,
     ?OK(Suite, "~s", [format_path(TC,Groups)]),
@@ -127,9 +119,9 @@ post_end_per_testcase(SuiteName,TC,Config,Error,State=#state{suite=Suite, groups
             io:format(user, "~n%%% ~p ==> ", [SuiteName]);
         true when IsVerbose ->
             io:format(user, " ==> ", []);
-        true when IsFirstInSuite ->
+        true ->
             io:format(user, ": ", []);
-        _Else ->
+        _Other ->
             ok
     end,
     case lists:keyfind(tc_status, 1, Config) of

--- a/vendor/cth_readable/src/cth_readable_shell.erl
+++ b/vendor/cth_readable/src/cth_readable_shell.erl
@@ -7,17 +7,27 @@
 
 -define(OK(Suite, CasePat, CaseArgs),
         ?CASE(Suite, CasePat, ?OKC, "OK", CaseArgs)).
--define(SKIP(Suite, CasePat, CaseArgs, Reason),
-        ?STACK(Suite, CasePat, CaseArgs, Reason, ?SKIPC, "SKIPPED")).
+-define(SKIP(Suite, CasePat, CaseArgs, Reason, Verbose),
+        ?STACK(Suite, CasePat, CaseArgs, Reason, ?SKIPC, "SKIPPED", Verbose)).
 -define(FAIL(Suite, CasePat, CaseArgs, Reason),
         ?STACK(Suite, CasePat, CaseArgs, Reason, ?FAILC, "FAILED")).
 -define(STACK(Suite, CasePat, CaseArgs, Reason, Color, Label),
+        ?STACK(Suite, CasePat, CaseArgs, Reason, Color, Label, true)).
+-define(STACK(Suite, CasePat, CaseArgs, Reason, Color, Label, Verbose),
         begin
-         ?CASE(Suite, CasePat, Color, Label, CaseArgs),
-         io:format(user, "%%% ~p ==> "++colorize(Color, maybe_eunit_format(Reason))++"~n", [Suite])
+          case Verbose of
+            true ->
+              ?CASE(Suite, CasePat, Color, Label, CaseArgs),
+             io:format(user, "%%% ~p ==> ~ts~n", [Suite,colorize(Color, maybe_eunit_format(Reason))]);
+            false ->
+              io:format(user, colorize(Color, "*"), [])
+          end
         end).
 -define(CASE(Suite, CasePat, Color, Res, Args),
-        io:format(user, "%%% ~p ==> "++CasePat++": "++colorize(Color, Res)++"~n", [Suite | Args])).
+        case Res of
+            "OK" -> io:put_chars(user, colorize(Color, "."));
+            _ -> io:format(user, lists:flatten(["~n%%% ~p ==> ",CasePat,": ",colorize(Color, Res),"~n"]), [Suite | Args])
+        end).
 
 %% Callbacks
 -export([id/1]).
@@ -41,7 +51,7 @@
 
 -export([terminate/1]).
 
--record(state, {id, suite, groups}).
+-record(state, {id, suite, groups, opts}).
 
 %% @doc Return a unique id for this CTH.
 id(_Opts) ->
@@ -49,8 +59,8 @@ id(_Opts) ->
 
 %% @doc Always called before any other callback function. Use this to initiate
 %% any common state.
-init(Id, _Opts) ->
-    {ok, #state{id=Id}}.
+init(Id, Opts) ->
+    {ok, #state{id=Id, opts=Opts}}.
 
 %% @doc Called before init_per_suite is called.
 pre_init_per_suite(Suite,Config,State) ->
@@ -114,20 +124,24 @@ on_tc_fail(TC, Reason, State=#state{suite=Suite, groups=Groups}) ->
 
 %% @doc Called when a test case is skipped by either user action
 %% or due to an init function failing. (>= 19.3)
-on_tc_skip(Suite, {TC,_Group}, Reason, State=#state{groups=Groups}) ->
-    ?SKIP(Suite, "~s", [format_path(TC,Groups)], Reason),
+on_tc_skip(Suite, {TC,_Group}, Reason, State=#state{groups=Groups, opts=Opts}) ->
+    skip(Suite, TC, Groups, Reason, Opts),
     State#state{suite=Suite};
-on_tc_skip(Suite, TC, Reason, State=#state{groups=Groups}) ->
-    ?SKIP(Suite, "~s", [format_path(TC,Groups)], Reason),
+on_tc_skip(Suite, TC, Reason, State=#state{groups=Groups, opts=Opts}) ->
+    skip(Suite, TC, Groups, Reason, Opts),
     State#state{suite=Suite}.
+
+skip(Suite, TC, Groups, Reason, Opts) ->
+    Verbose = proplists:get_value(verbose, Opts, true),
+    ?SKIP(Suite, "~s", [format_path(TC,Groups)], Reason, Verbose).
 
 %% @doc Called when a test case is skipped by either user action
 %% or due to an init function failing. (Pre-19.3)
 on_tc_skip({TC,Group}, Reason, State=#state{suite=Suite}) ->
-    ?SKIP(Suite, "~p (group ~p)", [TC, Group], Reason),
+    ?SKIP(Suite, "~p (group ~p)", [TC, Group], Reason, true),
     State;
 on_tc_skip(TC, Reason, State=#state{suite=Suite}) ->
-    ?SKIP(Suite, "~p", [TC], Reason),
+    ?SKIP(Suite, "~p", [TC], Reason, true),
     State.
 
 %% @doc Called when the scope of the CTH is done


### PR DESCRIPTION
# The change

As proposed by https://github.com/ferd/cth_readable/pull/41, instead of `SKIPPED` we get a magenta `*`, if `verbose` is `true`.

## Vendoring `cth_readable` in

I vendored `cth_readable` 1.6.0 in by changing `apps/rebar/rebar.config` to use the new version, then ran `rebar3 experimental vendor` from the root folder (after removing the `vendor` and `vendor_plugins` folders).

Not all of the vendored changes are from my previous pull request, and part of the result of command `vendor` (that which presented changes outside the `cth_readable` folder) were omitted :`erlware_commons`' `rebar.config.script` is also updated - without changing the reference version.

## Default `verbose`

The default `verbose` is `false`; I wonder if the output of the tests (from e.g. stdout) is considered part of the interface.

## Example output after the change

Ex. (as per the current integration):

```
===> Running Common Test suites...
%%% ex1_SUITE: *
Skipped 1 (1, 0) tests. Passed 0 tests.
```

Closes #2809.