### PR TITLE
fix: OTP29 compilation

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -46,8 +46,7 @@
         {erl_opts, [no_debug_info]},
         {overrides, [
             {override, erlware_commons, [
-                {erl_opts, [no_debug_info,
-                            warnings_as_errors]},
+                {erl_opts, [no_debug_info]},
                 {deps, []}, {plugins, []}]},
             {add, ssl_verify_hostname, [{erl_opts, [no_debug_info]}]},
             {add, certifi, [{erl_opts, [no_debug_info]}]},


### PR DESCRIPTION
OTP 29 brought a new compilation warning to discourage use of `catch ...`. There are several places where this occurs in `rebar3`, `relx` and `erlware_commons` which causes an error because only `erlware_commons` is compiled with `warning_as_errors` option.

I don't see why that dep should be treated differently, because IMHO that should either be enabled for all deps or for none.

I'll open separate MR-s to fix warning in `rebar3`, `relx` and `erlware_commons`, but I think that `warning_as_errors` should be removed anyways because it isn't forward compatible