### PR TITLE
Add (newer) Dialyzer info. about `invalid_contract`

### DIFF
--- a/apps/rebar/src/rebar_dialyzer_format.erl
+++ b/apps/rebar/src/rebar_dialyzer_format.erl
@@ -205,6 +205,10 @@ message_to_string({contract_range, [Contract, M, F, ArgStrings, Line, CRet]}) ->
 message_to_string({invalid_contract, [M, F, A, Sig]}) ->
     fmt("~!^Invalid type specification for function~!! ~w:~w/~w."
         "~!^ The success typing is~!! ~ts", [M, F, A, Sig]);
+message_to_string({invalid_contract, [M, F, A, _InvalidContractDetails, Contract, Sig]}) ->
+    fmt("~!^Invalid type specification for function~!! ~w:~w/~w."
+        "~!^ The success typing is~!! ~ts"
+        "~!^ but the spec is~!! ~ts", [M, F, A, Sig, Contract]);
 message_to_string({contract_with_opaque, [M, F, A, OpaqueType, SigType]}) ->
   fmt("~!^The specification for ~!!~w:~w/~w~!^ has an opaque"
       " subtype ~!!~ts~!^ which is violated by the success typing ~!!~ts",


### PR DESCRIPTION
... as per Dialyzer's [current implementation](https://github.com/erlang/otp/blob/master/lib/dialyzer/src/dialyzer.erl#L458).

I handle both `invalid_contract` clauses the same way, since I don't know if the `InvalidContractDetails` are interesting for the consumer, but lemme know and I'll update the code.