### PR TITLE
Fix typos again

### DIFF
--- a/apps/rebar/src/rebar_completion.erl
+++ b/apps/rebar/src/rebar_completion.erl
@@ -2,7 +2,7 @@
 
 -export([generate/2]).
 
--type arg_type() :: atom | binary | boolean | float | interger | string.
+-type arg_type() :: atom | binary | boolean | float | integer | string.
 
 -type cmpl_arg() :: #{short => char() | undefined,
                       long => string() | undefined,

--- a/apps/rebar/src/rebar_prv_compile.erl
+++ b/apps/rebar/src/rebar_prv_compile.erl
@@ -290,7 +290,7 @@ build_root_extras(State, Apps) ->
                 [] ->
                     [];
                 VirtApps ->
-                    %% re-use the project-apps digraph?
+                    %% reuse the project-apps digraph?
                     run_compilers(State, [], VirtApps, project_apps)
             end
     end.

--- a/apps/rebar/src/vendored/r3_hex_erl_tar.hrl
+++ b/apps/rebar/src/vendored/r3_hex_erl_tar.hrl
@@ -36,7 +36,7 @@
 %% Options used when reading a tar archive.
 -record(read_opts, {
           cwd                    :: string(),  %% Current working directory.
-          keep_old_files = false :: boolean(), %% Owerwrite or not.
+          keep_old_files = false :: boolean(), %% Overwrite or not.
           files = all,                         %% Set of files to extract (or all)
           output = file :: 'file' | 'memory',
           open_mode = [],                      %% Open mode options.
@@ -202,7 +202,7 @@
 %% These constants (except S_IFMT) are
 %% used to determine what type of device
 %% a file is. Namely, `S_IFMT band file_info.mode`
-%% will equal one of these contants, and tells us
+%% will equal one of these constants, and tells us
 %% which type it is. The stdlib file_info record
 %% does not differentiate between device types, and
 %% will not allow us to differentiate between sockets

--- a/apps/rebar/test/rebar_compile_SUITE.erl
+++ b/apps/rebar/test/rebar_compile_SUITE.erl
@@ -1549,7 +1549,7 @@ umbrella_mib_first_test(Config) ->
     catch (
     rebar_test_utils:run_and_check(Config, FailureRebarConfig, ["compile"], {ok, [{app, Name}]}) ),
 
-    %% check that the bin file was NOT cretated
+    %% check that the bin file was NOT created
     false = filelib:is_file(filename:join([PrivMibsDir, "AIMPORTER-MIB.bin"])),
 
 

--- a/apps/rebar/test/rebar_completion_SUITE.erl
+++ b/apps/rebar/test/rebar_completion_SUITE.erl
@@ -9,7 +9,7 @@ suite() ->
     [].
 
 all() ->
-    [test_competion_gen, check_bash, check_zsh].
+    [test_completion_gen, check_bash, check_zsh].
 
 groups() ->
     [].
@@ -48,7 +48,7 @@ shell_available(Shell) ->
 
 %% test cases
 
-test_competion_gen(Config) ->
+test_completion_gen(Config) ->
     Shells = ?config(shells, Config),
     ComplFile = ?config(compl_file, Config),
     lists:foreach(fun(Shell) ->

--- a/apps/rebar/test/rebar_deps_SUITE.erl
+++ b/apps/rebar/test/rebar_deps_SUITE.erl
@@ -93,7 +93,7 @@ init_per_testcase(https_proxy_settings, Config) ->
                                            [{https_proxy, "http://localhost:1234"}
                                            ]),
             %% Add a bad value by default to show config overtakes default
-            os:putenv("https_proxy", "unparseable-garbage"),
+            os:putenv("https_proxy", "unparsable-garbage"),
             rebar_test_utils:init_rebar_state(Config)
     end;
 init_per_testcase(http_os_proxy_settings, Config) ->

--- a/apps/rebar/test/rebar_upgrade_SUITE.erl
+++ b/apps/rebar/test/rebar_upgrade_SUITE.erl
@@ -121,7 +121,7 @@ upgrades(top_a) ->
      [{"A", "1.0.0", [{"B", [{"D", "3.0.0", []}]},
                   {"C", [{"D", "2.0.0", []}]}]}
      ],
-     %% Modified apps, gobally
+     %% Modified apps, globally
      ["A","B","D"],
      %% upgrade vs. new tree
      {"A", [{"A","1.0.0"}, "B", "C", {"D","3.0.0"}]}};
@@ -134,7 +134,7 @@ upgrades(top_b) ->
      [{"A", "1.0.0", [{"B", [{"D", "3.0.0", []}]},
                   {"C", [{"D", "2.0.0", []}]}]}
      ],
-     %% Modified apps, gobally
+     %% Modified apps, globally
      ["A","B","D"],
      %% upgrade vs. new tree
      {"B", {error, {rebar_prv_upgrade, {transitive_dependency, <<"B">>}}}}};
@@ -147,7 +147,7 @@ upgrades(top_c) ->
      [{"A", "1.0.0", [{"B", [{"D", "3.0.0", []}]},
                   {"C", [{"D", "2.0.0", []}]}]}
      ],
-     %% Modified apps, gobally
+     %% Modified apps, globally
      ["A","B","D"],
      %% upgrade vs. new tree
      {"C", {error, {rebar_prv_upgrade, {transitive_dependency, <<"C">>}}}}};
@@ -160,7 +160,7 @@ upgrades(top_d1) ->
      [{"A", "1.0.0", [{"B", [{"D", "3.0.0", []}]},
                   {"C", [{"D", "2.0.0", []}]}]}
      ],
-     %% Modified apps, gobally
+     %% Modified apps, globally
      ["A","B","D"],
      %% upgrade vs. new tree
      {"D", {error, {rebar_prv_upgrade, {transitive_dependency, <<"D">>}}}}};
@@ -173,7 +173,7 @@ upgrades(top_d2) ->
      [{"A", "1.0.0", [{"B", [{"D", "3.0.0", []}]},
                   {"C", [{"D", "2.0.0", []}]}]}
      ],
-     %% Modified apps, gobally
+     %% Modified apps, globally
      ["A","B","D"],
      %% upgrade vs. new tree
      {"D", {error, {rebar_prv_upgrade, {transitive_dependency, <<"D">>}}}}};
@@ -186,7 +186,7 @@ upgrades(top_e) ->
      [{"A", "1.0.0", [{"B", [{"D", "3.0.0", []}]},
                   {"C", [{"D", "2.0.0", []}]}]}
      ],
-     %% Modified apps, gobally
+     %% Modified apps, globally
      ["A","B","D"],
      %% upgrade vs. new tree
      {"E", {error, {rebar_prv_upgrade, {unknown_dependency, <<"E">>}}}}};


### PR DESCRIPTION
Found via `codespell -S vendor -L cant,manuel,nd` and `typos --hidden --format brief`