### PR TITLE
Fallback to the default error format when a file is empty

### DIFF
--- a/apps/rebar/src/rebar_compiler_format.erl
+++ b/apps/rebar/src/rebar_compiler_format.erl
@@ -29,13 +29,21 @@ format(Source, {Line, Column}, Extra, Desc, Config) ->
     end.
 
 find_line(Nth, Source) ->
-  try
-      {ok, Bin} = file:read_file(Source),
-      Splits = re:split(Bin, "(?:\n|\r\n|\r)", [{newline, anycrlf}]),
-      {ok, lists:nth(Nth, Splits)}
-  catch
-      error:X -> {error, X}
-  end.
+    try do_find_line(Nth, Source)
+    catch
+        error:X -> {error, X}
+    end.
+
+do_find_line(Nth, Source) ->
+    case file:read_file(Source) of
+        {ok, <<>>} ->
+            {error, empty_file};
+        {ok, Bin} ->
+            Splits = re:split(Bin, "(?:\n|\r\n|\r)", [{newline, anycrlf}]),
+            {ok, lists:nth(Nth, Splits)};
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 indent(0, _) -> "";
 indent(N, <<"\t", Rest/binary>>) -> [$\t | indent(N-1, Rest)];

--- a/apps/rebar/test/rebar_compiler_format_SUITE.erl
+++ b/apps/rebar/test/rebar_compiler_format_SUITE.erl
@@ -18,8 +18,10 @@ init_per_testcase(_, Config) ->
     application:set_env(cf, colour_term, cf_term:has_color("dumb")),
     FileName = filename:join(?config(priv_dir, Config), "oracle.erl"),
     ok = file:write_file(FileName, oracle()),
+    EmptyFileName = filename:join(?config(priv_dir, Config), "empty.erl"),
+    ok = file:write_file(EmptyFileName, ""),
     Conf = dict:from_list([{compiler_error_format, rich}]),
-    [{conf, Conf}, {file, FileName}, {term, OriginalTerm} | Config].
+    [{conf, Conf}, {file, FileName}, {empty_file, EmptyFileName}, {term, OriginalTerm} | Config].
 
 end_per_testcase(_, Config) ->
     case ?config(term, Config) of
@@ -65,6 +67,7 @@ nocolor() ->
     [{doc, "testing all sorts of planned output"}].
 nocolor(Config) ->
     Path = ?config(file, Config),
+    EmptyPath = ?config(empty_file, Config),
     Conf = ?config(conf, Config),
     ?assertEqual("   ┌─ "++Path++":"++?EOL++
                  "   │"++?EOL++
@@ -90,5 +93,8 @@ nocolor(Config) ->
                  rebar_compiler_format:format(Path, {855,1}, "", "invalid ranges.", Conf)),
     ?assertEqual("/very/fake/path.oof:1:1: unknown file."++?EOL,
                  rebar_compiler_format:format("/very/fake/path.oof", {1,1}, "", "unknown file.", Conf)),
+    %% empty file
+    ?assertEqual(EmptyPath++":1:1: should fallback to the minimal output"++?EOL,
+             rebar_compiler_format:format(EmptyPath, {1,1}, "", "should fallback to the minimal output", Conf)),
     ok.
 


### PR DESCRIPTION
This change resolves a bad match error that occurs when a .erl file is empty by falling back to the default error format.

## Before

```console
===> Task failed: {{badmatch,[]},
                              [{rebar_compiler_format,colorize,2,
                                [{file,
                                  "/home/runner/work/rebar3/rebar3/apps/rebar/src/rebar_compiler_format.erl"},
                                 {line,74}]},
                               {rebar_compiler_format,format,5,
                                [{file,
                                  "/home/runner/work/rebar3/rebar3/apps/rebar/src/rebar_compiler_format.erl"},
                                 {line,25}]},
                               {rebar_base_compiler,
                                '-format_errors/4-lc$^1/1-1-',4,
                                [{file,
                                  "/home/runner/work/rebar3/rebar3/apps/rebar/src/rebar_base_compiler.erl"},
                                 {line,278}]},
                               {rebar_base_compiler,
                                '-format_errors/4-lc$^0/1-0-',3,
                                [{file,
                                  "/home/runner/work/rebar3/rebar3/apps/rebar/src/rebar_base_compiler.erl"},
                                 {line,278}]},
                               {rebar_base_compiler,error_tuple,5,
                                [{file,
                                  "/home/runner/work/rebar3/rebar3/apps/rebar/src/rebar_base_compiler.erl"},
                                 {line,160}]},
                               {rebar_compiler,compile_worker,2,
                                [{file,
                                  "/home/runner/work/rebar3/rebar3/apps/rebar/src/rebar_compiler.erl"},
                                 {line,337}]},
                               {rebar_parallel,worker,3,
                                [{file,
                                  "/home/runner/work/rebar3/rebar3/apps/rebar/src/rebar_parallel.erl"},
                                 {line,260}]}]}
```

## After

```console
===> Compiling src/r3_colorize_bug.erl failed
src/r3_colorize_bug.erl:1:1: no module definition
```