### PR TITLE
Fix issue on windows with OTP 28 which causes rebar to get stuck at fetching dependencies.

### DIFF
--- a/vendor/erlware_commons/src/ec_file.erl
+++ b/vendor/erlware_commons/src/ec_file.erl
@@ -324,13 +324,13 @@ remove_recursive(Path, Options) ->
 
 -spec tmp() -> file:name().
 tmp() ->
-    case erlang:system_info(system_architecture) of
-        "win32" ->
+    case os:type() of
+        {win32, _} ->
             case os:getenv("TEMP") of
                 false -> "./tmp";
                 Val -> Val
             end;
-        _SysArch ->
+        _ ->
             case os:getenv("TMPDIR") of
                 false -> "/tmp";
                 Val -> Val


### PR DESCRIPTION
After upgrading to Erlang/OTP 28  on windows, rebar gets stuck at fetching dependencies and does not progress.

After doing a bit of investigation, it seems that  ec_file:tmp() of erlware_commons library uses erlang:system_info(system_architecture) instead of the commonly used os:type() in order to detect the current OS. On my system, the former resolves to "x86_64-pc-windows" instead of the expected "win32". This causes rebar to resolve the wrong path when creating temporary directories in code which uses ec_file:tmp().

Changing the logic inside ec_file:tmp() to use os:type() fixes this issue and rebar works as expected.

This behavior does not occur with Erlang/OTP 27.3.4