### PR TITLE
make escriptize reproducible with erlang 27.1

### DIFF
--- a/apps/rebar/src/rebar_prv_escriptize.erl
+++ b/apps/rebar/src/rebar_prv_escriptize.erl
@@ -246,7 +246,9 @@ read_file(Prefix, Filename, Dir) ->
     FilePath = filename:join(Dir, Filename),
     {ok, FileInfo0} = file:read_file_info(FilePath),
     DateTime = {{1970, 1, 1}, {0, 0, 1}},
-    FileInfo = FileInfo0#file_info{mtime = DateTime},
+    FileInfo = FileInfo0#file_info{atime = DateTime,
+                                   ctime = DateTime,
+                                   mtime = DateTime},
     [dir_entries(filename:dirname(Filename1)),
      {Filename1, file_contents(FilePath), FileInfo}].
 


### PR DESCRIPTION
Hi, Fred.

I've already submitted fix related to reproducible escripts generation. Here is minor additional change to make it work with newer Erlang 27.1.

Before patch:

```
% for a in $(seq 1 3); do ./bootstrap 2>&1 >/dev/null; md5sum rebar3; done
4af061db0dffb624cbcc4f791bec4811  rebar3
934a4bb8fc774c651fc88ecd2c906f9d  rebar3
da14315045711bda5bc9f7c99175e715  rebar3
```

After patch:

```
% for a in $(seq 1 3); do ./bootstrap 2>&1 >/dev/null; md5sum rebar3; done
98ec28baced972e9f59b1ff4e84cbc07  rebar3
98ec28baced972e9f59b1ff4e84cbc07  rebar3
98ec28baced972e9f59b1ff4e84cbc07  rebar3
```

Thank you!