### PR TITLE
Remove redundant droplast implementation

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -149,3 +149,4 @@ Luís Rascão
 Marko Minđek
 LEdoian
 Jonatan Männchen
+Otto Heiskanen

--- a/apps/rebar/src/rebar_app_discover.erl
+++ b/apps/rebar/src/rebar_app_discover.erl
@@ -404,7 +404,7 @@ flatten_resource_impl({Type, Files}, Acc = {ResAcc, Used}) ->
 %% @doc find the directory that an appfile has
 -spec app_dir(file:filename()) -> file:filename().
 app_dir(AppFile) ->
-    filename:join(rebar_utils:droplast(filename:split(filename:dirname(AppFile)))).
+    filename:join(lists:droplast(filename:split(filename:dirname(AppFile)))).
 
 %% @doc populates an app info record based on an app directory and its
 %% app file.

--- a/apps/rebar/src/rebar_compiler_erl.erl
+++ b/apps/rebar/src/rebar_compiler_erl.erl
@@ -470,7 +470,7 @@ warn_and_find_path(File, Dir) ->
         true ->
             [SrcHeader];
         false ->
-            IncludeDir = filename:join(rebar_utils:droplast(filename:split(Dir))++["include"]),
+            IncludeDir = filename:join(lists:droplast(filename:split(Dir))++["include"]),
             IncludeHeader = filename:join(IncludeDir, File),
             case filelib:is_regular(IncludeHeader) of
                 true ->

--- a/apps/rebar/src/rebar_erlc_compiler.erl
+++ b/apps/rebar/src/rebar_erlc_compiler.erl
@@ -771,7 +771,7 @@ warn_and_find_path(File, Dir) ->
         true ->
             [SrcHeader];
         false ->
-            IncludeDir = filename:join(rebar_utils:droplast(filename:split(Dir))++["include"]),
+            IncludeDir = filename:join(lists:droplast(filename:split(Dir))++["include"]),
             IncludeHeader = filename:join(IncludeDir, File),
             case filelib:is_regular(IncludeHeader) of
                 true ->

--- a/apps/rebar/src/rebar_utils.erl
+++ b/apps/rebar/src/rebar_utils.erl
@@ -27,7 +27,6 @@
 -module(rebar_utils).
 
 -export([sort_deps/1,
-         droplast/1,
          filtermap/2,
          is_arch/1,
          sh/2,
@@ -101,9 +100,6 @@ sort_deps(Deps) ->
     %% The list of deps is reversed when we get it. For the proper stable
     %% result, re-reverse it.
     lists:keysort(?APP_NAME_INDEX, lists:reverse(Deps)).
-
-droplast(L) ->
-    lists:reverse(tl(lists:reverse(L))).
 
 %% @doc wrapper around lists:filtermap/2
 -spec filtermap(F, [In]) -> [Out] when


### PR DESCRIPTION
## Summary

Replace the remaining uses of the redundant rebar_utils:droplast/1 helper with lists:droplast/1, and remove the unused helper implementation.

The standard library function is already used elsewhere in rebar3, so this change makes the remaining call sites consistent and removes duplicate functionality.

## Testing

Ran the existing test suite successfully.