### PR TITLE
Make log_level entry in rebar.app work again

### DIFF
--- a/apps/rebar/src/rebar.app.src.script
+++ b/apps/rebar/src/rebar.app.src.script
@@ -36,7 +36,7 @@
                  ]},
   {env, [
         %% Default log level
-        {log_level, warn},
+        {log_level, info},
 
         {resources, [{git, rebar_git_resource},
                      {git_subdir, rebar_git_subdir_resource},

--- a/apps/rebar/src/rebar3.erl
+++ b/apps/rebar/src/rebar3.erl
@@ -306,7 +306,12 @@ log_level() ->
                 Di when Di == false; Di == "" ->
                     case os:getenv("DEBUG") of
                         D when D == false; D == "" ->
-                            rebar_log:default_level();
+                            try
+                                {ok, L} = application:get_env(rebar, log_level),
+                                 rebar_log:atom_to_level(L)
+                            catch
+                                _:_ -> rebar_log:default_level()
+                            end;
                         _ ->
                             rebar_log:debug_level()
                     end;

--- a/apps/rebar/src/rebar_log.erl
+++ b/apps/rebar/src/rebar_log.erl
@@ -34,6 +34,7 @@
          default_level/0,
          debug_level/0,
          diagnostic_level/0,
+         atom_to_level/1,
          intensity/0,
          log/3,
          is_verbose/1,
@@ -142,6 +143,15 @@ is_verbose(State) ->
 
 valid_level(Level) ->
     erlang:max(?ERROR_LEVEL, erlang:min(Level, ?DIAGNOSTIC_LEVEL)).
+
+atom_to_level(Level) ->
+    case Level of
+        error -> ?ERROR_LEVEL;
+        warn  -> ?WARN_LEVEL;
+        info  -> ?INFO_LEVEL;
+        debug -> ?DEBUG_LEVEL;
+        diagnostic -> ?DIAGNOSTIC_LEVEL
+    end.
 
 %% ===================================================================
 %% Internal functions


### PR DESCRIPTION
The log_level app setting had become ignored during refactorings of old. This makes it take effect again and syncs its standard setting with that of with rebar_log:default_level(). We add rebar_log:atom_to_level/1 to avoid exposing the level numbers used internally.