### PR TITLE
Removed OTP_RELEASE macro statements

### DIFF
--- a/apps/rebar/src/rebar_uri.erl
+++ b/apps/rebar/src/rebar_uri.erl
@@ -19,7 +19,6 @@
            ((X) >= $a) andalso ((X) =< $f) -> (X) - $a + 10
         end).
 
--ifdef(OTP_RELEASE).
 -spec parse(URIString) -> URIMap when
     URIString :: uri_string:uri_string(),
     URIMap :: uri_string:uri_map() | uri_string:error().
@@ -33,41 +32,7 @@ parse(URIString, URIOpts) ->
         Map when is_map(Map) -> apply_opts(Map, URIOpts);
         {error, _, _} = E -> E
     end.
--else.
--spec parse(URIString) -> URIMap when
-    URIString :: iodata(),
-    URIMap :: map() | {error, term(), term()}.
 
-parse(URIString) ->
-    parse(URIString, []).
-
-parse(URIString, URIOpts) ->
-    case http_uri:parse(URIString, URIOpts) of
-        {error, Reason} ->
-            %% no additional parser/term info available to us,
-            %% e.g. see what uri_string returns in
-            %% uri_string:parse(<<"h$ttp:::://////lolz">>).
-            {error, "", Reason};
-        {ok, {Scheme, UserInfo, Host, Port, Path, Query}} ->
-            #{
-                scheme => rebar_utils:to_list(Scheme),
-                host => Host,
-                port => Port,
-                path => Path,
-                %% http_uri:parse/1 includes the leading question mark
-                %% in query string but uri_string:parse/1 leaves it out.
-                %% string:slice/2 isn't available in OTP <= 19.
-                query => case Query of
-                           [] -> "";
-                           _  -> string:substr(Query, 2)
-                         end,
-                userinfo => UserInfo
-            }
-    end.
--endif.
-
-%% OTP 21+
--ifdef(OTP_RELEASE).
 append_path(Url, ExtraPath) ->
      case parse(Url) of
          #{path := Path} = Map ->
@@ -76,29 +41,6 @@ append_path(Url, ExtraPath) ->
          _ ->
              error
      end.
--else.
-append_path(Url, ExtraPath) ->
-     case parse(Url) of
-         #{scheme := Scheme, userinfo := UserInfo, host := Host,
-           port := Port, path := Path, query := Query} ->
-             ListScheme = rebar_utils:to_list(Scheme),
-             PrefixedQuery = case Query of
-                               []    -> [];
-                               Other -> lists:append(["?", Other])
-                             end,
-             NormPath = case Path of
-                            "" -> "/";
-                            _ -> Path
-                        end,
-             {ok, maybe_port(
-                Url, lists:append([ListScheme, "://", UserInfo, Host]),
-                [$: | rebar_utils:to_list(Port)],
-                lists:append([join(NormPath, ExtraPath), PrefixedQuery])
-             )};
-         _ ->
-             error
-     end.
--endif.
 
 %% Taken from OTP 23.2
 -spec percent_decode(URI) -> Result when
@@ -127,15 +69,9 @@ percent_decode(URI) when is_list(URI) orelse
                          is_binary(URI) ->
     raw_decode(URI).
 
-%% OTP 21+
--ifdef(OTP_RELEASE).
 scheme_defaults() ->
     %% no scheme defaults here; just custom ones
     [].
--else.
-scheme_defaults() ->
-    http_uri:scheme_defaults().
--endif.
 
 join(URI, "") -> URI;
 join(URI, "/") -> URI;
@@ -146,7 +82,6 @@ join("", Path) -> [$/ | Path];
 join([H|T], Path) -> [H | join(T, Path)].
 
 
--ifdef(OTP_RELEASE).
 apply_opts(Map = #{port := _}, _) ->
     Map;
 apply_opts(Map = #{scheme := Scheme}, URIOpts) ->
@@ -162,13 +97,6 @@ apply_opts(Map = #{scheme := Scheme}, URIOpts) ->
         error:badarg -> % not an existing atom, not in the list
             Map
     end.
--else.
-maybe_port(Url, Host, Port, PathQ) ->
-    case lists:prefix(Host ++ Port, Url) of
-        true -> Host ++ Port ++ PathQ; % port was explicit
-        false -> Host ++ PathQ % port was implicit
-    end.
--endif.
 
 -spec raw_decode(list()|binary()) -> list() | binary() | error().
 raw_decode(Cs) ->

--- a/apps/rebar/src/rebar_utils.erl
+++ b/apps/rebar/src/rebar_utils.erl
@@ -982,11 +982,7 @@ get_http_vars(Scheme) ->
     Config = rebar_config:consult_file(GlobalConfigFile),
     proplists:get_value(Scheme, Config, OS).
 
--ifdef (OTP_RELEASE).
-  -if(?OTP_RELEASE >= 23).
-    -compile({nowarn_deprecated_function, [{http_uri, decode, 1}]}).
-  -endif.
--endif.
+-compile({nowarn_deprecated_function, [{http_uri, decode, 1}]}).
 
 set_httpc_options() ->
     set_httpc_options(https_proxy, get_http_vars(https_proxy)),


### PR DESCRIPTION
*  [`OTP_RELEASE` introduced in R21](https://www.erlang.org/doc/system/macros.html#predefined-macros)
* CI/CD uses R24 and onwards.