### PR TITLE
Eliminate use of experimental function code:lib_dir/2

### DIFF
--- a/apps/rebar/src/rebar_compiler_erl.erl
+++ b/apps/rebar/src/rebar_compiler_erl.erl
@@ -454,11 +454,11 @@ maybe_expand_include_lib_path(File, Dir) ->
         [_] ->
             warn_and_find_path(File, Dir);
         [Lib | SubDir] ->
-            case code:lib_dir(list_to_atom(Lib), list_to_atom(filename:join(SubDir))) of
+            case code:lib_dir(list_to_atom(Lib)) of
                 {error, bad_name} ->
                     warn_and_find_path(File, Dir);
                 AppDir ->
-                    [filename:join(AppDir, File1)]
+                    [filename:join([AppDir] ++ SubDir ++ [File1])]
             end
     end.
 

--- a/apps/rebar/src/rebar_erlc_compiler.erl
+++ b/apps/rebar/src/rebar_erlc_compiler.erl
@@ -755,11 +755,11 @@ maybe_expand_include_lib_path(File, Dir) ->
         [_] ->
             warn_and_find_path(File, Dir);
         [Lib | SubDir] ->
-            case code:lib_dir(list_to_atom(Lib), list_to_atom(filename:join(SubDir))) of
+            case code:lib_dir(list_to_atom(Lib)) of
                 {error, bad_name} ->
                     warn_and_find_path(File, Dir);
                 AppDir ->
-                    [filename:join(AppDir, File1)]
+                    [filename:join([AppDir] ++ SubDir ++ [File1])]
             end
     end.
 

--- a/apps/rebar/src/rebar_prv_dialyzer.erl
+++ b/apps/rebar/src/rebar_prv_dialyzer.erl
@@ -298,13 +298,14 @@ app_files(AppName, ExtraDirs) ->
     end.
 
 app_ebin(AppName) ->
-    case code:lib_dir(AppName, ebin) of
+    case code:lib_dir(AppName) of
         {error, bad_name} = Error ->
             Error;
-        EbinDir ->
+        AppDir ->
+            EbinDir = filename:join(AppDir, "ebin"),
             case check_ebin(EbinDir) of
                 {error, bad_name} ->
-                    check_ebin(filename:join(code:lib_dir(AppName), "preloaded/ebin"));
+                    check_ebin(filename:join(AppDir, "preloaded/ebin"));
                 Response ->
                     Response
             end

--- a/apps/rebar/src/rebar_prv_escriptize.erl
+++ b/apps/rebar/src/rebar_prv_escriptize.erl
@@ -191,10 +191,11 @@ get_apps_beams([App | Rest], AllApps, Acc) ->
             Beams = get_app_beams(App, OutDir),
             get_apps_beams(Rest, AllApps, Beams ++ Acc);
         _->
-            case code:lib_dir(App, ebin) of
+            case code:lib_dir(App) of
                 {error, bad_name} ->
                     throw(?PRV_ERROR({bad_name, App}));
-                Path ->
+                AppDir ->
+                    Path = filename:join(AppDir, "ebin"),
                     Beams = get_app_beams(App, Path),
                     get_apps_beams(Rest, AllApps, Beams ++ Acc)
             end

--- a/vendor/relx/src/rlx_assemble.erl
+++ b/vendor/relx/src/rlx_assemble.erl
@@ -741,7 +741,7 @@ maybe_check_for_undefined_functions_(State, Release) ->
             %% without adding the erts application there will be warnings about 
             %% missing functions from the preloaded modules even though they 
             %% are in the runtime.
-            ErtsApp = code:lib_dir(erts, ebin),
+            ErtsApp = filename:join(code:lib_dir(erts), "ebin"),
 
             %% xref library path is what is searched for functions used by the 
             %% project apps. 


### PR DESCRIPTION
The `code:lib_dir/2` function was introduced to support looking into archives. Both archives and the `code:lib_dir/2` are marked as experimental.

In the upcoming Erlang/OTP 27 release, `code:lib_dir/2` will be deprecated. In some future release, the archive functionality will be changed (`escript:extract/2` will continue to work, reading archive members using `erl_prim_loader` will not).