### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Create release and publish escript for every new tag


### PR DESCRIPTION
I believe that the OTP org, which has the parent org for this repo, has narrowed permissions for github action tokens since the last release.

We can ask for more permissions for this with the [proper permissions declaration](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions).

This PR is an attempt at turning this on so we can publish Rebar3 3.23.0 by unlocking the `contents` permission in write mode on tagged pushes, which should unblock us. If it doesn't work I'll need to go back to manually tagging and maybe figuring out local containers for build artifact uploads.