### PR TITLE
fix: crash on rebar_compiler_format:colorize/2

### DIFF
--- a/apps/rebar/src/rebar_compiler_format.erl
+++ b/apps/rebar/src/rebar_compiler_format.erl
@@ -79,6 +79,10 @@ compiler_error_format(Opts) ->
 colorize(Str, Col) ->
     Pre = string:slice(Str, 0, max(0,Col-1)),
     At = string:slice(Str, max(0,Col-1)),
-    [Bad | Tail] = [B || B <- re:split(At, "([^[A-Za-z0-9_#\"]+)", []),
-                         B =/= <<>>],
-    cf:format("~ts~!R~ts~!!~ts", [Pre,Bad,Tail]).
+    case [B || B <- re:split(At, "([^[A-Za-z0-9_#\"]+)", []),
+                         B =/= <<>>] of
+      [Bad |Tail] ->
+        cf:format("~ts~!R~ts~!!~ts", [Pre,Bad,Tail]);
+     [] ->
+        cf:format("~ts~n", [Str])
+   end.


### PR DESCRIPTION
fix: `rebar_compiler_format:colorize(<<>>, 1)` crash.
```
rebar3 compile
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling ecron
===> Task failed: {{badmatch,[]},
                   [{rebar_compiler_format,colorize,2,
                        [{file,
                             "/private/tmp/rebar3-20240921-6522-hpmqce/rebar3-3.24.0/apps/rebar/src/rebar_compiler_format.erl"},
                         {line,74}]},
                    {rebar_compiler_format,format,5,
                        [{file,
                             "/private/tmp/rebar3-20240921-6522-hpmqce/rebar3-3.24.0/apps/rebar/src/rebar_compiler_format.erl"},
                         {line,25}]},
                    {rebar_base_compiler,'-format_errors/4-lc$^1/1-1-',4,
                        [{file,
                             "/private/tmp/rebar3-20240921-6522-hpmqce/rebar3-3.24.0/apps/rebar/src/rebar_base_compiler.erl"},
                         {line,278}]},
                    {rebar_base_compiler,'-format_errors/4-lc$^0/1-0-',3,
                        [{file,
                             "/private/tmp/rebar3-20240921-6522-hpmqce/rebar3-3.24.0/apps/rebar/src/rebar_base_compiler.erl"},
                         {line,278}]},
                    {rebar_base_compiler,error_tuple,5,
                        [{file,
                             "/private/tmp/rebar3-20240921-6522-hpmqce/rebar3-3.24.0/apps/rebar/src/rebar_base_compiler.erl"},
                         {line,160}]},
                    {rebar_compiler,compile_worker,2,
                        [{file,
                             "/private/tmp/rebar3-20240921-6522-hpmqce/rebar3-3.24.0/apps/rebar/src/rebar_compiler.erl"},
                         {line,337}]},
                    {rebar_parallel,worker,3,
                        [{file,
                             "/private/tmp/rebar3-20240921-6522-hpmqce/rebar3-3.24.0/apps/rebar/src/rebar_parallel.erl"},
                         {line,260}]}]}
```