### PR TITLE
OTP-28 readiness (part 1)

### DIFF
--- a/apps/rebar/rebar.config
+++ b/apps/rebar/rebar.config
@@ -38,7 +38,7 @@
 
 {edoc_opts, [preprocess]}.
 
-%% Use OTP 23+ when dialyzing rebar3
+%% Use the newest OTP when dialyzing rebar3
 {dialyzer, [
     {warnings, [unknown]},
     {plt_extra_apps, [parsetools, public_key]}

--- a/apps/rebar/src/rebar.app.src.script
+++ b/apps/rebar/src/rebar.app.src.script
@@ -11,6 +11,7 @@
                   compiler,
                   crypto,
                   syntax_tools,
+                  parsetools,
                   tools,
                   eunit,
                   common_test,

--- a/rebar.config
+++ b/rebar.config
@@ -31,6 +31,7 @@
         {erl_opts, [debug_info, nowarn_export_all]},
         %% Ignore deps known to generate warnings
         {dialyzer, [{warnings, [no_unknown]},
+                    {plt_extra_apps, [parsetools, public_key]},
                     {exclude_apps, [cth_readable, erlware_commons, relx]}]}
     ]},
     %% Duplicated from apps/rebar3:


### PR DESCRIPTION
Covers portions of https://github.com/erlang/rebar3/issues/2936, namely the bits about Dialyzer checks for xrl and yrl compilers, and for Common Test and EUnit. 

Dependencies will need to be done in a different pull request.