### PR TITLE
Removed unsused platform_define options

### DIFF
--- a/apps/rebar/rebar.config
+++ b/apps/rebar/rebar.config
@@ -66,12 +66,7 @@
                 {erl_opts, [no_debug_info]},
                 {overrides, [
                     {override, erlware_commons, [
-                        {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
-                                    {platform_define, "^R1[4|5]", deprecated_crypto},
-                                    {platform_define, "^((1[8|9])|2)", rand_module},
-                                    {platform_define, "^2", unicode_str},
-                                    {platform_define, "^(R|1|20)", fun_stacktrace},
-                                    no_debug_info,
+                        {erl_opts, [no_debug_info,
                                     warnings_as_errors]},
                         {deps, []}, {plugins, []}]},
                     {add, ssl_verify_hostname, [{erl_opts, [no_debug_info]}]},

--- a/rebar.config
+++ b/rebar.config
@@ -45,12 +45,7 @@
         {erl_opts, [no_debug_info]},
         {overrides, [
             {override, erlware_commons, [
-                {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
-                            {platform_define, "^R1[4|5]", deprecated_crypto},
-                            {platform_define, "^((1[8|9])|2)", rand_module},
-                            {platform_define, "^2", unicode_str},
-                            {platform_define, "^(R|1|20)", fun_stacktrace},
-                            no_debug_info,
+                {erl_opts, [no_debug_info,
                             warnings_as_errors]},
                 {deps, []}, {plugins, []}]},
             {add, ssl_verify_hostname, [{erl_opts, [no_debug_info]}]},


### PR DESCRIPTION
Since erlware_commons bumped to 1.7.0, these options are of no use.

```shell
# grep -r platform_define vendor/erlware_commons/*; echo $?
1
```