### PR TITLE
Fix SIGQUIT (Ctrl+\) producing a core dump in rebar3 shell

### DIFF
--- a/apps/rebar/src/rebar_prv_shell.erl
+++ b/apps/rebar/src/rebar_prv_shell.erl
@@ -131,6 +131,16 @@ format_error(Reason) ->
 %% immediately kill the script. ctrl-g, however, works fine
 
 shell(State) ->
+    %% Restore the default `erl` SIGQUIT handling. As an escript, rebar3
+    %% never initializes the break handler, so SIGQUIT (Ctrl+\) is left
+    %% with the OS default action of dumping core instead of being
+    %% ignored/handled like a normal `erl` shell.
+    try
+        os:set_signal(sigquit, handle)
+    catch
+        _:Why ->
+            ?DEBUG("Failed to set signal handler for SIGQUIT!~n  Error: ~p~n", [Why])
+    end,
     setup_name(State),
     setup_paths(State),
     ShellArgs = debug_get_value(shell_args, rebar_state:get(State, shell, []), [],

--- a/apps/rebar/test/rebar_ct_SUITE.erl
+++ b/apps/rebar/test/rebar_ct_SUITE.erl
@@ -1303,7 +1303,8 @@ cfg_cover_spec(Config) ->
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
-    RebarConfig = [{ct_opts, [Opt = {cover, "spec/foo.spec"}]}],
+    Opt = {cover, "spec/foo.spec"},
+    RebarConfig = [{ct_opts, [Opt]}],
 
     {ok, State} = rebar_test_utils:run_and_check(C, RebarConfig, ["as", "test", "lock"], return),
 

--- a/apps/rebar/test/rebar_xref_SUITE.erl
+++ b/apps/rebar/test/rebar_xref_SUITE.erl
@@ -193,7 +193,17 @@ verify_test_results(xref_ignore_test, AppName, XrefResults, _QueryResults) ->
     ?assertNot(lists:keymember(deprecated_function_calls, 1, XrefResults)),
     ?assertNot(lists:member({IgnoreMod, notavailable, 1}, UndefFuns)),
     ?assertNot(lists:member({IgnoreMod2, notavailable, 1}, UndefFuns)),
-    ?assert(lists:member({SomeMod, notavailable, 1}, UndefFuns)),
+    case ?OTP_RELEASE >= 29 of
+        true ->
+            %% Since OTP 29, xref itself filters out results covered by
+            %% -ignore_xref attributes, so {SomeMod,notavailable,1} is
+            %% removed from undefined_functions because othermod's
+            %% -ignore_xref([{SomeMod,notavailable,1}, ...]) now applies
+            %% natively, not just to the call site.
+            ?assertNot(lists:member({SomeMod, notavailable, 1}, UndefFuns));
+        false ->
+            ?assert(lists:member({SomeMod, notavailable, 1}, UndefFuns))
+    end,
     ok.
 
 write_src_file(Dir, AppName, Module, IgnoreXref) ->


### PR DESCRIPTION
As an escript, rebar3 never initializes the break handler that erl sets up, leaving SIGQUIT at the OS default action of dumping core. Calling os:set_signal(sigquit, handle) aligns rebar3 shell's behavior with a regular erl shell.

Fixes #3012

Fix failing test suite compilation on Windows

```
      ┌─ apps/rebar/test/rebar_ct_SUITE.erl:
      │
 1312 │      false = lists:member(Opt, TestOpts).
      │                           ╰── variable 'Opt' exported from list (line 1306, column 19).
```

Fix rebar_xref_SUITE:xref_ignore_test on OTP 29

Since OTP 29, xref natively filters -ignore_xref attributes during xref:analyze, instead of leaving that entirely to rebar3's filter_xref_results/3. As a result, othermod's
-ignore_xref([{SomeMod,notavailable,1}, ...]) now also removes {SomeMod,notavailable,1} from undefined_functions (previously only the call-site was filtered, leaving the bare undefined function in the results). Make the assertion OTP-version-conditional.