### PR TITLE
Initial version of the Manifest plugin (experimental)

### DIFF
--- a/apps/rebar/src/rebar.app.src.script
+++ b/apps/rebar/src/rebar.app.src.script
@@ -66,6 +66,7 @@
                      rebar_prv_local_install,
                      rebar_prv_local_upgrade,
                      rebar_prv_lock,
+                     rebar_prv_manifest,
                      rebar_prv_new,
                      rebar_prv_packages,
                      rebar_prv_path,

--- a/apps/rebar/src/rebar_prv_manifest.erl
+++ b/apps/rebar/src/rebar_prv_manifest.erl
@@ -98,10 +98,15 @@ options() ->
 get_manifest(State) ->
     ProjectApps = rebar_state:project_apps(State),
     DepApps = rebar_state:all_deps(State),
-    #{apps => [adapt_context(App) || App <- ProjectApps],
-      deps => [adapt_context(App) || App <- DepApps],
+    #{apps => [adapt_context(App) || App <- ProjectApps, is_supported(App)],
+      deps => [adapt_context(App) || App <- DepApps, is_supported(App)],
       otp_lib_dir => code:lib_dir(),
       source_root => rebar_state:dir(State)}.
+
+-spec is_supported(rebar_app_info:t()) -> boolean().
+is_supported(App) ->
+    Type = rebar_app_info:project_type(App),
+    Type =:= rebar3 orelse Type =:= undefined.
 
 -spec adapt_context(rebar_app_info:t()) -> app_context().
 adapt_context(App) ->

