### PR TITLE
Removed fun_stacktrace

### DIFF
--- a/apps/rebar/rebar.config
+++ b/apps/rebar/rebar.config
@@ -34,8 +34,7 @@
 
 {erl_opts, [warnings_as_errors,
             {platform_define, "^(2[1-9])|(20\\\\.3)", filelib_find_source},
-            {platform_define, "^(1|(20))", no_customize_hostname_check},
-            {platform_define, "^(20)", fun_stacktrace}
+            {platform_define, "^(1|(20))", no_customize_hostname_check}
            ]}.
 
 {edoc_opts, [preprocess]}.

--- a/apps/rebar/src/rebar.hrl
+++ b/apps/rebar/src/rebar.hrl
@@ -63,11 +63,7 @@
 -type rebar_digraph() :: digraph:graph().
 -type rebar_set() :: sets:set().
 
--ifdef(fun_stacktrace).
--define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(),).
--else.
 -define(WITH_STACKTRACE(T, R, S), T:R:S ->).
--endif.
 
 -define(GRAPH_VSN, 2).
 -type v() :: {digraph:vertex(), term()} | 'false'.


### PR DESCRIPTION
* introduced by 5f9b4293bc029e2132d7c442cb5b4480915ea0e4
* CI/CD uses R24 and onwards
* [`erlang:get_stacktrace/0` removed in R23](https://erlang.org/documentation/doc-12.0-rc2/doc/general_info/removed.html#functions-removed-in-otp-23).