### PR TITLE
Fix OTP 29 deprecation warning in cfg_cover_spec test

### DIFF
--- a/apps/rebar/test/rebar_ct_SUITE.erl
+++ b/apps/rebar/test/rebar_ct_SUITE.erl
@@ -1303,7 +1303,8 @@ cfg_cover_spec(Config) ->
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
-    RebarConfig = [{ct_opts, [Opt = {cover, "spec/foo.spec"}]}],
+    Opt = {cover, "spec/foo.spec"},
+    RebarConfig = [{ct_opts, [Opt]}],
 
     {ok, State} = rebar_test_utils:run_and_check(C, RebarConfig, ["as", "test", "lock"], return),
 


### PR DESCRIPTION
OTP 29 deprecates exporting bindings from list subexpressions.  WIthout the change the build fails with:
```
===> Compiling apps/rebar/test/rebar_ct_SUITE.erl failed
      \x{250C}\x{2500} apps/rebar/test/rebar_ct_SUITE.erl:
      \x{2502}
 1312 \x{2502}      false = lists:member(Opt, TestOpts).
      \x{2502}                           \x{2570}\x{2500}\x{2500} variable 'Opt' exported from list (line 1306, column 19).
Exporting bindings from subexpressions other than block expressions is
deprecated and may yield an error in a future version of Erlang/OTP.
Please move the binding of 'Opt' out of the list.
Compile directive 'nowarn_export_var_subexpr' can be used to suppress
warnings in selected modules.
```