--- a/apps/rebar/src/rebar_prv_manifest.erl
+++ b/apps/rebar/src/rebar_prv_manifest.erl
@@ -33,11 +33,6 @@
 %% ===================================================================
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
-
-  %% By default, the provider outputs the manifest to stdout, so disable logs
-  %% not to interfere.
-  ok = rebar_log:init(api, 0),
-
   State1 = rebar_state:add_provider(
              State,
              providers:create([

--- a/apps/rebar/src/rebar_prv_manifest.erl
+++ b/apps/rebar/src/rebar_prv_manifest.erl
@@ -1,0 +1,138 @@
+%% ===================================================================
+%% Manifest Provider
+%% ===================================================================
+-module(rebar_prv_manifest).
+-behaviour(provider).
+-export([init/1,
+         do/1,
+         format_error/1]).
+
+-include_lib("providers/include/providers.hrl").
+
+-define(PROVIDER, manifest).
+-define(DEFAULT_FORMAT, erlang).
+
+-type extension() :: string().
+-type app_context() :: #{name         := binary(),
+                         src_dirs     := [file:filename()],
+                         include_dirs := [file:filename()],
+                         src_ext      := extension(),
+                         out_mappings := [#{extension := extension(), path := file:filename()}],
+                         dependencies_opts => any()}.
+-type manifest() :: #{
+                      apps := [app_context()],
+                      deps := [app_context()],
+                      otp_lib_dir := string(),
+                      source_root := string()
+                     }.
+
+-type format() :: erlang | eetf.
+
+%% ===================================================================
+%% Provider Callbacks
+%% ===================================================================
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+
+  %% By default, the provider outputs the manifest to stdout, so disable logs
+  %% not to interfere.
+  ok = rebar_log:init(api, 0),
+
+  State1 = rebar_state:add_provider(
+             State,
+             providers:create([
+                               {name, ?PROVIDER},
+                               {module, ?MODULE},
+                               {bare, true},
+                               {deps, [install_deps]},
+                               {example, "rebar3 manifest"},
+                               {short_desc, short_desc()},
+                               {desc, desc()},
+                               {opts, options()}
+                              ])
+            ),
+  {ok, State1}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+
+  {Opts, _} = rebar_state:command_parsed_args(State),
+  Format = proplists:get_value(format, Opts),
+  To = proplists:get_value(to, Opts),
+
+  Manifest = get_manifest(State),
+  case format(Manifest, Format) of
+    {ok, Formatted} ->
+      case output_manifest(Formatted, To) of
+        ok ->
+          {ok, State};
+        {error, Error} ->
+          ?PRV_ERROR({output_error, To, Error})
+      end;
+    {error, Error} ->
+      ?PRV_ERROR(Error)
+  end.
+
+-spec format_error(any()) -> iolist().
+format_error({format_not_supported, Format}) ->
+  io_lib:format("Format '~p' is not supported. Try 'erlang' or 'eetf'.", [Format]);
+format_error({output_error, To, Error}) ->
+  io_lib:format("Could not output manifest to ~p (~p)", [To, Error]);
+format_error(Reason) ->
+  io_lib:format("~p", [Reason]).
+
+%% ===================================================================
+%% Internal Helpers
+%% ===================================================================
+-spec short_desc() -> string().
+short_desc() ->
+  "Produce a project manifest".
+
+-spec desc() -> string().
+desc() ->
+  short_desc().
+
+-spec options() -> [tuple()].
+options() ->
+  [
+   {format, $f, "format", {atom, ?DEFAULT_FORMAT},
+    "Format for the manifest. "
+    "Supported formats are: erlang, eetf (Erlang External Binary Format)"},
+   {to, $t, "to", {string, undefined},
+    "If specified, write the manifest to file"}
+  ].
+
+-spec get_manifest(rebar_state:t()) -> manifest().
+get_manifest(State) ->
+  ProjectApps = rebar_state:project_apps(State),
+  DepApps = rebar_state:all_deps(State),
+  #{
+    apps => [adapt_context(App) || App <- ProjectApps],
+    deps => [adapt_context(App) || App <- DepApps],
+    otp_lib_dir => code:lib_dir(),
+    source_root => rebar_state:dir(State)
+   }.
+
+-spec adapt_context(rebar_app_info:t()) -> app_context().
+adapt_context(App) ->
+  Context0 = rebar_compiler_erl:context(App),
+  Context1 = maps:put(name, rebar_app_info:name(App), Context0),
+  OutMappings = [#{extension => Extension, path => Path} ||
+                  {Extension, Path} <- maps:get(out_mappings, Context1)],
+  maps:put(out_mappings, OutMappings, Context1).
+
+-spec output_manifest(binary(), string() | undefined) -> ok | {error, term()}.
+output_manifest(Manifest, undefined) ->
+  rebar_log:log(info, "Writing manifest to stdout:~n", []),
+  io:fwrite("~s~n", [Manifest]);
+output_manifest(Manifest, File) ->
+  rebar_log:log(info, "Build info written to: ~ts~n", [File]),
+  file:write_file(File, Manifest).
+
+-spec format(manifest(), format()) -> {ok, binary()} | {error, {format_not_supported, term()}}.
+format(Manifest, eetf) ->
+  {ok, term_to_binary(Manifest)};
+format(Manifest, erlang) ->
+  {ok, unicode:characters_to_binary(io_lib:format("~p.", [Manifest]))};
+format(_Manifest, Format) ->
+  {error, {format_not_supported, Format}}.

--- a/apps/rebar/src/rebar_prv_manifest.erl
+++ b/apps/rebar/src/rebar_prv_manifest.erl
@@ -114,7 +114,7 @@ adapt_context(App) ->
 -spec output_manifest(binary(), string() | undefined) -> ok | {error, term()}.
 output_manifest(Manifest, undefined) ->
     rebar_log:log(info, "Writing manifest to stdout:~n", []),
-    io:fwrite("~s~n", [Manifest]);
+    io:fwrite("~ts~n", [Manifest]);
 output_manifest(Manifest, File) ->
     rebar_log:log(info, "Build info written to: ~ts~n", [File]),
     file:write_file(File, Manifest).

--- a/apps/rebar/src/rebar_prv_manifest.erl
+++ b/apps/rebar/src/rebar_prv_manifest.erl
@@ -57,7 +57,7 @@ do(State) ->
     Manifest = get_manifest(State),
     case format(Manifest, Format) of
         {ok, Formatted} ->
-            case output_manifest(Formatted, To) of
+            case output_manifest(Formatted, Format, To) of
                 ok ->
                     {ok, State};
                 {error, Error} ->
@@ -116,11 +116,16 @@ adapt_context(App) ->
                       {Extension, Path} <- maps:get(out_mappings, Context1)],
     maps:put(out_mappings, OutMappings, Context1).
 
