### PR TITLE
Bump supported version to OTP-27, deprecate OTP-24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Common Test
 on: [pull_request, push]
 
 env:
-  LATEST_OTP_RELEASE: 26
+  LATEST_OTP_RELEASE: 27
 
 jobs:
   linux:
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24, 25, 26]
+        otp_version: [25, 26, 27]
         os: [ubuntu-latest]
 
     container:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,9 @@ jobs:
     - name: Debug Brew
       run: brew doctor || true
     - name: Install Erlang
-      run: brew install erlang@${{ env.LATEST_OTP_RELEASE }}
+      #run: brew install erlang@${{ env.LATEST_OTP_RELEASE }}
+      # fall back to OTP-26 since OTP 27.0 doesn't build on homebrew due to manpages issues
+      run: brew install erlang@26
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: erlef/setup-beam@v1
       with:
-          otp-version: '24'
+          otp-version: '25'
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
 
     - uses: erlef/setup-beam@v1
       with:
-          otp-version: '24'
+          otp-version: '25'
     - name: Compile
       run: ./bootstrap
     - name: CT tests

--- a/.github/workflows/shelltests.yml
+++ b/.github/workflows/shelltests.yml
@@ -15,8 +15,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: erlef/setup-beam@v1
       with:
-          otp-version: '27.0'
-          elixir-version: '1.16'
+          otp-version: '26.0'
+          elixir-version: '1.14'
     - name: Compile
       run: ./bootstrap
     - name: Install

--- a/.github/workflows/shelltests.yml
+++ b/.github/workflows/shelltests.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: erlef/setup-beam@v1
       with:
-          otp-version: '26.0'
+          otp-version: '27.0'
           elixir-version: '1.14'
     - name: Compile
       run: ./bootstrap

--- a/.github/workflows/shelltests.yml
+++ b/.github/workflows/shelltests.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: erlef/setup-beam@v1
       with:
           otp-version: '27.0'
-          elixir-version: '1.14'
+          elixir-version: '1.16'
     - name: Compile
       run: ./bootstrap
     - name: Install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rebar3
 
-[![Build Status](https://github.com/erlang/rebar3/workflows/Common%20Test/badge.svg)](https://github.com/erlang/rebar3/actions?query=branch%3Amaster+workflow%3A"Common+Test") [![Erlang Versions](https://img.shields.io/badge/Supported%20Erlang%2FOTP-24.0%20to%2026.0-blue)](http://www.erlang.org)
+[![Build Status](https://github.com/erlang/rebar3/workflows/Common%20Test/badge.svg)](https://github.com/erlang/rebar3/actions?query=branch%3Amaster+workflow%3A"Common+Test") [![Erlang Versions](https://img.shields.io/badge/Supported%20Erlang%2FOTP-25.0%20to%2027.0-blue)](http://www.erlang.org)
 
 1. [What is Rebar3?](#what-is-rebar3)
 2. [Why Rebar3?](#why-rebar3)
@@ -94,7 +94,7 @@ by [Erlang Solutions](https://www.erlang-solutions.com/resources/download.html),
 but be sure to choose the "Standard" download option or you'll have issues building
 projects.
 
-Do note that if you are planning to work with multiple Erlang versions on the same machine, you will want to build Rebar3 with the oldest one of them. The 3 newest major Erlang releases are supported at any given time: if the newest version is OTP-26, building with versions as old as OTP-24 will be supported, and produce an executable that will work with those that follow.
+Do note that if you are planning to work with multiple Erlang versions on the same machine, you will want to build Rebar3 with the oldest one of them. The 3 newest major Erlang releases are supported at any given time: if the newest version is OTP-27, building with versions as old as OTP-25 will be supported, and produce an executable that will work with those that follow.
 
 ## Documentation
 


### PR DESCRIPTION
This is keeping in line with our support policy for versions.


Opened as a Draft PR until we can show Dialyzer is happy (✅) and all of CI works (❌).

- Elixir version support needed to be bumped to shelltests, but Elixir does not yet recognize 27.0 in its own versions
- the MacOS tests are failing because brew failed to update to 27.0 (https://github.com/Homebrew/homebrew-core/pull/172171) (also see: https://elixirforum.com/t/erlang-27-not-available-in-homebrew/63897/5)
  - we could possibly move to asdf/kerl there, but this will make CI run incredibly longer. 