### PR TITLE
Update escriptize hook to work with newer Windows versions

### DIFF
--- a/apps/rebar/rebar.config
+++ b/apps/rebar/rebar.config
@@ -17,7 +17,7 @@
 {post_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)",
                escriptize,
                "cp \"$REBAR_BUILD_DIR/bin/rebar3\" ./rebar3"},
-              {"win32",
+              {"(win32|windows)",
                escriptize,
                "robocopy \"%REBAR_BUILD_DIR%/bin/\" ./ rebar3* "
                "/njs /njh /nfl /ndl & exit /b 0"} % silence things


### PR DESCRIPTION
The arch line changed from containing `win32` to containing `windows` in `rebar_utils:get_arch()` so to keep things working (and fix CI/CD) by providing the Rebar3 executables in the root project path, we have to update the regex.