### PR TITLE
Fix "clean" hooks in non-umbrella apps and when override are presents

### DIFF
--- a/apps/rebar/src/rebar_prv_clean.erl
+++ b/apps/rebar/src/rebar_prv_clean.erl
@@ -12,7 +12,7 @@
 -include("rebar.hrl").
 
 -define(PROVIDER, clean).
--define(DEPS, [app_discovery, install_deps]).
+-define(DEPS, []).
 
 %% ===================================================================
 %% Public API
@@ -37,7 +37,13 @@ do(State) ->
     Providers = rebar_state:providers(State),
     {All, Profiles, Specific} = handle_args(State),
 
-    State1 = rebar_state:apply_profiles(State, [list_to_atom(X) || X <- Profiles]),
+    %% Invoke provider deps as the desired profile(s) so the discovery of
+    %% apps respects profile options.
+    State0 = rebar_state:command_args(
+        State,
+        lists:join(",", ["default"|Profiles]) ++ ["install_deps"]
+    ),
+    {ok, State1} = rebar_prv_as:do(State0),
 
     Cwd = rebar_dir:get_cwd(),
     rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State1),
@@ -45,7 +51,14 @@ do(State) ->
     if All; Specific =/= [] ->
         DepsDir = rebar_dir:deps_dir(State1),
         DepsDirs = filelib:wildcard(filename:join(DepsDir, "*")),
-        AllApps = rebar_app_discover:find_apps(DepsDirs, all, State),
+        ProjectApps = rebar_state:project_apps(State1),
+        Deps = rebar_state:all_deps(State1),
+        KnownAppNames = [rebar_app_info:name(App) || App <- ProjectApps++Deps],
+        ParsedApps = rebar_app_discover:find_apps(DepsDirs, all, State1),
+        AllApps = ProjectApps ++ Deps ++
+                  [App || App <- ParsedApps,
+                          not lists:member(rebar_app_info:name(App),
+                                           KnownAppNames)],
         Filter = case All of
             true -> fun(_) -> true end;
             false -> fun(AppInfo) -> filter_name(AppInfo, Specific) end

--- a/apps/rebar/src/rebar_prv_clean.erl
+++ b/apps/rebar/src/rebar_prv_clean.erl
@@ -39,9 +39,12 @@ do(State) ->
 
     %% Invoke provider deps as the desired profile(s) so the discovery of
     %% apps respects profile options.
+    Task = if All; Specific =/= [] -> "install_deps";
+              true -> "app_discovery"
+           end,
     State0 = rebar_state:command_args(
         State,
-        lists:join(",", ["default"|Profiles]) ++ ["install_deps"]
+        lists:join(",", ["default"|Profiles]) ++ [Task]
     ),
     {ok, State1} = rebar_prv_as:do(State0),
 

--- a/apps/rebar/test/rebar_as_SUITE.erl
+++ b/apps/rebar/test/rebar_as_SUITE.erl
@@ -198,4 +198,5 @@ clean_as_profile(Config) ->
     rebar_test_utils:run_and_check(Config,
                                    [],
                                    ["clean", "-a", "-p", "foo"],
-                                   {ok, [{app, Name, invalid}]}).
+                                   {ok, [{app, Name, invalid}]}),
+    ok.

--- a/apps/rebar/test/rebar_hooks_SUITE.erl
+++ b/apps/rebar/test/rebar_hooks_SUITE.erl
@@ -166,10 +166,17 @@ deps_clean_hook_namespace(Config) ->
             ]}
         ]}
     ],
+    %% Only detect dependencies when asked to parse them.
+    %% Avoids scanning and fetching them only to clean them.
     rebar_test_utils:run_and_check(
         Config, RebarConfig, ["clean"],
+        {ok, [{dep_not_exist, "some_dep"}]}
+    ),
+    rebar_test_utils:run_and_check(
+        Config, RebarConfig, ["clean", "-a"],
         {ok, [{dep, "some_dep"}]}
-    ).
+    ),
+    ok.
 
 %% Checks that a hook that is defined on an app (not a top level hook of a project with subapps) is run
 eunit_app_hooks(Config) ->


### PR DESCRIPTION
The issue appears to be that because the 'clean' operation might be run while dependencies have not yet been compiled, we applied a partial app detection mechanism with `rebar_app_disover:find_apps(..., ..., all, ...)`, which worked to parse "invalid" (unbuilt) apps, but also did not apply overrides.

Instead, we trust the `install_deps` provider dependency by reusing the apps as they were fully parsed _if_ they were valid, and falling back to the `rebar_app_discover:find_apps/4` call only to cover the unreadable ones.

This, it turns out, has the side effect of properly applying hooks when apps are fully parsed, and fixes https://github.com/erlang/rebar3/issues/2862

In turn, this change let me fix things up such that we no longer call `install_deps` when just calling `rebar3 clean` -- we still need to call it when doing a broader clean (`--apps` or `--all`) but not when just calling it with no arguments.