--spec output_manifest(binary(), string() | undefined) -> ok | {error, term()}.
-output_manifest(Manifest, undefined) ->
+-spec output_manifest(binary(), format(), string() | undefined) -> ok | {error, term()}.
+output_manifest(Manifest, Format, undefined) ->
     rebar_log:log(info, "Writing manifest to stdout:~n", []),
-    io:fwrite("~ts~n", [Manifest]);
-output_manifest(Manifest, File) ->
+    case Format of
+      erlang ->
+        io:fwrite("~ts~n", [Manifest]);
+      eetf ->
+        io:fwrite("~s~n", [Manifest])
+    end;
+output_manifest(Manifest, _Format, File) ->
     rebar_log:log(info, "Build info written to: ~ts~n", [File]),
     file:write_file(File, Manifest).
 

--- a/apps/rebar/src/rebar_prv_manifest.erl
+++ b/apps/rebar/src/rebar_prv_manifest.erl
@@ -25,8 +25,8 @@
                          dependencies_opts => any()}.
 -type manifest() :: #{ apps := [app_context()],
                        deps := [app_context()],
-                       otp_lib_dir := string(),
-                       source_root := string()}.
+                       otp_lib_dir := file:filename(),
+                       source_root := file:filename()}.
 
 -type format() :: erlang | eetf.
 

--- a/apps/rebar/src/rebar_prv_manifest.erl
+++ b/apps/rebar/src/rebar_prv_manifest.erl
@@ -1,8 +1,11 @@
 %% ===================================================================
 %% Manifest Provider
 %% ===================================================================
+
 -module(rebar_prv_manifest).
+
 -behaviour(provider).
+
 -export([init/1,
          do/1,
          format_error/1]).
@@ -13,121 +16,113 @@
 -define(DEFAULT_FORMAT, erlang).
 
 -type extension() :: string().
--type app_context() :: #{name         := binary(),
-                         src_dirs     := [file:filename()],
+-type app_context() :: #{name := binary(),
+                         src_dirs := [file:filename()],
                          include_dirs := [file:filename()],
-                         src_ext      := extension(),
-                         out_mappings := [#{extension := extension(), path := file:filename()}],
+                         src_ext := extension(),
+                         out_mappings := [#{extension := extension(),
+                                            path := file:filename()}],
                          dependencies_opts => any()}.
--type manifest() :: #{
-                      apps := [app_context()],
-                      deps := [app_context()],
-                      otp_lib_dir := string(),
-                      source_root := string()
-                     }.
+-type manifest() :: #{ apps := [app_context()],
+                       deps := [app_context()],
+                       otp_lib_dir := string(),
+                       source_root := string()}.
 
 -type format() :: erlang | eetf.
 
 %% ===================================================================
-%% Provider Callbacks
+%% Public API
 %% ===================================================================
+
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
-  State1 = rebar_state:add_provider(
-             State,
-             providers:create([
-                               {name, ?PROVIDER},
-                               {module, ?MODULE},
-                               {bare, true},
-                               {deps, [install_deps]},
-                               {example, "rebar3 manifest"},
-                               {short_desc, short_desc()},
-                               {desc, desc()},
-                               {opts, options()}
-                              ])
-            ),
-  {ok, State1}.
+    State1 = rebar_state:add_provider(State,
+                                      providers:create([{name, ?PROVIDER},
+                                                        {module, ?MODULE},
+                                                        {bare, true},
+                                                        {deps, [install_deps]},
+                                                        {example, "rebar3 manifest"},
+                                                        {short_desc, short_desc()},
+                                                        {desc, desc()},
+                                                        {opts, options()}
+                                                       ])),
+    {ok, State1}.
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
+    {Opts, _} = rebar_state:command_parsed_args(State),
+    Format = proplists:get_value(format, Opts),
+    To = proplists:get_value(to, Opts),
 
-  {Opts, _} = rebar_state:command_parsed_args(State),
-  Format = proplists:get_value(format, Opts),
-  To = proplists:get_value(to, Opts),
-
-  Manifest = get_manifest(State),
-  case format(Manifest, Format) of
-    {ok, Formatted} ->
-      case output_manifest(Formatted, To) of
-        ok ->
-          {ok, State};
+    Manifest = get_manifest(State),
+    case format(Manifest, Format) of
+        {ok, Formatted} ->
+            case output_manifest(Formatted, To) of
+                ok ->
+                    {ok, State};
+                {error, Error} ->
+                    ?PRV_ERROR({output_error, To, Error})
+            end;
         {error, Error} ->
