### PR TITLE
Fix rebar_uri:parse compatibility with OTP 28

### DIFF
--- a/apps/rebar/src/rebar_uri.erl
+++ b/apps/rebar/src/rebar_uri.erl
@@ -29,7 +29,8 @@ parse(URIString) ->
 parse(URIString, URIOpts) ->
     case uri_string:parse(URIString) of
         #{path := ""} = Map -> apply_opts(Map#{path => "/"}, URIOpts);
-        Map when is_map(Map) -> apply_opts(Map, URIOpts);
+        #{path := _} = Map -> apply_opts(Map, URIOpts);
+        Map when is_map(Map) -> apply_opts(Map#{path => "/"}, URIOpts);
         {error, _, _} = E -> E
     end.
 


### PR DESCRIPTION
In OTP 28, uri_string:parse/1 may omit the 'path' key from the returned map when the path is empty, causing pattern matching failures. This commit adds a fallback clause to handle missing path key.