### PR TITLE
Draft: Adopt ExDoc & Move Documentation In-Tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ env
 
 # hex_core artifact
 apps/rebar/src/vendored/r3_safe_erl_term.erl
+apps/rebar/doc

--- a/apps/rebar/src/cth_fail_fast.erl
+++ b/apps/rebar/src/cth_fail_fast.erl
@@ -1,4 +1,5 @@
 -module(cth_fail_fast).
+-moduledoc false.
 
 %% Callbacks
 -export([id/1]).

--- a/apps/rebar/src/cth_retry.erl
+++ b/apps/rebar/src/cth_retry.erl
@@ -1,4 +1,5 @@
 -module(cth_retry).
+-moduledoc false.
 
 %% Callbacks
 -export([id/1]).

--- a/apps/rebar/src/rebar_agent.erl
+++ b/apps/rebar/src/rebar_agent.erl
@@ -290,9 +290,9 @@ reload_modules(Modules0) ->
     Modules = [M || M <- Modules0, is_changed(M)],
     reload_modules(Modules, erlang:function_exported(code, prepare_loading, 1)).
 
-%% @spec is_changed(atom()) -> boolean()
 %% @doc true if the loaded module is a beam with a vsn attribute
 %%      and does not match the on-disk beam file, returns false otherwise.
+-spec is_changed(atom()) -> boolean().
 is_changed(M) ->
     try
         module_vsn(M:module_info(attributes)) =/= module_vsn(code:get_object_code(M))

--- a/apps/rebar/src/rebar_file_utils.erl
+++ b/apps/rebar/src/rebar_file_utils.erl
@@ -86,7 +86,7 @@ consult_config(State, Filename) ->
     consult_config_terms(State, Config).
 
 %% @doc Reads a config file via consult_env_config/2 if the file name has
-%% the suffix `.src`, and with consult_config/2 otherwise
+%% the suffix `.src', and with consult_config/2 otherwise
 -spec consult_any_config(rebar_state:t(), file:filename()) -> [[tuple()]].
 consult_any_config(State, Filename) ->
     case is_src_config(Filename) of

--- a/doc.config
+++ b/doc.config
@@ -1,0 +1,18 @@
+%% ./bootstrap
+%% REBAR_CONFIG=doc.config ./rebar3 ex_doc
+
+{project_plugins, [
+    {rebar3_ex_doc, "0.2.30"},
+    {rebar3_hex, "7.0.11"}
+]}.
+
+{hex, [{doc, #{provider => ex_doc}}]}.
+{ex_doc, [
+    {source_url, ~"https://example.com"},
+    {extras, [
+        ~"README.md",
+        ~"LICENSE",
+        ~"CONTRIBUTING.md"
+    ]},
+    {main, ~"readme"}
+]}.

--- a/doc.config.script
+++ b/doc.config.script
@@ -1,0 +1,34 @@
+case filelib:is_dir("rebar3.org") of
+    true ->
+        ok;
+    false ->
+        erlang:error("""
+        This demo requires that you clone the rebar3.org repository from GitHub
+        so that we can bundle the documentation together.
+
+            git clone https://github.com/tsloughter/rebar3.org.git
+        """)
+end,
+
+GetRebar3OrgFiles = fun() ->
+    Files = filelib:wildcard("rebar3.org/content/en/docs/**/*.md"),
+    lists:filter(fun(X) -> nomatch =:= re:run(X, "_index", [{capture, none}]) end, Files)
+end,
+
+FixHeader = fun(File) ->
+    io:format("Processing ~p~n", [File]),
+    {ok, Content} = file:read_file(File),
+    NewContent = re:replace(Content, "^---$\n+title: \"(?<title>[^\"]*)\"$.*^---$", "# \\1", [unicode, dotall, anchored, multiline]),
+    file:write_file(File, NewContent),
+    File
+end,
+
+MdFiles = GetRebar3OrgFiles(),
+MdFiles = lists:map(FixHeader, MdFiles),
+
+ExDoc = proplists:get_value(ex_doc, CONFIG),
+Extras = proplists:get_value(extras, ExDoc),
+Extras2 = Extras ++ MdFiles,
+ExDoc2 = lists:keystore(extras, 1, ExDoc, {extras, Extras2}),
+CONFIG2 = lists:keystore(ex_doc, 1, CONFIG, {ex_doc, ExDoc2}),
+CONFIG2.


### PR DESCRIPTION
This draft PR proposes an integration of ExDoc and moves all generated documentation into the main `rebar3` repository. This change is not suitable to merge in its current state, and thus is a draft to facilitate community discussion. If it's a desirable direction for the project, I'm happy to help continue the effort.

The primary goal is to bring rebar3's documentation process in line with modern Erlang community standards, enhancing **discoverability**, **familiarity**, and **contributor experience**.

## ✨ Demo

[rebar3exdocdemo.stimpson.io](https://rebar3exdocdemo.stimpson.io)

For demonstration purposes, I've hosted the combined rebar3 ExDocs at the location above. I'll keep them up and running for the lifetime of this PR.

## 💡 Proposal

This PR proposes three major changes:

1.  **Move Documentation Source In-Tree:** The source files for documentation (currently in the separate [rebar3.org](https://github.com/tsloughter/rebar3.org) included directly in the `rebar3` project.
2.  **Adopt ExDoc for Generation:** Documentation generated using ExDoc.
3. **Hosting:** Docs hosted on erlang.org seems appropriate, but use of hexdocs.pm would also be an option

## ✅ Motivation

### 1\. **Familiarity & Community Alignment**

  * **Standardization:** ExDoc is the standard documentation tool across the Erlang/Elixir ecosystem, used by **OTP**, **Elixir**, and the majority of popular libraries.
  * **Reduced Friction:** By following this convention, new and experienced contributors alike can navigate and understand the documentation process much faster.

### 2\. **Enhanced Discoverability**

  * **Expected Locations:** A new user would likely look for documentation at **`erlang.org`** or **HexDocs**. Currently, the documentation is not hosted in either.

### 3\. **Facilitating Contribution**

  * **Easy Local Generation:** Contributors can now easily generate a complete, local version of the documentation with a simple command, viewing their changes before submitting. (And without npm 😄 )
  * **Higher-Quality PRs:** A simpler local build process increases contributor comfort and naturally leads to more comprehensive, higher-quality documentation improvements.

### 4\. **Clear Public API Definition**

  * **Convention-Driven Clarity:** ExDoc's default conventions inherently clarify the public API. **Any module that appears in the "Modules" section is considered public.**
  * **Robust Plugins:** This clear distinction will help developers building rebar3 plugins create more robust and stable integrations by knowing exactly which parts of rebar3's API they can safely rely on.

## 🛠 Implementation Details

  * Adds a standalone `doc.config[.script]` that uses the [rebar3_ex_doc](https://www.erlang.org/docs/28/system/documentation.html#using-exdoc-to-generate-html-epub-documentation) plugin. This should not be considered a circular dep, because it's only for HTML/CSS generation, and has no bearing on the rebar3 binary itself.
  * Including rebar.org files is done manually with `git clone https://github.com/tsloughter/rebar3.org.git`. For PR brevity, I did not copy them into the repo at this stage.
  * After bootstrapping, generation is done with `REBAR_CONFIG=doc.config ./rebar3 ex_doc`

I'm eager to hear community feedback. Thanks!

(FYI: I used AI to help structure the content of this PR description, but the content is my own)