-          ?PRV_ERROR({output_error, To, Error})
-      end;
-    {error, Error} ->
-      ?PRV_ERROR(Error)
-  end.
+            ?PRV_ERROR(Error)
+    end.
 
 -spec format_error(any()) -> iolist().
 format_error({format_not_supported, Format}) ->
-  io_lib:format("Format '~p' is not supported. Try 'erlang' or 'eetf'.", [Format]);
+    io_lib:format("Format '~p' is not supported. Try 'erlang' or 'eetf'.", [Format]);
 format_error({output_error, To, Error}) ->
-  io_lib:format("Could not output manifest to ~p (~p)", [To, Error]);
+    io_lib:format("Could not output manifest to ~p (~p)", [To, Error]);
 format_error(Reason) ->
-  io_lib:format("~p", [Reason]).
+    io_lib:format("~p", [Reason]).
 
 %% ===================================================================
 %% Internal Helpers
 %% ===================================================================
 -spec short_desc() -> string().
 short_desc() ->
-  "Produce a project manifest".
+    "Produce a project manifest".
 
 -spec desc() -> string().
 desc() ->
-  short_desc().
+    short_desc().
 
 -spec options() -> [tuple()].
 options() ->
-  [
-   {format, $f, "format", {atom, ?DEFAULT_FORMAT},
-    "Format for the manifest. "
-    "Supported formats are: erlang, eetf (Erlang External Binary Format)"},
-   {to, $t, "to", {string, undefined},
-    "If specified, write the manifest to file"}
-  ].
+    [{format, $f, "format", {atom, ?DEFAULT_FORMAT},
+      "Format for the manifest. "
+      "Supported formats are: erlang, eetf (Erlang External Binary Format)"},
+     {to, $t, "to", {string, undefined},
+      "If specified, write the manifest to file"}].
 
 -spec get_manifest(rebar_state:t()) -> manifest().
 get_manifest(State) ->
-  ProjectApps = rebar_state:project_apps(State),
-  DepApps = rebar_state:all_deps(State),
-  #{
-    apps => [adapt_context(App) || App <- ProjectApps],
-    deps => [adapt_context(App) || App <- DepApps],
-    otp_lib_dir => code:lib_dir(),
-    source_root => rebar_state:dir(State)
-   }.
+    ProjectApps = rebar_state:project_apps(State),
+    DepApps = rebar_state:all_deps(State),
+    #{apps => [adapt_context(App) || App <- ProjectApps],
+      deps => [adapt_context(App) || App <- DepApps],
+      otp_lib_dir => code:lib_dir(),
+      source_root => rebar_state:dir(State)}.
 
 -spec adapt_context(rebar_app_info:t()) -> app_context().
 adapt_context(App) ->
-  Context0 = rebar_compiler_erl:context(App),
-  Context1 = maps:put(name, rebar_app_info:name(App), Context0),
-  OutMappings = [#{extension => Extension, path => Path} ||
-                  {Extension, Path} <- maps:get(out_mappings, Context1)],
-  maps:put(out_mappings, OutMappings, Context1).
+    Context0 = rebar_compiler_erl:context(App),
+    Context1 = maps:put(name, rebar_app_info:name(App), Context0),
+    OutMappings = [#{extension => Extension, path => Path} ||
+                      {Extension, Path} <- maps:get(out_mappings, Context1)],
+    maps:put(out_mappings, OutMappings, Context1).
 
 -spec output_manifest(binary(), string() | undefined) -> ok | {error, term()}.
 output_manifest(Manifest, undefined) ->
-  rebar_log:log(info, "Writing manifest to stdout:~n", []),
-  io:fwrite("~s~n", [Manifest]);
+    rebar_log:log(info, "Writing manifest to stdout:~n", []),
+    io:fwrite("~s~n", [Manifest]);
 output_manifest(Manifest, File) ->
-  rebar_log:log(info, "Build info written to: ~ts~n", [File]),
-  file:write_file(File, Manifest).
+    rebar_log:log(info, "Build info written to: ~ts~n", [File]),
+    file:write_file(File, Manifest).
 
 -spec format(manifest(), format()) -> {ok, binary()} | {error, {format_not_supported, term()}}.
 format(Manifest, eetf) ->
