### PR TITLE
Add new 'shell_hooks_env' config to extend shell hooks' OS env vars

### DIFF
--- a/apps/rebar/src/rebar_env.erl
+++ b/apps/rebar/src/rebar_env.erl
@@ -58,7 +58,8 @@ create_env(State, Opts) ->
         {"ERLANG_TARGET",           rebar_api:get_arch()}
     ],
     EInterfaceVars = create_erl_interface_env(),
-    lists:append([EnvVars, EInterfaceVars]).
+    ConfigVars = rebar_state:get(State, env, []),
+    lists:append([EnvVars, EInterfaceVars, ConfigVars]).
 
 -spec create_erl_interface_env() -> list().
 create_erl_interface_env() ->

--- a/apps/rebar/src/rebar_env.erl
+++ b/apps/rebar/src/rebar_env.erl
@@ -58,7 +58,7 @@ create_env(State, Opts) ->
         {"ERLANG_TARGET",           rebar_api:get_arch()}
     ],
     EInterfaceVars = create_erl_interface_env(),
-    ConfigVars = rebar_state:get(State, env, []),
+    ConfigVars = rebar_state:get(State, shell_hooks_env, []),
     lists:append([EnvVars, EInterfaceVars, ConfigVars]).
 
 -spec create_erl_interface_env() -> list().

--- a/apps/rebar/test/rebar_hooks_SUITE.erl
+++ b/apps/rebar/test/rebar_hooks_SUITE.erl
@@ -275,7 +275,7 @@ env_vars_in_hooks(Config) ->
 
     HookFile = filename:join([?config(priv_dir, Config), "my-hook.txt"]),
     RebarConfig = [
-        {env, [{"VAR", HookFile}]},
+        {shell_hooks_env, [{"VAR", HookFile}]},
         {pre_hooks, [{compile, "echo test > $VAR"}]}
     ],
     rebar_test_utils:create_config(AppDir, RebarConfig),

--- a/apps/rebar/test/rebar_hooks_SUITE.erl
+++ b/apps/rebar/test/rebar_hooks_SUITE.erl
@@ -25,7 +25,7 @@ all() ->
     [build_and_clean_app, run_hooks_once, run_hooks_once_profiles,
      escriptize_artifacts, run_hooks_for_plugins, deps_hook_namespace,
      bare_compile_hooks_default_ns, deps_clean_hook_namespace, eunit_app_hooks,
-     sub_app_hooks, root_hooks, drop_hook_args].
+     sub_app_hooks, root_hooks, drop_hook_args, env_vars_in_hooks].
 
 %% Test post provider hook cleans compiled project app, leaving it invalid
 build_and_clean_app(Config) ->
@@ -265,3 +265,20 @@ drop_hook_args(Config) ->
         Config, RebarConfig, ["eunit", "--cover=false"],
         {ok, []}
     ).
+
+% Test that env vars are accessible from the hooks
+env_vars_in_hooks(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+
+    HookFile = filename:join([?config(priv_dir, Config), "my-hook.txt"]),
+    RebarConfig = [
+        {env, [{"VAR", HookFile}]},
+        {pre_hooks, [{compile, "echo test > $VAR"}]}
+    ],
+    rebar_test_utils:create_config(AppDir, RebarConfig),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"],
+                {ok, [{app, Name, valid}, {file, HookFile}]}).


### PR DESCRIPTION
The option requires a list of Name-Value pairs that are set as env variables when calling the hooks.
```erlang
{env, [{"MY_VAR", "my-value"}]}.

```

I tried to add a test in the hooks suite, I do not know if there is a better place.