### PR TITLE
Fix uncaught case_clause in rlx_assemble

### DIFF
--- a/vendor/relx/src/rlx_assemble.erl
+++ b/vendor/relx/src/rlx_assemble.erl
@@ -782,7 +782,7 @@ add_project_apps_to_xref(Rf, [AppSpec | Rest], State) ->
             of
                 {ok, _} ->
                     ok;
-                {error, _} = Error ->
+                {error, _, _} = Error ->
                     ?log_warn("Error adding application ~s to xref context: ~s",
                               [rlx_app_info:name(App), xref:format_error(Error)])
             end;


### PR DESCRIPTION
As described in https://www.erlang.org/doc/man/xref#add_application-3,

xref:add_application(XrefServer, Directory, Options) -> {ok, [application()] | {error, [module()], Reason}

the case clause should be of 3 elements in case of error occurs.