### PR TITLE
Keep quoting in zsh completion descriptions

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -150,3 +150,4 @@ Marko Minđek
 LEdoian
 Jonatan Männchen
 Otto Heiskanen
+Dylan Pulver

--- a/apps/rebar/src/rebar_completion_zsh.erl
+++ b/apps/rebar/src/rebar_completion_zsh.erl
@@ -66,7 +66,9 @@ nested_cmds(Cmds,Prev,CmplOpts) ->
     "  esac\n"].
 
 cmd_str(#{name:=N,help:=H}, _CmplOpts) ->
-    ["\"",N,":",help(H),"\""].
+    %% single quotes: the description is data, and must not be
+    %% expanded by the shell that sources the completion file
+    ["'",N,":",help(H),"'"].
 
 cmd_call_case(#{name:=Name}, Prev, _CmplOpts) ->
     ["  ",Name,")\n",
@@ -107,6 +109,8 @@ help(H) -> help_escape(H).
 
 help_escape([]) ->
     [];
+help_escape([$\\ | Rest]) ->
+    ["\\\\",help_escape(Rest)];
 help_escape([40 | Rest]) ->
     ["\\(",help_escape(Rest)];
 help_escape([41 | Rest]) ->
@@ -115,8 +119,8 @@ help_escape([91| Rest]) ->
     ["\\[",help_escape(Rest)];
 help_escape([93| Rest]) ->
     ["\\]",help_escape(Rest)];
-%% escaping single quotes by doubling them
+%% close the quoted string, emit an escaped quote, reopen it
 help_escape([$' | Rest]) ->
-    ["''",help_escape(Rest)];
+    ["'\\''",help_escape(Rest)];
 help_escape([C | Rest]) ->
     [C | help_escape(Rest)].

--- a/apps/rebar/test/rebar_completion_SUITE.erl
+++ b/apps/rebar/test/rebar_completion_SUITE.erl
@@ -9,7 +9,8 @@ suite() ->
     [].
 
 all() ->
-    [test_completion_gen, check_bash, check_zsh, check_bash_file_completion].
+    [test_completion_gen, check_bash, check_zsh, check_bash_file_completion,
+     check_zsh_escaping, check_zsh_valid_syntax].
 
 groups() ->
     [].
@@ -41,6 +42,13 @@ init_per_testcase(check_zsh, Config) ->
     case shell_available(zsh) of
         true ->
             rebar_test_utils:init_rebar_state(Config, "completion_");
+        false ->
+            {skip, "zsh not found"}
+    end;
+init_per_testcase(check_zsh_valid_syntax, Config) ->
+    case shell_available(zsh) of
+        true ->
+            Config;
         false ->
             {skip, "zsh not found"}
     end;
@@ -119,7 +127,38 @@ check_bash_file_completion(Config) ->
     %% Check that fallback completion is present
     {match, _} = re:run(Completion, "If no completions found, fall back to normal completion").
 
+%% Descriptions are data: whatever quoting they contain has to survive
+%% into the completion menu unchanged.
+check_zsh_escaping(Config) ->
+    Compl = quoted_completion(Config),
+    Escaped = "Shell type, '\\''bash'\\'' or '\\''zsh'\\''.",
+    %% command descriptions are handed to _describe as "<name>:<description>"
+    ?assertNotEqual(nomatch, string:find(Compl, "'quoted:" ++ Escaped ++ "'")),
+    %% option descriptions are handed to _arguments inside "[...]"
+    ?assertNotEqual(nomatch, string:find(Compl, "[" ++ Escaped ++ "]")).
+
+check_zsh_valid_syntax(Config) ->
+    ComplFile = ?config(compl_file, Config),
+    ok = file:write_file(ComplFile, quoted_completion(Config)),
+    ?assertMatch({ok, _}, rebar_utils:sh("zsh -n " ++ ComplFile,
+                                         [return_on_error])).
+
 %% helpers
+
+%% a command and an option whose descriptions both contain single quotes
+quoted_completion(Config) ->
+    Help = "Shell type, 'bash' or 'zsh'.",
+    Cmds = [#{name => "quoted",
+              help => Help,
+              cmds => [],
+              args => [#{short => $s,
+                         long => "shell",
+                         type => atom,
+                         help => Help}]}],
+    CmplOpts = #{shell => zsh,
+                 aliases => [],
+                 file => ?config(compl_file, Config)},
+    unicode:characters_to_list(rebar_completion:generate(Cmds, CmplOpts)).
 
 completion_gen(Config, CmplOpts) ->
     CmplConf = maps:to_list(CmplOpts),


### PR DESCRIPTION
`rebar_completion_zsh` escapes a single quote in a description by doubling it. Doubling is a CSV/SQL convention, not a shell one: in zsh `''` closes the quoted word and immediately reopens it, so the quote is deleted rather than escaped.

On a stock project `rebar3 completion --shell zsh` therefore mangles two built-in descriptions. Verbatim from a real zsh under a pty (`rebar3 a<TAB>`, `rebar3 completion -<TAB>`):

before
```
alias  -- List aliases'' definitions.
--shell    -s  -- Shell type, bash or zsh.
```
after
```
alias  -- List aliases' definitions.
--shell    -s  -- Shell type, 'bash' or 'zsh'.
```

Option specs are single-quoted, so the quotes vanish there. Command descriptions were emitted inside a *double*-quoted word instead, where the same doubling is literal — and where a `$` or a backtick in a description gets expanded when the file is sourced.

This emits command descriptions inside single quotes like the option specs, so one escaping rule is correct for both, and escapes a quote the way a shell does. A backslash is escaped too, since `_describe` and `_arguments` each consume one level.

The tempting one-liner, `''` -> `\'`, is worse than the bug: it unbalances the `_arguments` specs, `zsh -n` reports `unmatched '`, and every option completion silently disappears. `check_zsh_valid_syntax` guards against that.

Testing: `./rebar3 ct` gives 45 suites, 656 passed, 1 skipped on this branch and on cf1152b4, identical. Both new assertions fail on cf1152b4.
