### PR TITLE
Remove hostname checks

### DIFF
--- a/apps/rebar/rebar.config
+++ b/apps/rebar/rebar.config
@@ -33,8 +33,7 @@
 {overrides, [{add, relx, [{erl_opts, [{d, 'RLX_LOG', rebar_log}]}]}]}.
 
 {erl_opts, [warnings_as_errors,
-            {platform_define, "^(2[1-9])|(20\\\\.3)", filelib_find_source},
-            {platform_define, "^(1|(20))", no_customize_hostname_check}
+            {platform_define, "^(2[1-9])|(20\\\\.3)", filelib_find_source}
            ]}.
 
 {edoc_opts, [preprocess]}.

--- a/apps/rebar/src/rebar_utils.erl
+++ b/apps/rebar/src/rebar_utils.erl
@@ -1138,17 +1138,9 @@ ssl_opts(ssl_verify_enabled, Url) ->
             [{verify, verify_none}]
     end.
 
--ifdef(no_customize_hostname_check).
-check_hostname_opt(Url, Opts) ->
-    #{host := Hostname} = rebar_uri:parse(rebar_utils:to_list(Url)),
-    VerifyFun = {fun ssl_verify_hostname:verify_fun/3,
-                 [{check_hostname, Hostname}]},
-    [{verify_fun, VerifyFun} | Opts].
--else.
 check_hostname_opt(_, Opts) ->
     MatchFun = public_key:pkix_verify_hostname_match_fun(https),
     [{customize_hostname_check, [{match_fun, MatchFun}]} | Opts].
--endif.
 
 -spec partial_chain(Certs) -> Res when
       Certs :: list(any()),


### PR DESCRIPTION
* introduced by 4bf81cb44e665983089f759047dffade166c3810
* used for a compatibility with R21 and onwards
* CI/CD now uses R25 up to R27.