### PR TITLE
Bump relx vendored copy

### DIFF
--- a/apps/rebar/rebar.config
+++ b/apps/rebar/rebar.config
@@ -9,7 +9,7 @@
         {providers,        "1.9.0"},
         {getopt,           "1.0.2"},
         {bbmustache,       "1.12.2"},
-        {relx,             "4.9.0"},
+        {relx,             "4.10.0"},
         {cf,               "0.3.1"},
         {cth_readable,     "1.5.1"},
         {eunit_formatters, "0.5.0"}]}.

--- a/vendor/relx/hex_metadata.config
+++ b/vendor/relx/hex_metadata.config
@@ -28,4 +28,4 @@
    [{<<"app">>,<<"bbmustache">>},
     {<<"optional">>,false},
     {<<"requirement">>,<<"~>1.10">>}]}]}.
-{<<"version">>,<<"4.9.0">>}.
+{<<"version">>,<<"4.10.0">>}.

--- a/vendor/relx/src/relx.app.src
+++ b/vendor/relx/src/relx.app.src
@@ -1,6 +1,6 @@
 {application,relx,
              [{description,"Release assembler for Erlang/OTP Releases"},
-              {vsn,"4.9.0"},
+              {vsn,"4.10.0"},
               {modules,[]},
               {registered,[]},
               {applications,[kernel,stdlib,bbmustache,sasl,tools]},


### PR DESCRIPTION
Since I had already manually ported the changeset between 3.9.0 and 3.10.0, only metadata changed on the update.