### PR TITLE
`zsh` support for aliases in `completion`

### DIFF
--- a/apps/rebar/src/rebar_completion_zsh.erl
+++ b/apps/rebar/src/rebar_completion_zsh.erl
@@ -7,12 +7,15 @@
 -export([generate/2]).
 
 -spec generate([rebar_completion:cmpl_cmd()], rebar_completion:cmpl_opts()) -> iolist().
-generate(Commands, #{shell:=zsh}=CmplOpts) ->
-    ["#compdef _rebar3 rebar3\n",
-        rebar_completion:prelude(CmplOpts),
+generate(Commands, #{shell:=zsh, aliases:=As}=CmplOpts) ->
+    [rebar_completion:prelude(CmplOpts),
         io_lib:nl(),
         main(Commands, CmplOpts),
-        io_lib:nl()].
+        io_lib:nl(),
+        compdefs(["rebar3" | As])].
+
+compdefs(As) ->
+    [["compdef _rebar3 ", A, io_lib:nl()] || A <- As].
 
 main(Commands, CmplOpts) ->
     H = #{short=>$s,

--- a/apps/rebar/test/rebar_completion_SUITE.erl
+++ b/apps/rebar/test/rebar_completion_SUITE.erl
@@ -77,15 +77,19 @@ check_bash(Config) ->
 
 check_zsh(Config) ->
     ComplFile = ?config(compl_file, Config),
+    Aliases = ["rebar", "r3"],
     Opts = #{shell => zsh,
              file => ComplFile,
-             aliases => []},
+             aliases => Aliases},
     completion_gen(Config, Opts),
     {ok, Completion} = file:read_file(ComplFile),
     %% function definition
     {match, _} = re:run(Completion, "function _rebar3 {"),
-    CompleteCmd = "#compdef _rebar3 ",
-    ?assertMatch({match, _}, re:run(Completion, CompleteCmd++"rebar3"++"\n")).
+    CompleteCmd = "compdef _rebar3 ",
+    lists:foreach(fun(Alias) ->
+                    ?assertMatch({Alias, {match, _}}, {Alias, re:run(Completion, CompleteCmd++Alias++"\n")})
+                  end,
+                  ["rebar3" | Aliases]).
 
 %% helpers
 


### PR DESCRIPTION
I was writing docs for `completion` provider and tried to simplify loading `zsh` completion. I copied the loading process from `1pw` which stated that `zsh` completion must be done in multiple files. However, I found that's not true - you bind multiple commands to a completion function in a singe file. 

That enables automatic usage of aliases in zsh and unifies the whole process (usage becomes simpler)!

Also, I fixed a bug where aliases weren't split into multiple ones, I dunno how I missed that before.dsa