-  {ok, term_to_binary(Manifest)};
+    {ok, term_to_binary(Manifest)};
 format(Manifest, erlang) ->
-  {ok, unicode:characters_to_binary(io_lib:format("~p.", [Manifest]))};
+    {ok, unicode:characters_to_binary(io_lib:format("~p.", [Manifest]))};
 format(_Manifest, Format) ->
-  {error, {format_not_supported, Format}}.
+    {error, {format_not_supported, Format}}.

--- a/apps/rebar/src/rebar_prv_manifest.erl
+++ b/apps/rebar/src/rebar_prv_manifest.erl
@@ -13,6 +13,7 @@
 -include_lib("providers/include/providers.hrl").
 
 -define(PROVIDER, manifest).
+-define(NAMESPACE, experimental).
 -define(DEFAULT_FORMAT, erlang).
 
 -type extension() :: string().
@@ -38,9 +39,10 @@
 init(State) ->
     State1 = rebar_state:add_provider(State,
                                       providers:create([{name, ?PROVIDER},
+                                                        {namespace, ?NAMESPACE},
                                                         {module, ?MODULE},
                                                         {bare, true},
-                                                        {deps, [install_deps]},
+                                                        {deps, [{default, install_deps}]},
                                                         {example, "rebar3 manifest"},
                                                         {short_desc, short_desc()},
                                                         {desc, desc()},

--- a/apps/rebar/test/rebar_manifest_SUITE.erl
+++ b/apps/rebar/test/rebar_manifest_SUITE.erl
@@ -1,0 +1,67 @@
+-module(rebar_manifest_SUITE).
+
+-export([all/0,
+         init_per_testcase/2,
+         end_per_testcase/2,
+         basic_check/1,
+         write_to_file_erlang/1,
+         write_to_file_eetf/1,
+         non_supported_format/1
+        ]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+all() -> [
+          basic_check,
+          write_to_file_erlang,
+          write_to_file_eetf,
+          non_supported_format
+         ].
+
+init_per_testcase(Case, Config0) ->
+    %% Create a project directory in the test run's priv_dir
+    Config = rebar_test_utils:init_rebar_state(Config0),
+    %% Create toy applications
+    AppDir = ?config(apps, Config),
+    Name = rebar_test_utils:create_random_name("app1_"++atom_to_list(Case)),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    %% Add the data to the test config
+    [{name, unicode:characters_to_binary(Name)} | Config].
+
+end_per_testcase(_, Config) ->
+    Config.
+
+basic_check(Config) ->
+  rebar_test_utils:run_and_check(Config, [],
+                                 ["manifest"],
+                                 {ok, []}).
+
+write_to_file_erlang(Config) ->
+  AppName = proplists:get_value(name, Config),
+  PrivDir = proplists:get_value(priv_dir, Config),
+  FilePath = filename:join([PrivDir, "manifest"]),
+  rebar_test_utils:run_and_check(Config, [],
+                                 ["manifest", "--to", FilePath],
+                                 {ok, []}),
+  {ok, [Manifest]} = file:consult(FilePath),
+  ?assertMatch(#{deps := [], apps := [#{name := AppName}]}, Manifest).
+
+write_to_file_eetf(Config) ->
+  AppName = proplists:get_value(name, Config),
+  PrivDir = proplists:get_value(priv_dir, Config),
+  FilePath = filename:join([PrivDir, "manifest"]),
+  rebar_test_utils:run_and_check(Config, [],
+                                 ["manifest", "--to", FilePath, "--format", "eetf"],
+                                 {ok, []}),
+  {ok, Content} = file:read_file(FilePath),
+  Manifest = binary_to_term(Content),
+  ?assertMatch(#{deps := [], apps := [#{name := AppName}]}, Manifest).
+
+non_supported_format(Config) ->
+  PrivDir = proplists:get_value(priv_dir, Config),
+  FilePath = filename:join([PrivDir, "manifest"]),
+  rebar_test_utils:run_and_check(Config, [],
+                                 ["manifest", "--to", FilePath, "--format", "non-existing"],
+                                 {error,{rebar_prv_manifest,{format_not_supported,'non-existing'}}}).

--- a/apps/rebar/test/rebar_manifest_SUITE.erl
+++ b/apps/rebar/test/rebar_manifest_SUITE.erl
@@ -11,6 +11,8 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
+-define(NAMESPACE, "experimental").
+
 all() -> [basic_check,
           write_to_file_erlang,
           write_to_file_eetf,
@@ -32,7 +34,7 @@ end_per_testcase(_, Config) ->
 
 basic_check(Config) ->
     rebar_test_utils:run_and_check(Config, [],
-                                   ["manifest"],
+                                   [?NAMESPACE, "manifest"],
                                    {ok, []}).
 
 write_to_file_erlang(Config) ->
@@ -40,7 +42,7 @@ write_to_file_erlang(Config) ->
     PrivDir = proplists:get_value(priv_dir, Config),
     FilePath = filename:join([PrivDir, "manifest"]),
     rebar_test_utils:run_and_check(Config, [],
-                                   ["manifest", "--to", FilePath],
+                                   [?NAMESPACE, "manifest", "--to", FilePath],
                                    {ok, []}),
     {ok, [Manifest]} = file:consult(FilePath),
     ?assertMatch(#{deps := [], apps := [#{name := AppName}]}, Manifest).
@@ -50,7 +52,7 @@ write_to_file_eetf(Config) ->
     PrivDir = proplists:get_value(priv_dir, Config),
     FilePath = filename:join([PrivDir, "manifest"]),
     rebar_test_utils:run_and_check(Config, [],
-                                   ["manifest", "--to", FilePath, "--format", "eetf"],
+                                   [?NAMESPACE, "manifest", "--to", FilePath, "--format", "eetf"],
                                    {ok, []}),
     {ok, Content} = file:read_file(FilePath),
     Manifest = binary_to_term(Content),
@@ -60,5 +62,5 @@ non_supported_format(Config) ->
     PrivDir = proplists:get_value(priv_dir, Config),
     FilePath = filename:join([PrivDir, "manifest"]),
     rebar_test_utils:run_and_check(Config, [],
-                                   ["manifest", "--to", FilePath, "--format", "non-existing"],
-                                   {error,{rebar_prv_manifest,{format_not_supported,'non-existing'}}}).
+                                   [?NAMESPACE, "manifest", "--to", FilePath, "--format", "non-existing"],
+                                   {error, {rebar_prv_manifest, {format_not_supported, 'non-existing'}}}).

--- a/apps/rebar/test/rebar_manifest_SUITE.erl
+++ b/apps/rebar/test/rebar_manifest_SUITE.erl
@@ -6,18 +6,15 @@
          basic_check/1,
          write_to_file_erlang/1,
          write_to_file_eetf/1,
-         non_supported_format/1
-        ]).
+         non_supported_format/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
-all() -> [
-          basic_check,
+all() -> [basic_check,
           write_to_file_erlang,
           write_to_file_eetf,
-          non_supported_format
-         ].
+          non_supported_format].
 
 init_per_testcase(Case, Config0) ->
     %% Create a project directory in the test run's priv_dir
@@ -34,34 +31,34 @@ end_per_testcase(_, Config) ->
     Config.
 
 basic_check(Config) ->
-  rebar_test_utils:run_and_check(Config, [],
-                                 ["manifest"],
-                                 {ok, []}).
+    rebar_test_utils:run_and_check(Config, [],
+                                   ["manifest"],
+                                   {ok, []}).
 
 write_to_file_erlang(Config) ->
-  AppName = proplists:get_value(name, Config),
-  PrivDir = proplists:get_value(priv_dir, Config),
-  FilePath = filename:join([PrivDir, "manifest"]),
-  rebar_test_utils:run_and_check(Config, [],
-                                 ["manifest", "--to", FilePath],
-                                 {ok, []}),
-  {ok, [Manifest]} = file:consult(FilePath),
-  ?assertMatch(#{deps := [], apps := [#{name := AppName}]}, Manifest).
+    AppName = proplists:get_value(name, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
+    FilePath = filename:join([PrivDir, "manifest"]),
+    rebar_test_utils:run_and_check(Config, [],
+                                   ["manifest", "--to", FilePath],
+                                   {ok, []}),
+    {ok, [Manifest]} = file:consult(FilePath),
+    ?assertMatch(#{deps := [], apps := [#{name := AppName}]}, Manifest).
 
 write_to_file_eetf(Config) ->
-  AppName = proplists:get_value(name, Config),
-  PrivDir = proplists:get_value(priv_dir, Config),
-  FilePath = filename:join([PrivDir, "manifest"]),
-  rebar_test_utils:run_and_check(Config, [],
-                                 ["manifest", "--to", FilePath, "--format", "eetf"],
-                                 {ok, []}),
-  {ok, Content} = file:read_file(FilePath),
-  Manifest = binary_to_term(Content),
-  ?assertMatch(#{deps := [], apps := [#{name := AppName}]}, Manifest).
+    AppName = proplists:get_value(name, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
+    FilePath = filename:join([PrivDir, "manifest"]),
+    rebar_test_utils:run_and_check(Config, [],
+                                   ["manifest", "--to", FilePath, "--format", "eetf"],
+                                   {ok, []}),
+    {ok, Content} = file:read_file(FilePath),
+    Manifest = binary_to_term(Content),
+    ?assertMatch(#{deps := [], apps := [#{name := AppName}]}, Manifest).
 
 non_supported_format(Config) ->
-  PrivDir = proplists:get_value(priv_dir, Config),
-  FilePath = filename:join([PrivDir, "manifest"]),
-  rebar_test_utils:run_and_check(Config, [],
-                                 ["manifest", "--to", FilePath, "--format", "non-existing"],
-                                 {error,{rebar_prv_manifest,{format_not_supported,'non-existing'}}}).
+    PrivDir = proplists:get_value(priv_dir, Config),
+    FilePath = filename:join([PrivDir, "manifest"]),
+    rebar_test_utils:run_and_check(Config, [],
+                                   ["manifest", "--to", FilePath, "--format", "non-existing"],
+                                   {error,{rebar_prv_manifest,{format_not_supported,'non-existing'}}}).


### PR DESCRIPTION
The `manifest` provider allows users to extract information about a `rebar3` project, so that the information can be used by external tools such as language servers to learn about the structure of a project. The format and content of the produced manifest is totally up for debate. This is just to start the discussion. Ideally, the manifest should not be tight to `rebar3` as a build tool. This would enable other build tools to produce an equivalent file.

The provider is inspired by the [build_info](https://github.com/WhatsApp/eqwalizer/blob/main/eqwalizer_rebar3/src/eqwalizer_build_info_prv.erl) one which is part of the `eqWalizer` type checker for Erlang, but uses built-in functionality to fetch dependencies.

Having a built-in provider would remove friction for language server users and implementors. [ELP](https://github.com/whatsapp/erlang-language-platform) users are currently required to [install additional plugins](https://whatsapp.github.io/erlang-language-platform/docs/get-started/emacs/#rebar3-build-info-plugin) to be able to use the language server.
Erlang LS implementors are attempting efforts such as [this one](https://github.com/erlang-ls/erlang_ls/commit/63b18395ac313cc4a975b30c54749ab172c6848c), to approximate the structure of a `rebar3` project. A built-in manifest provider would simplify all of this.

## Format

Ideally, one could have used JSON as the standard format for the manifest (the _Rust Analyzer_ language server uses a [rust-project.json](https://rust-analyzer.github.io/manual.html#non-cargo-based-projects) format for a similar concept. Unfortunately, there's currently no JSON library provided out-of-the-box by Erlang/OTP or rebar3, so I'm defaulting to Erlang terms. I am also adding the ability to use `EETF` ([Erlang External Term Format](https://www.erlang.org/doc/apps/erts/erl_ext_dist.html)) as an alternative format, since this is the format currently used by the ELP language server via the `build_info` plugin.

## Output

By default the provider outputs the manifest to stdout. For this reason, logging is disabled by the provider (an alternative would have been to ask users to use the `QUIET=1` option or to filter out extraneous log messages). A dedicated option provides the ability to dump the manifest to file. This is mostly done to simplify testing and to avoid playing with group leaders or similar approaches. Again, this is all open for discussion.

## Example

Running the command:

```
rebar3 manifest
```

For the `Erlang LS project` would produce something like [this](https://gist.github.com/robertoaloi/af97c28569ef10049cb98aa76a93616d).