### PR TITLE
Fix MacOS CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,10 @@ jobs:
       run: brew untap homebrew/cask homebrew/core
     - name: Keep Brew Fresh
       run: |
-        brew update
-        brew upgrade
+        brew update || true
+        brew upgrade || true
     - name: Debug Brew
-      run: brew doctor
+      run: brew doctor || true
     - name: Install Erlang
       run: brew install erlang@${{ env.LATEST_OTP_RELEASE }}
     - name: Compile


### PR DESCRIPTION
This mostly allows the "maybe this helps" brew-related commands to silently fail. If something later also breaks, we'll still have the logs to debug them.