### PR TITLE
Bump eunit_formatters to 0.6.0

### DIFF
--- a/apps/rebar/rebar.config
+++ b/apps/rebar/rebar.config
@@ -12,7 +12,7 @@
         {relx,             "4.10.0"},
         {cf,               "0.3.1"},
         {cth_readable,     "1.6.1"},
-        {eunit_formatters, "0.5.0"}]}.
+        {eunit_formatters, "0.6.0"}]}.
 
 {post_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)",
                escriptize,

--- a/vendor/eunit_formatters/hex_metadata.config
+++ b/vendor/eunit_formatters/hex_metadata.config
@@ -1,15 +1,13 @@
-{<<"name">>,<<"eunit_formatters">>}.
-{<<"version">>,<<"0.5.0">>}.
-{<<"requirements">>,#{}}.
 {<<"app">>,<<"eunit_formatters">>}.
-{<<"maintainers">>,[<<"Sean Cribbs">>,<<"Tristan Sloughter">>]}.
-{<<"precompiled">>,false}.
+{<<"build_tools">>,[<<"rebar3">>]}.
 {<<"description">>,<<"Better output for eunit suites">>}.
 {<<"files">>,
- [<<"src/eunit_formatters.app.src">>,<<"LICENSE">>,<<"README.md">>,
-  <<"rebar.config">>,<<"rebar.lock">>,<<"src/binomial_heap.erl">>,
+ [<<"LICENSE">>,<<"README.md">>,<<"rebar.config">>,<<"rebar.lock">>,<<"src">>,
+  <<"src/binomial_heap.erl">>,<<"src/eunit_formatters.app.src">>,
   <<"src/eunit_progress.erl">>]}.
 {<<"licenses">>,[<<"Apache2">>]}.
 {<<"links">>,
  [{<<"Github">>,<<"https://github.com/seancribbs/eunit_formatters">>}]}.
-{<<"build_tools">>,[<<"rebar3">>]}.
+{<<"name">>,<<"eunit_formatters">>}.
+{<<"requirements">>,[]}.
+{<<"version">>,<<"0.6.0">>}.

--- a/vendor/eunit_formatters/rebar.config
+++ b/vendor/eunit_formatters/rebar.config
@@ -1,3 +1,2 @@
 %% Dogfooding
-{erl_opts, [{platform_define, "^[0-9]+", namespaced_dicts}]}.
 {eunit_opts, [no_tty, {report, {eunit_progress, [colored, profile]}}]}.

--- a/vendor/eunit_formatters/src/binomial_heap.erl
+++ b/vendor/eunit_formatters/src/binomial_heap.erl
@@ -15,6 +15,8 @@
 %% @doc Binomial heap based on Okasaki 6.2.2
 -module(binomial_heap).
 -export([new/0, insert/2, insert/3, merge/2, delete/1, to_list/1, take/2, size/1]).
+-compile({no_auto_import,[link/2]}).
+
 -record(node,{
           rank = 0    :: non_neg_integer(),
           key         :: term(),

--- a/vendor/eunit_formatters/src/eunit_formatters.app.src
+++ b/vendor/eunit_formatters/src/eunit_formatters.app.src
@@ -1,6 +1,6 @@
 {application,eunit_formatters,
              [{description,"Better output for eunit suites"},
-              {vsn,"0.5.0"},
+              {vsn,"0.6.0"},
               {applications,[kernel,stdlib,eunit]},
               {env,[]},
               {maintainers,["Sean Cribbs","Tristan Sloughter"]},


### PR DESCRIPTION
Does some fixing for Otp-28.

Bumped the version then re-ran `rebar3 experimental vendor` to refresh the list, and kept the manual edits we had made in other apps.