### PR TITLE
Ignore optional Hex package dependencies

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -148,3 +148,4 @@ Manas Chaudhari
 Luís Rascão
 Marko Minđek
 LEdoian
+Jonatan Männchen

--- a/apps/rebar/src/rebar.hrl
+++ b/apps/rebar/src/rebar.hrl
@@ -29,7 +29,7 @@
 -define(LOCK_FILE, "rebar.lock").
 -define(DEFAULT_COMPILER_SOURCE_FORMAT, relative).
 -define(DEFAULT_COMPILER_ERROR_FORMAT, rich). % 'minimal' for default values as of 3.23.0 and earlier
--define(PACKAGE_INDEX_VERSION, 6).
+-define(PACKAGE_INDEX_VERSION, 7).
 -define(PACKAGE_TABLE, package_index).
 -define(INDEX_FILE, "packages.idx").
 -define(HEX_AUTH_FILE, "hex.config").


### PR DESCRIPTION
Filter out dependencies marked as optional in Hex package metadata. Rebar3 does not support optional dependencies, so they should not be fetched or compiled. This fixes issues where optional Mix-only transitive dependencies would cause build failures.

Bump`PACKAGE_INDEX_VERSION` to invalidate existing caches.

I have verified the change with the `purl` package locally.

Fixes #2977