### PR TITLE
Bump Runner images for Nightly and release builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Publish escript for every merge to main
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build:
     name: Create release and publish escript for every new tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Nightly and Publish tasks have been deprecated for a while. The PR jobs use ubuntu-latest fine, so let's bump everything to use these.