### PR TITLE
Removed filelib_find_source macro, and rebar_utils:find_source/3

### DIFF
--- a/apps/rebar/rebar.config
+++ b/apps/rebar/rebar.config
@@ -34,9 +34,7 @@
 
 {overrides, [{add, relx, [{erl_opts, [{d, 'RLX_LOG', rebar_log}]}]}]}.
 
-{erl_opts, [warnings_as_errors,
-            {platform_define, "^(2[1-9])|(20\\\\.3)", filelib_find_source}
-           ]}.
+{erl_opts, [warnings_as_errors]}.
 
 {edoc_opts, [preprocess]}.
 

--- a/apps/rebar/src/rebar_utils.erl
+++ b/apps/rebar/src/rebar_utils.erl
@@ -38,7 +38,6 @@
          find_files/2,
          find_files/3,
          find_files_in_dirs/3,
-         find_source/3,
          beam_to_mod/1,
          erl_to_mod/1,
          beams/1,
@@ -1211,77 +1210,3 @@ version_pad([Major, Minor, Patch]) ->
     {list_to_integer(Major), list_to_integer(Minor), list_to_integer(Patch)};
 version_pad([Major, Minor, Patch | _]) ->
     {list_to_integer(Major), list_to_integer(Minor), list_to_integer(Patch)}.
-
-
--ifdef(filelib_find_source).
-find_source(Filename, Dir, Rules) ->
-    filelib:find_source(Filename, Dir, Rules).
--else.
-%% Looks for a file relative to a given directory
-
--type find_file_rule() :: {ObjDirSuffix::string(), SrcDirSuffix::string()}.
-
-%% Looks for a source file relative to the object file name and directory
-
--type find_source_rule() :: {ObjExtension::string(), SrcExtension::string(),
-                             [find_file_rule()]}.
-
-keep_suffix_search_rules(Rules) ->
-    [T || {_,_,_}=T <- Rules].
-
--spec find_source(file:filename(), file:filename(), [find_source_rule()]) ->
-        {ok, file:filename()} | {error, not_found}.
-find_source(Filename, Dir, Rules) ->
-    try_suffix_rules(keep_suffix_search_rules(Rules), Filename, Dir).
-
-try_suffix_rules(Rules, Filename, Dir) ->
-    Ext = filename:extension(Filename),
-    try_suffix_rules(Rules, filename:rootname(Filename, Ext), Dir, Ext).
-
-try_suffix_rules([{Ext,Src,Rules}|Rest], Root, Dir, Ext)
-  when is_list(Src), is_list(Rules) ->
-    case try_dir_rules(add_local_search(Rules), Root ++ Src, Dir) of
-        {ok, File} -> {ok, File};
-        _Other ->
-            try_suffix_rules(Rest, Root, Dir, Ext)
-    end;
-try_suffix_rules([_|Rest], Root, Dir, Ext) ->
-    try_suffix_rules(Rest, Root, Dir, Ext);
-try_suffix_rules([], _Root, _Dir, _Ext) ->
-    {error, not_found}.
-
-%% ensuring we check the directory of the object file before any other directory
-add_local_search(Rules) ->
-    Local = {"",""},
-    [Local] ++ lists:filter(fun (X) -> X =/= Local end, Rules).
-
-try_dir_rules([{From, To}|Rest], Filename, Dir)
-  when is_list(From), is_list(To) ->
-    case try_dir_rule(Dir, Filename, From, To) of
-	{ok, File} -> {ok, File};
-	error      -> try_dir_rules(Rest, Filename, Dir)
-    end;
-try_dir_rules([], _Filename, _Dir) ->
-    {error, not_found}.
-
-try_dir_rule(Dir, Filename, From, To) ->
-    case lists:suffix(From, Dir) of
-	true ->
-	    NewDir = lists:sublist(Dir, 1, length(Dir)-length(From))++To,
-	    Src = filename:join(NewDir, Filename),
-	    case filelib:is_regular(Src) of
-		true -> {ok, Src};
-		false -> find_regular_file(filelib:wildcard(Src))
-	    end;
-	false ->
-	    error
-    end.
-
-find_regular_file([]) ->
-    error;
-find_regular_file([File|Files]) ->
-    case filelib:is_regular(File) of
-        true -> {ok, File};
-        false -> find_regular_file(Files)
-    end.
--endif.


### PR DESCRIPTION
* introcuded by dec484643c233fda9c17d38c1854ba7f3f37547b
* introcuded to workaround releases prior R20 not having [`filelib:find_source/3`](https://www.erlang.org/doc/apps/stdlib/filelib.html#find_source/3)
* CI/CD now uses R25 to R27.