### PR TITLE
Fix CI OTP versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: Common Test
 
 on: [pull_request, push]
 
+env:
+  LATEST_OTP_RELEASE: 26
+
 jobs:
   linux:
     name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
@@ -14,9 +17,6 @@ jobs:
 
     container:
       image: erlang:${{ matrix.otp_version }}
-
-    env:
-      LATEST_OTP_RELEASE: 26
 
     steps:
     - uses: actions/checkout@v2
@@ -40,15 +40,19 @@ jobs:
     - name: Brew Version Check
       run: brew --version
     - name: Brew Cleanup
-      run: brew cleanup
+      run: |
+        brew cleanup --prune=all -s
+        brew autoremove
     - name: Brew Untap Casks
       run: brew untap homebrew/cask homebrew/core
+    - name: Keep Brew Fresh
+      run: |
+        brew update
+        brew upgrade
     - name: Debug Brew
       run: brew doctor
-    - name: Keep Brew Fresh
-      run: brew update
     - name: Install Erlang
-      run: brew install erlang
+      run: brew install erlang@${{ env.LATEST_OTP_RELEASE }}
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,6 @@
 name: Common Test
 
-on:
-  pull_request:
-    branches:
-      - 'main'
-  push:
-    branches:
-      - 'main'
+on: [pull_request, push]
 
 jobs:
   linux:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       image: erlang:${{ matrix.otp_version }}
 
     env:
-      LATEST_OTP_RELEASE: 26.0
+      LATEST_OTP_RELEASE: 26
 
     steps:
     - uses: actions/checkout@v2
@@ -33,7 +33,9 @@ jobs:
     - shell: bash
       name: Dialyzer
       run: |
-        [[ "${{ matrix.otp_version }}" != "${{ env.LATEST_OTP_RELEASE }}" ]] || (./rebar3 clean -a && ./rebar3 as dialyzer dialyzer)
+        ./rebar3 clean -a
+        ./rebar3 as dialyzer dialyzer
+      if: ${{ matrix.otp_version == env.LATEST_OTP_RELEASE }}
 
   macos:
     name: Test on MacOS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24, 25.0, 26]
+        otp_version: [24, 25, 26]
         os: [ubuntu-latest]
 
     container:


### PR DESCRIPTION
Found while working on #2825.

I was going to do this on that one's scope, but maybe separating it is more proper, especially for review purposes.

In my `rebar3` fork this is failing for OTP 25...