### PR TITLE
Dedupe compiler DAG edge insertion for artifacts

### DIFF
--- a/apps/rebar/src/rebar_compiler_dag.erl
+++ b/apps/rebar/src/rebar_compiler_dag.erl
@@ -362,7 +362,16 @@ terminate(G) ->
 store_artifact(G, Source, Target, Meta) ->
     mark_dirty(G),
     digraph:add_vertex(G, Target, {artifact, Meta}),
-    digraph:add_edge(G, Target, Source, artifact).
+    %% artifact edges can get duplicated, so see if it exists before doing
+    %% anything with it
+    Edges = [{Beam,Src} || E <- digraph:edges(G, Target),
+                           {_,Beam,Src,artifact} <- [digraph:edge(G,E)]],
+    case lists:member({Target, Source}, Edges) of
+        true ->
+            ok;
+        false ->
+            digraph:add_edge(G, Target, Source, artifact)
+    end.
 
 %%%%%%%%%%%%%%%
 %%% PRIVATE %%%


### PR DESCRIPTION
Issue described at https://erlangforums.com/t/rebar3-is-taking-longer-to-compile-projects/3061/13

It appears that edge insertion with a label involved messes with the bag table and continuously inflates the size of a DAG after many runs. Since changes are propagated through a graph, frequent changes to often-included header files or parse transforms risk multiplying edge counts.

This little patch ensures that before inserting an artifact edge, we first look whether it already exists; if so we don't add it any further, but keep all other semantics the same.