### PR TITLE
fix: prepare for OTP-29 defaulting to warn_deprecated_catch

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -177,7 +177,7 @@ compile_yrl_file(File) ->
     {ok, _} = yecc:file(File).
 
 compile_erl_file(File, Opts) ->
-    case compile:file(File, Opts) of
+    case compile:file(File, [nowarn_deprecated_catch | Opts]) of
         {ok, _Mod} ->
             ok;
         {ok, _Mod, []} ->

--- a/rebar.config
+++ b/rebar.config
@@ -5,6 +5,8 @@
 {project_app_dirs, ["apps/*","lib/*",".","vendor/*"]}.
 {project_plugin_dirs, ["plugins/*","vendor_plugins/*"]}.
 
+{erl_opts, [nowarn_deprecated_catch]}.
+
 %% Duplicated from apps/rebar3:
 %% - we want people who rely on rebar3 as a dependency to still be able
 %%   to fetch it with git_subdir and have it work
@@ -18,7 +20,8 @@
 {escript_incl_priv, [{relx, "templates/*"},
                      {rebar, "templates/*"}]}.
 
-{overrides, [{add, relx, [{erl_opts, [{d, 'RLX_LOG', rebar_log}]}]}]}.
+{overrides, [{override, erlware_commons, [{erl_opts, [nowarn_deprecated_catch]}]},
+             {add, relx, [{erl_opts, [{d, 'RLX_LOG', rebar_log}]}]}]}.
 
 {profiles, [
     %% Only works at the top-level


### PR DESCRIPTION
@richcarl brought this to my attention and I think this resolves any issue we'd have (bootstrapping works fine even with `ERL_COMPILER_OPTIONS=[warn_deprecated_catch]` set.