### PR TITLE
make escriptize reproducible by setting timestamps for files in zip to unix epoch

### DIFF
--- a/apps/rebar/src/rebar_prv_escriptize.erl
+++ b/apps/rebar/src/rebar_prv_escriptize.erl
@@ -243,8 +243,12 @@ read_file(Prefix, Filename, Dir) ->
                     _ ->
                         filename:join([Prefix, Filename])
                 end,
+    FilePath = filename:join(Dir, Filename),
+    {ok, FileInfo0} = file:read_file_info(FilePath),
+    DateTime = {{1970, 1, 1}, {0, 0, 1}},
+    FileInfo = FileInfo0#file_info{mtime = DateTime},
     [dir_entries(filename:dirname(Filename1)),
-     {Filename1, file_contents(filename:join(Dir, Filename))}].
+     {Filename1, file_contents(FilePath), FileInfo}].
 
 file_contents(Filename) ->
     {ok, Bin} = file:read_file(Filename),
@@ -272,7 +276,7 @@ usort(List) ->
     lists:ukeysort(1, lists:flatten(List)).
 
 get_nonempty(Files) ->
-    [{FName,FBin} || {FName,FBin} <- Files, FBin =/= <<>>].
+    [{FName,FBin,FInfo} || {FName,FBin,FInfo} <- Files, FBin =/= <<>>].
 
 find_deps(AppNames, AllApps, State) ->
     BinAppNames = [rebar_utils:to_binary(Name) || Name <- AppNames],


### PR DESCRIPTION
Hi Ferd,

here is a small patch which makes escriptize to be reproducible by setting timestamps for files in zip. It may be usable for reproducible systems such as Guix System and NixOS.