### PR TITLE
Turn rich compiler errors on by default

### DIFF
--- a/apps/rebar/src/rebar.hrl
+++ b/apps/rebar/src/rebar.hrl
@@ -28,7 +28,7 @@
 -define(DEFAULT_CDN, "https://repo.hex.pm").
 -define(LOCK_FILE, "rebar.lock").
 -define(DEFAULT_COMPILER_SOURCE_FORMAT, relative).
--define(DEFAULT_COMPILER_ERROR_FORMAT, minimal). % 'rich' for multiline values
+-define(DEFAULT_COMPILER_ERROR_FORMAT, rich). % 'minimal' for default values as of 3.23.0 and earlier
 -define(PACKAGE_INDEX_VERSION, 6).
 -define(PACKAGE_TABLE, package_index).
 -define(INDEX_FILE, "packages.idx").

--- a/apps/rebar/src/rebar_compiler_format.erl
+++ b/apps/rebar/src/rebar_compiler_format.erl
@@ -23,7 +23,7 @@ format(Source, {Line, Column}, Extra, Desc, Config) ->
                  [LnPad, Source,
                   LnPad,
                   Line, colorize(LnBin, Column),
-                  LnPad, lists:duplicate(max(0, Column-1), " "), Arrow, Extra, Desc]);
+                  LnPad, indent(max(0, Column-1), LnBin), Arrow, Extra, Desc]);
         _ ->
             ?FMT("~ts:~w:~w: ~ts~ts~n", [Source, Line, Column, Extra, Desc])
     end.
@@ -36,6 +36,10 @@ find_line(Nth, Source) ->
   catch
       error:X -> {error, X}
   end.
+
+indent(0, _) -> "";
+indent(N, <<"\t", Rest/binary>>) -> [$\t | indent(N-1, Rest)];
+indent(N, <<_/utf8, Rest/binary>>) -> [$\s | indent(N-1, Rest)].
 
 compiler_error_format(Opts) ->
     %% `Opts' can be passed in both as a list or a dictionary depending

--- a/apps/rebar/test/rebar_compiler_format_SUITE.erl
+++ b/apps/rebar/test/rebar_compiler_format_SUITE.erl
@@ -37,7 +37,7 @@ oracle() ->
     ++ lists:duplicate(9, $\n) ++
     "first character on line 11.\n"
     ++ lists:duplicate(99, $\n) ++
-    "case X of ^whatever % on line 111\n".
+    "case \tX of ^whatever % on line 111\n".
 
 minimal() ->
     [{doc, "showing minimal (default) output"}].
@@ -48,8 +48,8 @@ minimal(Config) ->
                  rebar_compiler_format:format(Path, {1,20}, "=> ", "unexpected token: ;", Conf)),
     ?assertEqual(Path++":11:1: some message"++?EOL,
                  rebar_compiler_format:format(Path, {11,1}, "", "some message", Conf)),
-    ?assertEqual(Path++":111:11: the character '^' is not expected here."++?EOL,
-                 rebar_compiler_format:format(Path, {111,11}, "", "the character '^' is not expected here.", Conf)),
+    ?assertEqual(Path++":111:12: the character '^' is not expected here."++?EOL,
+                 rebar_compiler_format:format(Path, {111,12}, "", "the character '^' is not expected here.", Conf)),
     ?assertEqual(Path++":-23:-42: invalid ranges."++?EOL,
                  rebar_compiler_format:format(Path, {-23,-42}, "", "invalid ranges.", Conf)),
     ?assertEqual(Path++":-23:-42: invalid ranges."++?EOL,
@@ -78,9 +78,9 @@ nocolor(Config) ->
                  rebar_compiler_format:format(Path, {11,1}, "", "some message", Conf)),
     ?assertEqual("     ┌─ "++Path++":"++?EOL++
                  "     │"++?EOL++
-                 " 111 │  case X of ^whatever % on line 111"++?EOL++
-                 "     │            ╰── the character '^' is not expected here."++?EOL++?EOL,
-                 rebar_compiler_format:format(Path, {111,11}, "", "the character '^' is not expected here.", Conf)),
+                 " 111 │  case \tX of ^whatever % on line 111"++?EOL++
+                 "     │       \t     ╰── the character '^' is not expected here."++?EOL++?EOL,
+                 rebar_compiler_format:format(Path, {111,12}, "", "the character '^' is not expected here.", Conf)),
     %% invalid cases fall back to minimal mode
     ?assertEqual(Path++":-23:-42: invalid ranges."++?EOL,
                  rebar_compiler_format:format(Path, {-23,-42}, "", "invalid ranges.", Conf)),


### PR DESCRIPTION
They've been enabled almost a year ago since [3.22.0](https://github.com/erlang/rebar3/releases/tag/3.22.0).

I've [started gathering feedback on the Erlang Forums about it](https://erlangforums.com/t/rebar3-upgrades/1558/6), and have been using it the whole time. 

Once a long enough period has gone without any significant opposition, I'll merge this, with instructions on how to turn this off on the docs site.