### PR TITLE
Tweak manifest plugin to return ELP compatible information.

### DIFF
--- a/apps/rebar/src/rebar_prv_manifest.erl
+++ b/apps/rebar/src/rebar_prv_manifest.erl
@@ -75,7 +75,7 @@ do(State) ->
 format_error({format_not_supported, Format}) ->
     io_lib:format("Format '~p' is not supported. Try 'erlang' or 'eetf'.", [Format]);
 format_error(no_json_module) ->
-    io_lib:format("The 'json' module is not available. Either upgrade to OTP 27 or use a different format.", []);
+    io_lib:format("The 'json' module is not available. Either upgrade to OTP 27 or newer, or select a different output format.", []);
 format_error({output_error, To, Error}) ->
     io_lib:format("Could not output manifest to ~p (~p)", [To, Error]);
 format_error(Reason) ->


### PR DESCRIPTION
Starting the discussion around the actual format to use in the `manifest` plugin.

For the time being, instead of returning the raw context, I'm basically adopting the same format previously adopted by the [`build_info`](https://github.com/WhatsApp/eqwalizer/blob/main/eqwalizer_rebar3/src/eqwalizer_build_info_prv.erl) plugin, used by the ELP language server. Using the same format avoids changes to ELP itself.

I am also adding a `json` format to make it easier for tools to consume the information.

# Test Plan

Generate build information for the Erlang LS repo via ELP (internally using the `build_info` plugin):

```
elp build-info --project ~/git/github/erlang-ls/erlang_ls --to /tmp/erlang-ls-build
```

Locally modify ELP to use the `experimental manifest` plugin instead, then:

```
elp build-info --project ~/git/github/erlang-ls/erlang_ls --to /tmp/erlang-ls-manifest
```

Finally compare the two generated files:

```
diff /tmp/erlang-ls-build /tmp/erlang-ls-manifest
```

The only difference, for each application, is:

```
<         "include"
---
>         "include",
>         "src",
>         ""
```

This *should* not be an issue, but we can double check that as a follow-up.