### PR TITLE
add env var for skipping project plugins

### DIFF
--- a/apps/rebar/src/rebar3.erl
+++ b/apps/rebar/src/rebar3.erl
@@ -182,8 +182,15 @@ run_aux(State, RawArgs) ->
     {ok, Providers} = application:get_env(rebar, providers),
     %% Providers can modify profiles stored in opts, so set default after initializing providers
     State6 = rebar_state:create_logic_providers(Providers, State5),
-    %% Initializing project_plugins which can override default providers
-    State7 = rebar_plugins:project_plugins_install(State6),
+
+    State7 = case os:getenv("REBAR_SKIP_PROJECT_PLUGINS") of
+                 false ->
+                     %% Initializing project_plugins which can override default providers
+                     rebar_plugins:project_plugins_install(State6);
+                 _ ->
+                     State6
+             end,
+
     State8 = rebar_plugins:top_level_install(State7),
 
     State9 = rebar_state:default(State8, rebar_state:opts(State8)),


### PR DESCRIPTION
tools like mix and gleam only use rebar3 to compile deps and thus don't wnat project_plugins. They can now set this to skip installing those.

I originally was going to check if `bare` was the task but there are too many ways that might be run without being the first command (like rebar3 as prod bare compile) that I figured this was better.