### PR TITLE
Make xref recognize apps again

### DIFF
--- a/apps/rebar/src/rebar_prv_xref.erl
+++ b/apps/rebar/src/rebar_prv_xref.erl
@@ -97,11 +97,11 @@ prepare(State) ->
                              rebar_state:get(State, xref_warnings, false)},
                             {verbose, rebar_log:is_verbose(State)}]),
 
-    [{ok, _} = xref:add_directory(xref, Dir)
+    [ {ok, _} = xref:add_application(xref, Dir, [{name, binary_to_atom(rebar_app_info:name(App))}])
      || App <- rebar_state:project_apps(State),
         %% the directory may not exist in rare cases of a compile
         %% hook of a dep running xref prior to the full job being done
-        Dir <- [rebar_app_info:ebin_dir(App)], filelib:is_dir(Dir)],
+        Dir <- [rebar_app_info:out_dir(App)], filelib:is_dir(Dir)],
 
     %% Get list of xref checks we want to run
     ConfXrefChecks = rebar_state:get(State, xref_checks,


### PR DESCRIPTION
Rebar offers the possibilty to add xref queries to the rebar.config file.
These queries can take atoms representing names of applications. However, such names were no longer recognized. No longer, because https://github.com/srijan/library_sample shows that it seems to have been possible to use application names.

This is a fix to make rebar3 add applications correctly to the xref machinery.

Test is provided that fails on old code, showing the problem that names are not recognized (and applications are unknown).
