### PR TITLE
release: filter and prepend 'mode' in relx config

### DIFF
--- a/apps/rebar/src/rebar_relx.erl
+++ b/apps/rebar/src/rebar_relx.erl
@@ -41,8 +41,9 @@ do(Provider, State) ->
 
     Args = [include_erts, system_libs, vm_args, sys_config],
     RelxConfig2 = maybe_obey_command_args(RelxConfig1, Opts, Args),
+    RelxConfig3 = put_mode_first(RelxConfig2),
 
-    {ok, RelxState_0} = rlx_config:to_state(RelxConfig2),
+    {ok, RelxState_0} = rlx_config:to_state(RelxConfig3),
     XrefIgnores = rebar_state:get(State, xref_ignores, []),
     RelxState = rlx_state:filter_xref_warning(RelxState_0,
         fun(Warnings) ->
@@ -227,6 +228,10 @@ overlay_vars(RelxConfig, Opts) ->
         FileName when is_list(FileName) ->
             [FileName]
     end.
+
+put_mode_first(RelxConfig) ->
+    Modes = [V || {mode, _} = V <- RelxConfig],
+    Modes ++ (RelxConfig -- Modes).
 
 maybe_obey_command_args(RelxConfig, Opts, Args) ->
     lists:foldl(


### PR DESCRIPTION
since rlx_config:to_state/1 and rlx_config:load/2 will override any previously set 'include_src', 'debug_info' and 'include_erts' when {mod,dev|prod|minimal} is set:

put {mode, ...} elements first in the relx configuration.

fix #2853